### PR TITLE
Fix rust build

### DIFF
--- a/.run/clean.run.xml
+++ b/.run/clean.run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="clean" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="clean" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ In the event that you *do* want to compile the SDK from sources, follow these st
 rustup target add armv7-linux-androideabi aarch64-linux-android i686-linux-android x86_64-linux-android
 ```
 3. Clone this repo 
-4. [Install Android Studio](https://developer.android.com/studio/install) and open this project via `/your/path/to/zcash-android-wallet-sdk/build.gradle`
+4. [Install Android Studio](https://developer.android.com/studio/install) and open this project via `/your/path/to/zcash-android-wallet-sdk/build.gradle.kts`
 5. Open Android Studio’s SDK manager
 <p align="center">
     <img src="assets/sdk-manager-icon.png?raw=true" width="70%"/>
@@ -178,17 +178,19 @@ rustup target add armv7-linux-androideabi aarch64-linux-android i686-linux-andro
 
   8. To build from the command line, run:
   ```bash
-  ./gradlew clean assemble
+  ./gradlew assemble
   
-  // or to install in MavenLocal, set properties in Deps.kt then run
+  // or to install in MavenLocal
   
   ./gradlew publishToMavenLocal
   ```
 
-This creates a build of the SDK under `build/outputs/aar/` that can be used to preview functionality. For more detailed examples, see the [demo app](demo-app). Note that merely using the SDK does not require installing Rust or Cargo--that is only required when compiling from source.
+This creates a build of the SDK under `build/outputs/aar/` that can be used to preview functionality. For more detailed examples, see the [demo app](demo-app).
+
+Note that merely using the SDK does not require installing Rust or Cargo--that is only required when compiling from source. Also note that the Mozilla Rust Gradle plugin puts outputs under `sdk-lib/targets`, which has implications for manually testing build script changes. This is discussed further under [docs/tests/Build.md](docs/tests/Build.md).
 
 The repo also contains a small demo application, to verify integration with the SDK.  Note that by default, the demo application is configured to retrieve dependencies from artifact hosting and therefore does not rely on the local compilation of the SDK.  This can be changed by publishing to maven local as described above, as local maven publications will take precedence over hosted publications in the demo app.
-1. [Create an emulator](https://developer.android.com/studio/run/managing-avds) if you don’t already have one (recommended target: API 29)
+1. [Create an emulator](https://developer.android.com/studio/run/managing-avds) if you don’t already have one (recommended target: API 31)
 2. Import the subdirectory samples/demo-app as a separate Android Studio project
 3. Select your desired build variant. Currently, we recommend `zcashmainnetDebug` as the testnet variants are slower to sync to current height due to a lack of checkpoints.
 <p align="center">

--- a/docs/tests/Build.md
+++ b/docs/tests/Build.md
@@ -1,0 +1,23 @@
+# Build
+There are a variety of aspects to building the SDK and demo app.  Although much of this ends up being tested automatically by the CI server, understanding these step can help when troubleshooting build issues.  These test cases provide sanity checks that the build is not broken.
+
+# Build
+1. Run the assemble Gradle task, e.g. `./gradlew assemble`
+1. Verify the build completes successfully
+
+# Build tests
+1. Run the assembleAndroidTest Gradle task, e.g. `./gradlew assembleAndroidTest`
+1. Verify the build completes successfully
+
+# Publishing
+1. Run the task `./gradlew publishToMavenLocal`
+1. Open the `~/.m2` directory and look for the newly published artifact
+1. Verify the coordinate are correct, e.g. `cash/z/ecc/android/zcash-android-sdk`
+1. Verify the version is correct, matching the version set in `gradle.properties`
+1. Verify the file size looks correct—the AAR should be on the order of 9 megabytes, which indicates that the native libraries have been bundled in
+
+# Clean builds — _To have a clean build, both the local Gradle outputs as well as the Rust outputs need to be deleted.  The Rust outputs are stored in the directory `targets`._
+1. Run the clean Gradle task, e.g. `./gradlew clean`
+1. Delete the folder `targets` in the root of the Git repo, if it exists
+1. Run the assemble Gradle task, forcing the Gradle build cache to be ignored, e.g. `./gradlew assemble --rerun-tasks`. _Note that `--rerun-tasks` also causes the cache under `~/.gradle/` to be ignored._
+1. Verify that the build completes successfully

--- a/docs/tests/Build.md
+++ b/docs/tests/Build.md
@@ -16,8 +16,8 @@ There are a variety of aspects to building the SDK and demo app.  Although much 
 1. Verify the version is correct, matching the version set in `gradle.properties`
 1. Verify the file size looks correct—the AAR should be on the order of 9 megabytes, which indicates that the native libraries have been bundled in
 
-# Clean builds — _To have a clean build, both the local Gradle outputs as well as the Rust outputs need to be deleted.  The Rust outputs are stored in the directory `targets`._
+# Clean builds
+_To have a clean build, both the local Gradle outputs as well as the Rust outputs need to be deleted.  The Rust outputs are stored in the directory `sdk-lib/targets`.  The `clean` task has been modified to delete the folder `sdk-lib/targets` if it exists._
 1. Run the clean Gradle task, e.g. `./gradlew clean`
-1. Delete the folder `targets` in the root of the Git repo, if it exists
-1. Run the assemble Gradle task, forcing the Gradle build cache to be ignored, e.g. `./gradlew assemble --rerun-tasks`. _Note that `--rerun-tasks` also causes the cache under `~/.gradle/` to be ignored._
+1. Run the assemble Gradle task, forcing the Gradle build cache to be ignored, e.g. `./gradlew assemble --rerun-tasks`. _Note that `--rerun-tasks` also causes the cache under `~/.gradle/` to be ignored_
 1. Verify that the build completes successfully

--- a/sdk-lib/build.gradle.kts
+++ b/sdk-lib/build.gradle.kts
@@ -229,11 +229,22 @@ dependencies {
     androidTestImplementation(libs.bip39)
 }
 
-tasks.getByName("preBuild").dependsOn(tasks.create("bugfixTask") {
-    doFirst {
-        mkdir("build/extracted-include-protos/main")
-    }
-})
+tasks {
+    getByName("preBuild").dependsOn(create("bugfixTask") {
+        doFirst {
+            mkdir("build/extracted-include-protos/main")
+        }
+    })
+
+    /*
+     * The Mozilla Rust Gradle plugin caches the native build data under the "target" directory,
+     * which does not normally get deleted during a clean. The following task and dependency solves
+     * that.
+     */
+    getByName<Delete>("clean").dependsOn(create<Delete>("cleanRustBuildOutput") {
+        delete("target")
+    })
+}
 
 project.afterEvaluate {
     val cargoTask = tasks.getByName("cargoBuild")
@@ -241,4 +252,5 @@ project.afterEvaluate {
     tasks.getByName("javaPreCompileRelease").dependsOn(cargoTask)
 }
 
-fun MinimalExternalModuleDependency.asCoordinateString() = "${module.group}:${module.name}:${versionConstraint.displayName}"
+fun MinimalExternalModuleDependency.asCoordinateString() =
+    "${module.group}:${module.name}:${versionConstraint.displayName}"

--- a/sdk-lib/build.gradle.kts
+++ b/sdk-lib/build.gradle.kts
@@ -152,6 +152,13 @@ cargo {
         "x86",
         "x86_64"
     )
+    apiLevels = mapOf(
+        "arm" to 16,
+        "arm64" to 21,
+        "x86" to 16,
+        "x86_64" to 21,
+    )
+
     profile = "release"
     prebuiltToolchains = true
 }


### PR DESCRIPTION
This resolves a regression from implementing #251.  Two different problems are fixed:
 - The target API levels are set for 32-bit and 64-bit native libraries, preventing a build failure
 - Rust build caches are purged, which masked this issue during testing
 
 closes #290
 closes #291