### PR TITLE
add empty swift_prefix option value to .proto files

### DIFF
--- a/src/main/proto/WalletData.proto
+++ b/src/main/proto/WalletData.proto
@@ -1,4 +1,5 @@
 package cash.z.wallet.sdk.proto;
+option swift_prefix = "";
 message WalletData {
   required string name = 1;
   required int32 id = 2;

--- a/src/main/proto/compact_formats.proto
+++ b/src/main/proto/compact_formats.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package cash.z.wallet.sdk.rpc;
 option go_package = "walletrpc";
-
+option swift_prefix = "";
 // Remember that proto3 fields are all optional. A field that is not present will be set to its zero value.
 // bytes fields of hashes are in canonical little-endian format.
 

--- a/src/main/proto/service.proto
+++ b/src/main/proto/service.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package cash.z.wallet.sdk.rpc;
 option go_package = "walletrpc";
-
+option swift_prefix = "";
 import "compact_formats.proto";
 
 // A BlockID message contains identifiers to select a block: a height or a


### PR DESCRIPTION
Motivation.

proto-swift-gen script adds the package prefix on a snake case fashion to Swift Struct files. 
This makes the code difficult to read and has no convenience to us.

Example:
`CompactBlock` -> `Cash_Z_Wallet_SDK_RPC_CompactBlock`

When adding `option swift_prefix = "";` the resulting struct Name is `CompactBlock`
