### PR TITLE
Added explicit support for x86_64

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -193,6 +193,7 @@ cargo {
         "arm",
         "arm64",
         "x86",
+        "x86_64"
     ]
     profile = "release"
     forceTargets = true

--- a/buildSrc/src/main/java/cash/z/ecc/android/Deps.kt
+++ b/buildSrc/src/main/java/cash/z/ecc/android/Deps.kt
@@ -6,8 +6,8 @@ object Deps {
     const val kotlinVersion =   "1.3.72"
     const val group =           "cash.z.ecc.android"
     const val artifactName =    "zcash-android-wallet-sdk"
-    const val versionName =     "1.1.0-beta01"
-    const val versionCode =     1_01_00_201  // last digits are alpha(0XX) beta(2XX) rc(4XX) release(8XX). Ex: 1_08_04_401 is an release candidate build of version 1.8.4 and 1_08_04_800 would be the final release.
+    const val versionName =     "1.1.0-beta02"
+    const val versionCode =     1_01_00_202  // last digits are alpha(0XX) beta(2XX) rc(4XX) release(8XX). Ex: 1_08_04_401 is an release candidate build of version 1.8.4 and 1_08_04_800 would be the final release.
     const val description =     "This lightweight SDK connects Android to Zcash. It welds together Rust and Kotlin in a minimal way, allowing third-party Android apps to send and receive shielded transactions easily, securely and privately."
     const val githubUrl =       "https://github.com/zcash/zcash-android-wallet-sdk"
 


### PR DESCRIPTION
Previously, we just relied on implicit support given that x86 is compatible with both 32-bit and 64-bit systems but, going forward, the Play Store will reject these builds, EVEN FOR INTERAL TESTS. This addresses that but it comes with other considerations. arm64 and x86_64 are only supported on Android for API 21+. We probably should structure our resource folders differently to reflect this nuance. Our supported versions are: API 16+ for 32-bit hardware and API 21+ for 64-bit hardware, unless its 64-bit arm which is backward compatible with our 32-bit arm code. Clear as mud, right? I'll add this verbiage somewhere.