### PR TITLE
Fix: Corrected logic when calculating birthdates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 Change Log
 ==========
 
+Version 1.3.0-beta18 *(2021-08-10)*
+------------------------------------
+- Fix: Corrected logic when calculating birthdates for wallets with zero received notes.
+
+
 Version 1.3.0-beta17 *(2021-07-29)*
 ------------------------------------
 - Fix: Autoshielding confirmation count error so funds are available after 10 confirmations.
 - New: Allow developers to enable Rust logs.
 - New: Accept GZIP compression from lightwalletd.
-- New: Reduce the UTXO retry time
+- New: Reduce the UTXO retry time.
 
 Version 1.3.0-beta16 *(2021-06-30)*
 ------------------------------------

--- a/config.gradle
+++ b/config.gradle
@@ -9,8 +9,8 @@ targetSdkVersion = 30
 
 publish {
     group = 'cash.z.ecc.android'
-    versionName = '1.3.0-beta17'
-    versionCode = 1_03_00_217   // last digits are alpha(0XX) beta(2XX) rc(4XX) release(8XX). Ex: 1_08_04_401 is an release candidate build of version 1.8.4 and 1_08_04_800 would be the final release.
+    versionName = '1.3.0-beta18'
+    versionCode = 1_03_00_218   // last digits are alpha(0XX) beta(2XX) rc(4XX) release(8XX). Ex: 1_08_04_401 is an release candidate build of version 1.8.4 and 1_08_04_800 would be the final release.
     artifactId = 'zcash-android-sdk'
     target = 'release'
 }

--- a/src/main/java/cash/z/ecc/android/sdk/block/CompactBlockProcessor.kt
+++ b/src/main/java/cash/z/ecc/android/sdk/block/CompactBlockProcessor.kt
@@ -756,7 +756,7 @@ class CompactBlockProcessor(
     suspend fun calculateBirthdayHeight(): Int {
         var oldestTransactionHeight = 0
         try {
-            oldestTransactionHeight = repository.receivedTransactions.first().last()?.minedHeight ?: lowerBoundHeight
+            oldestTransactionHeight = repository.receivedTransactions.first().lastOrNull()?.minedHeight ?: lowerBoundHeight
             // to be safe adjust for reorgs (and generally a little cushion is good for privacy)
             // so we round down to the nearest 100 and then subtract 100 to ensure that the result is always at least 100 blocks away
             oldestTransactionHeight = ZcashSdk.MAX_REORG_SIZE.let { boundary ->


### PR DESCRIPTION
When wallets have no received notes, finding the last transaction will fail so we should search in a way that returns null rather than an exception. 

_Note that the `receivedTransactions` flow is never null so the call to `first()` is fine but the call to `last()` needed to change._