### PR TITLE
[#262] Target Android SDK 31

### DIFF
--- a/demo-app/src/main/AndroidManifest.xml
+++ b/demo-app/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"
-            android:theme="@style/AppTheme.NoActionBar">
+            android:theme="@style/AppTheme.NoActionBar"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -43,5 +43,5 @@ POM_DEVELOPER_URL=https://github.com/gmale/
 # Note: When updating the NDK version here, be sure to update the version on the CI server as well
 ndkVersion=21.1.6352462
 minSdkVersion=16
-targetSdkVersion=29
-compileSdkVersion=29
+targetSdkVersion=31
+compileSdkVersion=31


### PR DESCRIPTION
Also resolve setting the main activity to exported, which is a new requirement for the new API level.