### PR TITLE
Reduce configurability per Security Finding 1.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
 apply plugin: 'org.owasp.dependencycheck'
 
 group = 'cash.z.android.wallet'
-version = '1.0.0-alpha01'
+version = '1.0.0-alpha02'
 
 repositories {
     google()
@@ -65,7 +65,7 @@ android {
     defaultConfig {
         minSdkVersion buildConfig.minSdkVersion
         targetSdkVersion buildConfig.targetSdkVersion
-        versionCode = 1_00_00_001  // last digits are alpha(0XX) beta(2XX) rc(4XX) release(8XX). Ex: 1_08_04_401 is an release candidate build of version 1.8.4 and 1_08_04_800 would be the final release.
+        versionCode = 1_00_00_002  // last digits are alpha(0XX) beta(2XX) rc(4XX) release(8XX). Ex: 1_08_04_401 is an release candidate build of version 1.8.4 and 1_08_04_800 would be the final release.
         versionName = "$version"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'

--- a/samples/memo/app/src/main/java/cash/z/wallet/sdk/sample/memo/Injection.kt
+++ b/samples/memo/app/src/main/java/cash/z/wallet/sdk/sample/memo/Injection.kt
@@ -13,7 +13,7 @@ import cash.z.wallet.sdk.secure.Wallet
 import cash.z.wallet.sdk.service.LightWalletGrpcService
 
 object Injection {
-    private const val host: String = "lightwalletd.z.cash"
+    private const val host: String = "34.68.177.238"
     private const val port: Int = 9067
     private const val cacheDbName = "memos-cache.db"
     private const val dataDbName = "memos-data.db"

--- a/src/androidTest/java/cash/z/wallet/sdk/db/GlueIntegrationTest.kt
+++ b/src/androidTest/java/cash/z/wallet/sdk/db/GlueIntegrationTest.kt
@@ -5,7 +5,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.test.core.app.ApplicationProvider
-import cash.z.wallet.sdk.entity.CompactBlock
+import cash.z.wallet.sdk.entity.CompactBlockEntity
 import cash.z.wallet.sdk.jni.RustBackend
 import cash.z.wallet.sdk.jni.RustBackendWelding
 import cash.z.wallet.sdk.rpc.CompactTxStreamerGrpc
@@ -47,19 +47,19 @@ class GlueIntegrationTest {
         )
         while (result.hasNext()) {
             val compactBlock = result.next()
-            dao.insert(CompactBlock(compactBlock.height.toInt(), compactBlock.toByteArray()))
+            dao.insert(CompactBlockEntity(compactBlock.height.toInt(), compactBlock.toByteArray()))
             System.err.println("stored block at height: ${compactBlock.height} with time ${compactBlock.time}")
         }
     }
 
     private fun scanData() {
         val dbFileName = "/data/user/0/cash.z.wallet.sdk.test/databases/new-data-glue.db"
-        rustBackend.initDataDb(dbFileName)
-        rustBackend.initAccountsTable(dbFileName, "dummyseed".toByteArray(), 1)
+        rustBackend.initDataDb()
+        rustBackend.initAccountsTable("dummyseed".toByteArray(), 1)
 
 
         Log.e("tezt", "scanning blocks...")
-        val result = rustBackend.scanBlocks(cacheDbPath, dbFileName)
+        val result = rustBackend.scanBlocks()
         System.err.println("done.")
     }
 
@@ -69,7 +69,7 @@ class GlueIntegrationTest {
 
     companion object {
         // jni
-        val rustBackend: RustBackendWelding = RustBackend()
+        val rustBackend: RustBackendWelding = RustBackend
 
         // db
         private lateinit var dao: CompactBlockDao
@@ -83,7 +83,7 @@ class GlueIntegrationTest {
         @BeforeClass
         @JvmStatic
         fun setup() {
-            rustBackend.initLogs()
+            rustBackend.create(ApplicationProvider.getApplicationContext())
 
             val channel = ManagedChannelBuilder.forAddress("10.0.2.2", 9067).usePlaintext().build()
             blockingStub = CompactTxStreamerGrpc.newBlockingStub(channel)

--- a/src/androidTest/java/cash/z/wallet/sdk/jni/RustBackendTest.kt
+++ b/src/androidTest/java/cash/z/wallet/sdk/jni/RustBackendTest.kt
@@ -1,5 +1,6 @@
 package cash.z.wallet.sdk.jni
 
+import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.BeforeClass
@@ -7,30 +8,25 @@ import org.junit.Test
 
 class RustBackendTest {
 
-    private val dbDataFile = "/data/user/0/cash.z.wallet.sdk.test/databases/data2.db"
-
     @Test
     fun testGetAddress_exists() {
-        assertNotNull(rustBackend.getAddress(dbDataFile, 0))
+        assertNotNull(rustBackend.getAddress(0))
     }
 
     @Test
     fun testGetAddress_valid() {
-        val address = rustBackend.getAddress(dbDataFile, 0)
+        val address = rustBackend.getAddress(0)
         val expectedAddress = "ztestsapling1snmqdnfqnc407pvqw7sld8w5zxx6nd0523kvlj4jf39uvxvh7vn0hs3q38n07806dwwecqwke3t"
         assertEquals("Invalid address", expectedAddress, address)
     }
 
     @Test
     fun testScanBlocks() {
-        rustBackend.initDataDb(dbDataFile)
-        rustBackend.initAccountsTable(dbDataFile, "dummyseed".toByteArray(), 1)
+        rustBackend.initDataDb()
+        rustBackend.initAccountsTable("dummyseed".toByteArray(), 1)
 
         // note: for this to work, the db file below must be uploaded to the device. Eventually, this test will be self-contained and remove that requirement.
-        val result = rustBackend.scanBlocks(
-            "/data/user/0/cash.z.wallet.sdk.test/databases/dummy-cache.db",
-            dbDataFile
-        )
+        val result = rustBackend.scanBlocks()
 //        Thread.sleep(15 * DateUtils.MINUTE_IN_MILLIS)
         assertEquals("Invalid number of results", 3, 3)
     }
@@ -38,19 +34,16 @@ class RustBackendTest {
     @Test
     fun testSend() {
         rustBackend.createToAddress(
-            "/data/user/0/cash.z.wallet.sdk.test/databases/data2.db",
             0,
             "dummykey",
             "ztestsapling1fg82ar8y8whjfd52l0xcq0w3n7nn7cask2scp9rp27njeurr72ychvud57s9tu90fdqgwdt07lg",
             210_000,
-            "",
-            "/data/user/0/cash.z.wallet.sdk.test/databases/sapling-spend.params",
-            "/data/user/0/cash.z.wallet.sdk.test/databases/sapling-output.params"
+            ""
         )
     }
 
     companion object {
-        val rustBackend: RustBackendWelding = RustBackend()
+        val rustBackend: RustBackendWelding = RustBackend.create(ApplicationProvider.getApplicationContext(), "rustTestCache.db", "rustTestData.db")
     }
 
 }

--- a/src/androidTest/java/cash/z/wallet/sdk/util/AddressGeneratorUtil.kt
+++ b/src/androidTest/java/cash/z/wallet/sdk/util/AddressGeneratorUtil.kt
@@ -1,4 +1,4 @@
-package cash.z.wallet.sdk.db
+package cash.z.wallet.sdk.util
 
 import androidx.test.platform.app.InstrumentationRegistry
 import cash.z.wallet.sdk.data.TroubleshootingTwig
@@ -23,14 +23,13 @@ class AddressGeneratorUtil {
 
     private val dataDbName = "AddressUtilData.db"
     private val context = InstrumentationRegistry.getInstrumentation().context
-    private val rustBackend = RustBackend()
+    private val rustBackend = RustBackend.create(context)
 
     private lateinit var wallet: Wallet
 
     @Before
     fun setup() {
         Twig.plant(TroubleshootingTwig())
-        rustBackend.initLogs()
     }
 
     private fun deleteDb() {
@@ -64,13 +63,7 @@ class AddressGeneratorUtil {
     private fun initWallet(seed: String): ReadWriteProperty<Any?, String> {
         deleteDb()
         val spendingKeyProvider = Delegates.notNull<String>()
-        wallet = Wallet(
-            context = context,
-            rustBackend = rustBackend,
-            dataDbName = dataDbName,
-            seedProvider = SampleSeedProvider(seed),
-            spendingKeyProvider = spendingKeyProvider
-        )
+        wallet = Wallet(context, rustBackend, SampleSeedProvider(seed), spendingKeyProvider)
         wallet.initialize()
         return spendingKeyProvider
     }

--- a/src/main/java/cash/z/wallet/sdk/block/CompactBlockDbStore.kt
+++ b/src/main/java/cash/z/wallet/sdk/block/CompactBlockDbStore.kt
@@ -5,26 +5,27 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import cash.z.wallet.sdk.db.CompactBlockDao
 import cash.z.wallet.sdk.db.CompactBlockDb
-import cash.z.wallet.sdk.entity.CompactBlock
-import cash.z.wallet.sdk.ext.SAPLING_ACTIVATION_HEIGHT
+import cash.z.wallet.sdk.entity.CompactBlockEntity
+import cash.z.wallet.sdk.ext.ZcashSdk.DB_CACHE_NAME
+import cash.z.wallet.sdk.ext.ZcashSdk.SAPLING_ACTIVATION_HEIGHT
+import cash.z.wallet.sdk.rpc.CompactFormats
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.withContext
 
 class CompactBlockDbStore(
-    applicationContext: Context,
-    cacheDbName: String
+    applicationContext: Context
 ) : CompactBlockStore {
 
     private val cacheDao: CompactBlockDao
     private val cacheDb: CompactBlockDb
 
     init {
-        cacheDb = createCompactBlockCacheDb(applicationContext, cacheDbName)
+        cacheDb = createCompactBlockCacheDb(applicationContext)
         cacheDao = cacheDb.complactBlockDao()
     }
 
-    private fun createCompactBlockCacheDb(applicationContext: Context, cacheDbName: String): CompactBlockDb {
-        return Room.databaseBuilder(applicationContext, CompactBlockDb::class.java, cacheDbName)
+    private fun createCompactBlockCacheDb(applicationContext: Context): CompactBlockDb {
+        return Room.databaseBuilder(applicationContext, CompactBlockDb::class.java, DB_CACHE_NAME)
             .setJournalMode(RoomDatabase.JournalMode.TRUNCATE)
             // this is a simple cache of blocks. destroying the db should be benign
             .fallbackToDestructiveMigration()
@@ -36,8 +37,8 @@ class CompactBlockDbStore(
         if (lastBlock < SAPLING_ACTIVATION_HEIGHT) -1 else lastBlock
     }
 
-    override suspend fun write(result: List<CompactBlock>) = withContext(IO) {
-        cacheDao.insert(result)
+    override suspend fun write(result: List<CompactFormats.CompactBlock>) = withContext(IO) {
+        cacheDao.insert(result.map { CompactBlockEntity(it.height.toInt(), it.toByteArray()) })
     }
 
     override suspend fun rewindTo(height: Int) = withContext(IO) {

--- a/src/main/java/cash/z/wallet/sdk/block/CompactBlockDownloader.kt
+++ b/src/main/java/cash/z/wallet/sdk/block/CompactBlockDownloader.kt
@@ -1,6 +1,5 @@
 package cash.z.wallet.sdk.block
 
-import cash.z.wallet.sdk.data.twig
 import cash.z.wallet.sdk.service.LightWalletService
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.withContext

--- a/src/main/java/cash/z/wallet/sdk/block/CompactBlockStore.kt
+++ b/src/main/java/cash/z/wallet/sdk/block/CompactBlockStore.kt
@@ -1,6 +1,6 @@
 package cash.z.wallet.sdk.block
 
-import cash.z.wallet.sdk.entity.CompactBlock
+import cash.z.wallet.sdk.rpc.CompactFormats
 
 /**
  * Interface for storing compact blocks.
@@ -14,7 +14,7 @@ interface CompactBlockStore {
     /**
      * Write the given blocks to this store, which may be anything from an in-memory cache to a DB.
      */
-    suspend fun write(result: List<CompactBlock>)
+    suspend fun write(result: List<CompactFormats.CompactBlock>)
 
     /**
      * Remove every block above and including the given height.

--- a/src/main/java/cash/z/wallet/sdk/data/PersistentTransactionManager.kt
+++ b/src/main/java/cash/z/wallet/sdk/data/PersistentTransactionManager.kt
@@ -7,7 +7,7 @@ import cash.z.wallet.sdk.db.PendingTransactionDao
 import cash.z.wallet.sdk.db.PendingTransactionDb
 import cash.z.wallet.sdk.entity.PendingTransaction
 import cash.z.wallet.sdk.entity.Transaction
-import cash.z.wallet.sdk.ext.EXPIRY_OFFSET
+import cash.z.wallet.sdk.ext.ZcashSdk.EXPIRY_OFFSET
 import cash.z.wallet.sdk.service.LightWalletService
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.withContext

--- a/src/main/java/cash/z/wallet/sdk/data/SdkSynchronizer.kt
+++ b/src/main/java/cash/z/wallet/sdk/data/SdkSynchronizer.kt
@@ -200,8 +200,8 @@ class SdkSynchronizer (
         val progressUpdates = progress()
         for (progress in progressUpdates) {
             if (progress == 100) {
-                twig("triggering a balance update because progress is complete")
-                refreshBalance()
+                twig("triggering a balance update because progress is complete (j/k)")
+                //refreshBalance()
             }
         }
         twig("done monitoring for progress changes")
@@ -217,8 +217,8 @@ class SdkSynchronizer (
         val channel = pendingChannel.openSubscription()
         for (pending in channel) {
             if(balanceChannel.isClosedForSend) break
-            twig("triggering a balance update because pending transactions have changed")
-            refreshBalance()
+            twig("triggering a balance update because pending transactions have changed (j/kk)")
+//            refreshBalance()
         }
         twig("done monitoring for pending changes and balance changes")
     }

--- a/src/main/java/cash/z/wallet/sdk/data/SdkSynchronizerOld.kt
+++ b/src/main/java/cash/z/wallet/sdk/data/SdkSynchronizerOld.kt
@@ -1,0 +1,305 @@
+// This has been replaced by "StableSynchronizer" We keep it around for the docs
+
+
+//package cash.z.wallet.sdk.data
+//
+//import cash.z.wallet.sdk.block.CompactBlockProcessor
+//import cash.z.wallet.sdk.entity.ClearedTransaction
+//import cash.z.wallet.sdk.exception.SynchronizerException
+//import cash.z.wallet.sdk.exception.WalletException
+//import cash.z.wallet.sdk.secure.Wallet
+//import kotlinx.coroutines.*
+//import kotlinx.coroutines.Dispatchers.IO
+//import kotlinx.coroutines.channels.ConflatedBroadcastChannel
+//import kotlinx.coroutines.channels.ReceiveChannel
+//import kotlinx.coroutines.channels.distinct
+//import kotlin.coroutines.CoroutineContext
+//
+///**
+// * The glue. Downloads compact blocks to the database and then scans them for transactions. In order to serve that
+// * purpose, this class glues together a variety of key components. Each component contributes to the team effort of
+// * providing a simple source of truth to interact with.
+// *
+// * Another way of thinking about this class is the reference that demonstrates how all the pieces can be tied
+// * together.
+// *
+// * @param processor the component that saves the downloaded compact blocks to the cache and then scans those blocks for
+// * data related to this wallet.
+// * @param repository the component that exposes streams of wallet transaction information.
+// * @param activeTransactionManager the component that manages the lifecycle of active transactions. This includes sent
+// * transactions that have not been mined.
+// * @param wallet the component that wraps the JNI layer that interacts with librustzcash and manages wallet config.
+// * @param batchSize the number of compact blocks to download at a time.
+// * @param staleTolerance the number of blocks to allow before considering our data to be stale
+// * @param blockPollFrequency how often to poll for compact blocks. Once all missing blocks have been downloaded, this
+// * number represents the number of milliseconds the synchronizer will wait before checking for newly mined blocks.
+// */
+//class SdkSynchronizer(
+//    private val processor: CompactBlockProcessor,
+//    private val repository: TransactionRepository,
+//    private val activeTransactionManager: ActiveTransactionManager,
+//    private val wallet: Wallet,
+//    private val staleTolerance: Int = 10
+//) : Synchronizer {
+//
+//    /**
+//     * The primary job for this Synchronizer. It leverages structured concurrency to cancel all work when the
+//     * `parentScope` provided to the [start] method ends.
+//     */
+//    private lateinit var blockJob: Job
+//
+//    /**
+//     * The state this Synchronizer was in when it started. This is helpful because the conditions that lead to FirstRun
+//     * or isStale being detected can change quickly so retaining the initial state is useful for walkthroughs or other
+//     * elements of an app that need to rely on this information later, rather than in realtime.
+//     */
+//    private lateinit var initialState: SyncState
+//
+//    /**
+//     * Returns true when `start` has been called on this synchronizer.
+//     */
+//    private val wasPreviouslyStarted
+//        get() = ::blockJob.isInitialized
+//
+//    /**
+//     * Retains the error that caused this synchronizer to fail for future error handling or reporting.
+//     */
+//    private var failure: Throwable? = null
+//
+//    /**
+//     * The default exception handler for the block job. Calls [onException].
+//     */
+//    private val exceptionHandler: (c: CoroutineContext, t: Throwable) -> Unit = { _, t -> onException(t) }
+//
+//    /**
+//     * Sets a listener to be notified of uncaught Synchronizer errors. When null, errors will only be logged.
+//     */
+//    override var onSynchronizerErrorListener: ((Throwable?) -> Boolean)? = null
+//        set(value) {
+//            field = value
+//            if (failure != null) value?.invoke(failure)
+//        }
+//
+//    /**
+//     * Channel of transactions from the repository.
+//     */
+//    private val transactionChannel = ConflatedBroadcastChannel<List<ClearedTransaction>>()
+//
+//    /**
+//     * Channel of balance information.
+//     */
+//    private val balanceChannel = ConflatedBroadcastChannel<Wallet.WalletBalance>()
+//
+//    //
+//    // Public API
+//    //
+//
+//    /* Lifecycle */
+//
+//    /**
+//     * Starts this synchronizer within the given scope. For simplicity, attempting to start an instance that has already
+//     * been started will throw a [SynchronizerException.FalseStart] exception. This reduces the complexity of managing
+//     * resources that must be recycled. Instead, each synchronizer is designed to have a long lifespan and should be
+//     * started from an activity, application or session.
+//     *
+//     * @param parentScope the scope to use for this synchronizer, typically something with a lifecycle such as an
+//     * Activity for single-activity apps or a logged in user session. This scope is only used for launching this
+//     * synchronzer's job as a child.
+//     */
+//    override fun start(parentScope: CoroutineScope): Synchronizer {
+//        //  prevent restarts so the behavior of this class is easier to reason about
+//        if (wasPreviouslyStarted) throw SynchronizerException.FalseStart
+//        twig("starting")
+//        failure = null
+//        blockJob = parentScope.launch(CoroutineExceptionHandler(exceptionHandler)) {
+//            supervisorScope {
+//                try {
+//                    wallet.initialize()
+//                } catch (e: WalletException.AlreadyInitializedException) {
+//                    twig("Warning: wallet already initialized but this is safe to ignore " +
+//                            "because the SDK now automatically detects where to start downloading.")
+//                }
+//                onReady()
+//            }
+//        }
+//        return this
+//    }
+//
+//    /**
+//     * Stops this synchronizer by stopping the downloader, repository, and activeTransactionManager, then cancelling the
+//     * parent job. Note that we do not cancel the parent scope that was passed into [start] because the synchronizer
+//     * does not own that scope, it just uses it for launching children.
+//     */
+//    override fun stop() {
+//        twig("stopping")
+//        (repository as? PollingTransactionRepository)?.stop().also { twig("repository stopped") }
+//        activeTransactionManager.stop().also { twig("activeTransactionManager stopped") }
+//        // TODO: investigate whether this is necessary and remove or improve, accordingly
+//        Thread.sleep(5000L)
+//        blockJob.cancel().also { twig("blockJob cancelled") }
+//    }
+//
+//
+//    /* Channels */
+//
+//    /**
+//     * A stream of all the wallet transactions, delegated to the [activeTransactionManager].
+//     */
+//    override fun activeTransactions() = activeTransactionManager.subscribe()
+//
+//    /**
+//     * A stream of all the wallet transactions, delegated to the [repository].
+//     */
+//    override fun allTransactions(): ReceiveChannel<List<ClearedTransaction>> {
+//        return transactionChannel.openSubscription()
+//    }
+//
+//    /**
+//     * A stream of progress values, corresponding to this Synchronizer downloading blocks, delegated to the
+//     * [downloader]. Any non-zero value below 100 indicates that progress indicators can be shown and a value of 100
+//     * signals that progress is complete and any progress indicators can be hidden. At that point, the synchronizer
+//     * switches from catching up on missed blocks to periodically monitoring for newly mined blocks.
+//     */
+//    override fun progress(): ReceiveChannel<Int> {
+//        return processor.progress()
+//    }
+//
+//    /**
+//     * A stream of balance values, delegated to the [wallet].
+//     */
+//    override fun balances(): ReceiveChannel<Wallet.WalletBalance> {
+//        return balanceChannel.openSubscription()
+//    }
+//
+//
+//    /* Status */
+//
+//    /**
+//     * A flag to indicate that this Synchronizer is significantly out of sync with it's server. This is determined by
+//     * the delta between the current block height reported by the server and the latest block we have stored in cache.
+//     * Whenever this delta is greater than the [staleTolerance], this function returns true. This is intended for
+//     * showing progress indicators when the user returns to the app after having not used it for a long period.
+//     * Typically, this means the user may have to wait for downloading to occur and the current balance and transaction
+//     * information cannot be trusted as 100% accurate.
+//     *
+//     * @return true when the local data is significantly out of sync with the remote server and the app data is stale.
+//     */
+//    override suspend fun isStale(): Boolean = withContext(IO) {
+//        val latestBlockHeight = processor.downloader.getLatestBlockHeight()
+//        val ourHeight = processor.downloader.getLastDownloadedHeight()
+//        val tolerance = staleTolerance
+//        val delta = latestBlockHeight - ourHeight
+//        twig("checking whether out of sync. " +
+//                "LatestHeight: $latestBlockHeight  ourHeight: $ourHeight  Delta: $delta   tolerance: $tolerance")
+//        delta > tolerance
+//    }
+//
+//    /* Operations */
+//
+//    /**
+//     * Gets the address for the given account.
+//     *
+//     * @param accountId the optional accountId whose address of interest. Typically, this value is zero.
+//     */
+//    override fun getAddress(accountId: Int): String = wallet.getAddress()
+//
+//    override suspend fun getBalance(accountId: Int): Wallet.WalletBalance = wallet.getBalanceInfo(accountId)
+//
+//    /**
+//     * Sends zatoshi.
+//     *
+//     * @param zatoshi the amount of zatoshi to send.
+//     * @param toAddress the recipient's address.
+//     * @param memo the optional memo to include as part of the transaction.
+//     * @param fromAccountId the optional account id to use. By default, the first account is used.
+//     */
+//    override suspend fun sendToAddress(zatoshi: Long, toAddress: String, memo: String, fromAccountId: Int) =
+//        activeTransactionManager.sendToAddress(zatoshi, toAddress, memo, fromAccountId)
+//
+//    /**
+//     * Attempts to cancel a previously sent transaction. Transactions can only be cancelled during the calculation phase
+//     * before they've been submitted to the server. This method will return false when it is too late to cancel. This
+//     * logic is delegated to the activeTransactionManager, which knows the state of the given transaction.
+//     *
+//     * @param transaction the transaction to cancel.
+//     * @return true when the cancellation request was successful. False when it is too late to cancel.
+//     */
+//    override fun cancelSend(transaction: ActiveSendTransaction): Boolean = activeTransactionManager.cancel(transaction)
+//
+//
+//    //
+//    // Private API
+//    //
+//
+//
+//    /**
+//     * Logic for starting the Synchronizer once it is ready for processing. All starts eventually end with this method.
+//     */
+//    private fun CoroutineScope.onReady() = launch {
+//        twig("synchronization is ready to begin!")
+//        launch { monitorTransactions(transactionChannel.openSubscription().distinct()) }
+//
+//        activeTransactionManager.start()
+//        repository.poll(transactionChannel)
+//        processor.start()
+//    }
+//
+//    /**
+//     * Monitors transactions and recalculates the balance any time transactions have changed.
+//     */
+//    private suspend fun monitorTransactions(transactionChannel: ReceiveChannel<List<ClearedTransaction>>) =
+//        withContext(IO) {
+//            twig("beginning to monitor transactions in order to update the balance")
+//            launch {
+//                for (i in transactionChannel) {
+//                    twig("triggering a balance update because transactions have changed")
+//                    balanceChannel.send(wallet.getBalanceInfo())
+//                    twig("done triggering balance check!")
+//                }
+//            }
+//            twig("done monitoring transactions in order to update the balance")
+//        }
+//
+//    /**
+//     * Wraps exceptions, logs them and then invokes the [onSynchronizerErrorListener], if it exists.
+//     */
+//    private fun onException(throwable: Throwable) {
+//        twig("********")
+//        twig("********  ERROR: $throwable")
+//        if (throwable.cause != null) twig("******** caused by ${throwable.cause}")
+//        if (throwable.cause?.cause != null) twig("******** caused by ${throwable.cause?.cause}")
+//        twig("********")
+//
+//        val hasRecovered = onSynchronizerErrorListener?.invoke(throwable)
+//        if (hasRecovered != true) stop().also { failure = throwable }
+//    }
+//
+//    /**
+//     * Represents the initial state of the Synchronizer.
+//     */
+//    sealed class SyncState {
+//        /**
+//         * State for the first run of the Synchronizer, when the database has not been initialized.
+//         */
+//        object FirstRun : SyncState()
+//
+//        /**
+//         * State for when compact blocks have been downloaded but not scanned. This state is typically achieved when the
+//         * app was previously started but killed before the first scan took place. In this case, we do not need to
+//         * download compact blocks that we already have.
+//         *
+//         * @param startingBlockHeight the last block that has been downloaded into the cache. We do not need to download
+//         * any blocks before this height because we already have them.
+//         */
+//        class CacheOnly(val startingBlockHeight: Int = Int.MAX_VALUE) : SyncState()
+//
+//        /**
+//         * The final state of the Synchronizer, when all initialization is complete and the starting block is known.
+//         *
+//         * @param startingBlockHeight the height that will be fed to the downloader. In most cases, it will represent
+//         * either the wallet birthday or the last block that was processed in the previous session.
+//         */
+//        class ReadyToProcess(val startingBlockHeight: Int = Int.MAX_VALUE) : SyncState()
+//    }
+//
+//}

--- a/src/main/java/cash/z/wallet/sdk/db/CompactBlockDb.kt
+++ b/src/main/java/cash/z/wallet/sdk/db/CompactBlockDb.kt
@@ -1,7 +1,7 @@
 package cash.z.wallet.sdk.db
 
 import androidx.room.*
-import cash.z.wallet.sdk.entity.CompactBlock
+import cash.z.wallet.sdk.entity.CompactBlockEntity
 
 
 //
@@ -9,8 +9,7 @@ import cash.z.wallet.sdk.entity.CompactBlock
 //
 
 @Database(
-    entities = [
-        CompactBlock::class],
+    entities = [CompactBlockEntity::class],
     version = 1,
     exportSchema = false
 )
@@ -26,10 +25,10 @@ abstract class CompactBlockDb : RoomDatabase() {
 @Dao
 interface CompactBlockDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insert(block: CompactBlock)
+    fun insert(block: CompactBlockEntity)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insert(block: List<CompactBlock>)
+    fun insert(block: List<CompactBlockEntity>)
 
     @Query("DELETE FROM compactblocks WHERE height >= :height")
     fun rewindTo(height: Int)

--- a/src/main/java/cash/z/wallet/sdk/entity/CompactBlock.kt
+++ b/src/main/java/cash/z/wallet/sdk/entity/CompactBlock.kt
@@ -4,14 +4,14 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 
 @Entity(primaryKeys = ["height"], tableName = "compactblocks")
-data class CompactBlock(
+data class CompactBlockEntity(
     val height: Int,
     @ColumnInfo(typeAffinity = ColumnInfo.BLOB)
     val data: ByteArray
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (other !is CompactBlock) return false
+        if (other !is CompactBlockEntity) return false
 
         if (height != other.height) return false
         if (!data.contentEquals(other.data)) return false

--- a/src/main/java/cash/z/wallet/sdk/exception/Exceptions.kt
+++ b/src/main/java/cash/z/wallet/sdk/exception/Exceptions.kt
@@ -30,6 +30,8 @@ sealed class CompactBlockProcessorException(message: String, cause: Throwable? =
             " than just the database filename because Rust does not access the app Context." +
             " So pass in context.getDatabasePath(dbFileName).absolutePath instead of just dbFileName alone.", null)
     class FailedReorgRepair(message: String) : CompactBlockProcessorException(message)
+    object FailedScan : CompactBlockProcessorException("Error while scanning blocks. This most " +
+            "likely means a block is missing or a reorg was mishandled. See Rust logs for details.")
 }
 
 sealed class CompactBlockStreamException(message: String, cause: Throwable? = null) : RuntimeException(message, cause) {

--- a/src/main/java/cash/z/wallet/sdk/ext/CurrencyFormatter.kt
+++ b/src/main/java/cash/z/wallet/sdk/ext/CurrencyFormatter.kt
@@ -2,6 +2,7 @@ package cash.z.wallet.sdk.ext
 
 import cash.z.wallet.sdk.ext.Conversions.USD_FORMATTER
 import cash.z.wallet.sdk.ext.Conversions.ZEC_FORMATTER
+import cash.z.wallet.sdk.ext.ZcashSdk.ZATOSHI_PER_ZEC
 import java.math.BigDecimal
 import java.math.MathContext
 import java.math.RoundingMode

--- a/src/main/java/cash/z/wallet/sdk/ext/WalletService.kt
+++ b/src/main/java/cash/z/wallet/sdk/ext/WalletService.kt
@@ -2,6 +2,7 @@ package cash.z.wallet.sdk.ext
 
 import android.content.Context
 import cash.z.wallet.sdk.data.twig
+import cash.z.wallet.sdk.ext.ZcashSdk.MAX_BACKOFF_INTERVAL
 import kotlinx.coroutines.delay
 import java.io.File
 import kotlin.random.Random
@@ -22,7 +23,7 @@ suspend inline fun retryUpTo(retries: Int, initialDelay: Int = 10, block: () -> 
     }
 }
 
-suspend inline fun retryWithBackoff(noinline onErrorListener: ((Throwable) -> Boolean)? = null, initialDelayMillis: Long = 1000L, maxDelayMillis: Long = DEFAULT_MAX_BACKOFF_INTERVAL, block: () -> Unit) {
+suspend inline fun retryWithBackoff(noinline onErrorListener: ((Throwable) -> Boolean)? = null, initialDelayMillis: Long = 1000L, maxDelayMillis: Long = MAX_BACKOFF_INTERVAL, block: () -> Unit) {
     var sequence = 0 // count up to the max and then reset to half. So that we don't repeat the max but we also don't repeat too much.
     while (true) {
         try {

--- a/src/main/java/cash/z/wallet/sdk/ext/ZcashSdk.kt
+++ b/src/main/java/cash/z/wallet/sdk/ext/ZcashSdk.kt
@@ -1,75 +1,84 @@
 package cash.z.wallet.sdk.ext
 
-//
-// Constants
-//
-
 /**
- * Miner's fee in zatoshi.
+ * Wrapper for all the constant values in the SDK. It is important that these values stay fixed for
+ * all users of the SDK. Otherwise, if individual wallet makers are using different values, it
+ * becomes easier to reduce privacy by segmenting the anonymity set of users, particularly as it
+ * relates to network requests.
  */
-const val MINERS_FEE_ZATOSHI = 10_000L
+object ZcashSdk {
 
-/**
- * The number of zatoshi that equal 1 ZEC.
- */
-const val ZATOSHI_PER_ZEC = 100_000_000L
+    /**
+     * Miner's fee in zatoshi.
+     */
+    const val MINERS_FEE_ZATOSHI = 10_000L
 
-/**
- * The height of the first sapling block. When it comes to shielded transactions, we do not need to consider any blocks
- * prior to this height, at all.
- */
-const val SAPLING_ACTIVATION_HEIGHT = 280_000
+    /**
+     * The number of zatoshi that equal 1 ZEC.
+     */
+    const val ZATOSHI_PER_ZEC = 100_000_000L
 
-/**
- * The theoretical maximum number of blocks in a reorg, due to other bottlenecks in the protocol design.
- */
-const val MAX_REORG_SIZE = 100
+    /**
+     * The height of the first sapling block. When it comes to shielded transactions, we do not need to consider any blocks
+     * prior to this height, at all.
+     */
+    const val SAPLING_ACTIVATION_HEIGHT = 280_000
 
-/**
- * The amount of blocks ahead of the current height where new transactions are set to expire. This value is controlled
- * by the rust backend but it is helpful to know what it is set to and shdould be kept in sync.
- */
-const val EXPIRY_OFFSET = 20
+    /**
+     * The theoretical maximum number of blocks in a reorg, due to other bottlenecks in the protocol design.
+     */
+    const val MAX_REORG_SIZE = 100
 
-//
-// Defaults
-//
+    /**
+     * The amount of blocks ahead of the current height where new transactions are set to expire. This value is controlled
+     * by the rust backend but it is helpful to know what it is set to and shdould be kept in sync.
+     */
+    const val EXPIRY_OFFSET = 20
 
-/**
- * Default size of batches of blocks to request from the compact block service.
- */
-const val DEFAULT_BATCH_SIZE = 100
+    /**
+     * Default size of batches of blocks to request from the compact block service.
+     */
+    const val DOWNLOAD_BATCH_SIZE = 100
 
-/**
- * Default amount of time, in milliseconds, to poll for new blocks. Typically, this should be about half the average
- * block time.
- */
-const val DEFAULT_POLL_INTERVAL = 75_000L
+    /**
+     * Default amount of time, in milliseconds, to poll for new blocks. Typically, this should be about half the average
+     * block time.
+     */
+    const val POLL_INTERVAL = 75_000L
 
-/**
- * Default attempts at retrying.
- */
-const val DEFAULT_RETRIES = 5
+    /**
+     * Default attempts at retrying.
+     */
+    const val RETRIES = 5
 
-/**
- * The default maximum amount of time to wait during retry backoff intervals. Failed loops will never wait longer than
- * this before retyring.
- */
-const val DEFAULT_MAX_BACKOFF_INTERVAL = 600_000L
+    /**
+     * The default maximum amount of time to wait during retry backoff intervals. Failed loops will never wait longer than
+     * this before retyring.
+     */
+    const val MAX_BACKOFF_INTERVAL = 600_000L
 
-/**
- * Default number of blocks to rewind when a chain reorg is detected. This should be large enough to recover from the
- * reorg but smaller than the theoretical max reorg size of 100.
- */
-const val DEFAULT_REWIND_DISTANCE = 10
+    /**
+     * Default number of blocks to rewind when a chain reorg is detected. This should be large enough to recover from the
+     * reorg but smaller than the theoretical max reorg size of 100.
+     */
+    const val REWIND_DISTANCE = 10
 
-/**
- * The number of blocks to allow before considering our data to be stale. This usually helps with what to do when
- * returning from the background and is exposed via the Synchronizer's isStale function.
- */
-const val DEFAULT_STALE_TOLERANCE = 10
+    /**
+     * The default port to use for connecting to lightwalletd instances.
+     */
+    const val LIGHTWALLETD_PORT = 9067
 
-/**
- * The default port to use for connecting to lightwalletd instances.
- */
-const val DEFAULT_LIGHTWALLETD_PORT = 9067
+    const val DB_DATA_NAME = "transactionData.db"
+    const val DB_CACHE_NAME = "compactBlockCache.db"
+
+    /**
+     * File name for the sappling spend params
+     */
+    const val SPEND_PARAM_FILE_NAME = "sapling-spend.params"
+
+    /**
+     * File name for the sapling output params
+     */
+    const val OUTPUT_PARAM_FILE_NAME = "sapling-output.params"
+
+}

--- a/src/main/java/cash/z/wallet/sdk/jni/RustBackendWelding.kt
+++ b/src/main/java/cash/z/wallet/sdk/jni/RustBackendWelding.kt
@@ -1,56 +1,52 @@
 package cash.z.wallet.sdk.jni
 
+import android.content.Context
+import cash.z.wallet.sdk.ext.ZcashSdk
+
 /**
- * Contract defining the exposed capabilitiies of the Rust backend.
+ * Contract defining the exposed capabilities of the Rust backend.
  * This is what welds the SDK to the Rust layer.
  */
 interface RustBackendWelding {
 
-    fun initDataDb(dbDataPath: String): Boolean
+    fun create(
+        appContext: Context,
+        dbCacheName: String = ZcashSdk.DB_CACHE_NAME,
+        dbDataName: String = ZcashSdk.DB_DATA_NAME
+    ): RustBackendWelding
 
-    fun initAccountsTable(
-        dbDataPath: String,
-        seed: ByteArray,
-        accounts: Int): Array<String>
+    fun initDataDb(): Boolean
 
-    fun initBlocksTable(
-        dbDataPath: String,
-        height: Int,
-        hash: String,
-        time: Long,
-        saplingTree: String): Boolean
+    fun initAccountsTable(seed: ByteArray, numberOfAccounts: Int): Array<String>
 
-    fun getAddress(dbDataPath: String, account: Int): String
+    fun initBlocksTable(height: Int, hash: String, time: Long, saplingTree: String): Boolean
+
+    fun getAddress(account: Int = 0): String
 
     fun isValidShieldedAddress(addr: String): Boolean
 
     fun isValidTransparentAddress(addr: String): Boolean
 
-    fun getBalance(dbDataPath: String, account: Int): Long
+    fun getBalance(account: Int = 0): Long
 
-    fun getVerifiedBalance(dbDataPath: String, account: Int): Long
+    fun getVerifiedBalance(account: Int = 0): Long
 
-    fun getReceivedMemoAsUtf8(dbDataPath: String, idNote: Long): String
+    fun getReceivedMemoAsUtf8(idNote: Long): String
 
-    fun getSentMemoAsUtf8(dbDataPath: String, idNote: Long): String
+    fun getSentMemoAsUtf8(idNote: Long): String
 
-    fun validateCombinedChain(dbCachePath: String, dbDataPath: String): Int
+    fun validateCombinedChain(): Int
 
-    fun rewindToHeight(dbDataPath: String, height: Int): Boolean
+    fun rewindToHeight(height: Int): Boolean
 
-    fun scanBlocks(dbCachePath: String, dbDataPath: String): Boolean
+    fun scanBlocks(): Boolean
 
     fun createToAddress(
-        dbDataPath: String,
         account: Int,
         extsk: String,
         to: String,
         value: Long,
-        memo: String,
-        spendParamsPath: String,
-        outputParamsPath: String
+        memo: String
     ): Long
-
-    fun initLogs()
 
 }

--- a/src/main/java/cash/z/wallet/sdk/service/LightWalletService.kt
+++ b/src/main/java/cash/z/wallet/sdk/service/LightWalletService.kt
@@ -1,6 +1,6 @@
 package cash.z.wallet.sdk.service
 
-import cash.z.wallet.sdk.entity.CompactBlock
+import cash.z.wallet.sdk.rpc.CompactFormats
 import cash.z.wallet.sdk.rpc.Service
 
 /**
@@ -14,7 +14,7 @@ interface LightWalletService {
      * @param heightRange the inclusive range to fetch. For instance if 1..5 is given, then every block in that range
      * will be fetched, including 1 and 5.
      */
-    fun getBlockRange(heightRange: IntRange): List<CompactBlock>
+    fun getBlockRange(heightRange: IntRange): List<CompactFormats.CompactBlock>
 
     /**
      * Return the latest block height known to the service.
@@ -24,5 +24,5 @@ interface LightWalletService {
     /**
      * Submit a raw transaction.
      */
-    fun submitTransaction(transactionRaw: ByteArray): Service.SendResponse
+    fun submitTransaction(spendTransaction: ByteArray): Service.SendResponse
 }

--- a/src/test/java/cash/z/wallet/sdk/block/CompactBlockProcessorTest.kt
+++ b/src/test/java/cash/z/wallet/sdk/block/CompactBlockProcessorTest.kt
@@ -4,7 +4,9 @@ import cash.z.wallet.sdk.data.TransactionRepository
 import cash.z.wallet.sdk.data.TroubleshootingTwig
 import cash.z.wallet.sdk.data.Twig
 import cash.z.wallet.sdk.entity.CompactBlock
+import cash.z.wallet.sdk.entity.CompactBlockEntity
 import cash.z.wallet.sdk.ext.SAPLING_ACTIVATION_HEIGHT
+import cash.z.wallet.sdk.ext.ZcashSdk.SAPLING_ACTIVATION_HEIGHT
 import cash.z.wallet.sdk.jni.RustBackendWelding
 import cash.z.wallet.sdk.service.LightWalletService
 import com.nhaarman.mockitokotlin2.*
@@ -12,7 +14,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -51,7 +53,7 @@ internal class CompactBlockProcessorTest {
                 getBlockRange(any())
             }.thenAnswer { invocation ->
                 val range = invocation.arguments[0] as IntRange
-                range.map { CompactBlock(it, ByteArray(0)) }
+                range.map { CompactBlockEntity(it, ByteArray(0)) }
             }
         }
         lightwalletService.stub {
@@ -64,7 +66,7 @@ internal class CompactBlockProcessorTest {
             onBlocking {
                 write(any())
             }.thenAnswer { invocation ->
-                val lastBlockHeight = (invocation.arguments[0] as List<CompactBlock>).last().height
+                val lastBlockHeight = (invocation.arguments[0] as List<CompactBlockEntity>).last().height
                 lastDownloadedHeight = lastBlockHeight
                 Unit
             }


### PR DESCRIPTION
These changes largely reduce the amount of configuration that can be tweaked in order to prevent fragmentation of the anonymity set of users. If wallet makers change certain properties than it can become easy to detect which network requests are coming from which client. The goal is for clients to be as anonymous as possible.