### PR TITLE
bugfix: update JNI method signature to match implementation.

### DIFF
--- a/src/main/java/cash/z/wallet/sdk/jni/JniConverter.kt
+++ b/src/main/java/cash/z/wallet/sdk/jni/JniConverter.kt
@@ -23,7 +23,8 @@ class JniConverter {
 
     external fun sendToAddress(
         dbData: String,
-        seed: ByteArray,
+        account: Int,
+        extsk: String,
         to: String,
         value: Long,
         memo: String,


### PR DESCRIPTION
We removed the need to pass the seed around because that is highly sensitive data. Instead, we work with less sensitive sending keys.