### PR TITLE
[#269] Convert blocking calls to suspend functions

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -5,6 +5,8 @@ Upcoming Migrating to Version 1.4.* from 1.3.*
 --------------------------------------
 Various APIs that have always been considered private have been moved into a new package called `internal`.  While this should not be a breaking change, clients that might have relied on these internal classes should stop doing so.
 
+A number of methods have been converted to suspending functions, because they were performing slow or blocking calls (e.g. disk IO) internally.  This is a breaking change.
+
 Migrating to Version 1.3.* from 1.2.*
 --------------------------------------
 The biggest breaking changes in 1.3 that inspired incrementing the minor version number was simplifying down to one "network aware" library rather than two separate libraries, each dedicated to either testnet or mainnet. This greatly simplifies the gradle configuration and has lots of other benefits. Wallets can now set a network with code similar to the following:

--- a/darkside-test-lib/src/androidTest/java/cash/z/ecc/android/sdk/darkside/test/DarksideTestCoordinator.kt
+++ b/darkside-test-lib/src/androidTest/java/cash/z/ecc/android/sdk/darkside/test/DarksideTestCoordinator.kt
@@ -141,8 +141,10 @@ class DarksideTestCoordinator(val wallet: TestWallet) {
     inner class DarksideTestValidator {
 
         fun validateHasBlock(height: Int) {
-            assertTrue((synchronizer as SdkSynchronizer).findBlockHashAsHex(height) != null)
-            assertTrue((synchronizer as SdkSynchronizer).findBlockHash(height)?.size ?: 0 > 0)
+            runBlocking {
+                assertTrue((synchronizer as SdkSynchronizer).findBlockHashAsHex(height) != null)
+                assertTrue((synchronizer as SdkSynchronizer).findBlockHash(height)?.size ?: 0 > 0)
+            }
         }
 
         fun validateLatestHeight(height: Int) = runBlocking<Unit> {
@@ -185,7 +187,7 @@ class DarksideTestCoordinator(val wallet: TestWallet) {
         }
 
         fun validateBlockHash(height: Int, expectedHash: String) {
-            val hash = (synchronizer as SdkSynchronizer).findBlockHashAsHex(height)
+            val hash = runBlocking { (synchronizer as SdkSynchronizer).findBlockHashAsHex(height) }
             assertEquals(expectedHash, hash)
         }
 
@@ -194,7 +196,7 @@ class DarksideTestCoordinator(val wallet: TestWallet) {
         }
 
         fun validateTxCount(count: Int) {
-            val txCount = (synchronizer as SdkSynchronizer).getTransactionCount()
+            val txCount = runBlocking { (synchronizer as SdkSynchronizer).getTransactionCount() }
             assertEquals("Expected $count transactions but found $txCount instead!", count, txCount)
         }
 

--- a/demo-app/src/androidTest/java/cash/z/wallet/sdk/sample/demoapp/SampleCodeTest.kt
+++ b/demo-app/src/androidTest/java/cash/z/wallet/sdk/sample/demoapp/SampleCodeTest.kt
@@ -52,7 +52,12 @@ class SampleCodeTest {
     // ///////////////////////////////////////////////////
     // Derive Extended Spending Key
     @Test fun deriveSpendingKey() {
-        val spendingKeys = DerivationTool.deriveSpendingKeys(seed, ZcashNetwork.Mainnet)
+        val spendingKeys = runBlocking {
+            DerivationTool.deriveSpendingKeys(
+                seed,
+                ZcashNetwork.Mainnet
+            )
+        }
         assertEquals(1, spendingKeys.size)
         log("Spending Key: ${spendingKeys?.get(0)}")
     }
@@ -140,7 +145,7 @@ class SampleCodeTest {
         private val lightwalletdHost: String = ZcashNetwork.Mainnet.defaultHost
 
         private val context = InstrumentationRegistry.getInstrumentation().targetContext
-        private val synchronizer = Synchronizer(Initializer(context) {})
+        private val synchronizer = Synchronizer(runBlocking { Initializer.new(context) {} })
 
         @BeforeClass
         @JvmStatic

--- a/demo-app/src/main/java/cash/z/ecc/android/sdk/demoapp/demos/getbalance/GetBalanceFragment.kt
+++ b/demo-app/src/main/java/cash/z/ecc/android/sdk/demoapp/demos/getbalance/GetBalanceFragment.kt
@@ -17,6 +17,7 @@ import cash.z.ecc.android.sdk.ext.convertZatoshiToZecString
 import cash.z.ecc.android.sdk.tool.DerivationTool
 import cash.z.ecc.android.sdk.type.WalletBalance
 import cash.z.ecc.android.sdk.type.ZcashNetwork
+import kotlinx.coroutines.runBlocking
 
 /**
  * Displays the available balance && total balance associated with the seed defined by the default config.
@@ -43,13 +44,13 @@ class GetBalanceFragment : BaseDemoFragment<FragmentGetBalanceBinding>() {
         val seed = Mnemonics.MnemonicCode(seedPhrase).toSeed()
 
         // converting seed into viewingKey
-        val viewingKey = DerivationTool.deriveUnifiedViewingKeys(seed, ZcashNetwork.fromResources(requireApplicationContext())).first()
+        val viewingKey = runBlocking { DerivationTool.deriveUnifiedViewingKeys(seed, ZcashNetwork.fromResources(requireApplicationContext())).first() }
 
         // using the ViewingKey to initialize
-        Initializer(requireApplicationContext()) {
+        runBlocking {Initializer.new(requireApplicationContext(), null) {
             it.setNetwork(ZcashNetwork.fromResources(requireApplicationContext()))
             it.importWallet(viewingKey, network = ZcashNetwork.fromResources(requireApplicationContext()))
-        }.let { initializer ->
+        }}.let { initializer ->
             synchronizer = Synchronizer(initializer)
         }
     }

--- a/demo-app/src/main/java/cash/z/ecc/android/sdk/demoapp/demos/getprivatekey/GetPrivateKeyFragment.kt
+++ b/demo-app/src/main/java/cash/z/ecc/android/sdk/demoapp/demos/getprivatekey/GetPrivateKeyFragment.kt
@@ -2,6 +2,7 @@ package cash.z.ecc.android.sdk.demoapp.demos.getprivatekey
 
 import android.os.Bundle
 import android.view.LayoutInflater
+import androidx.lifecycle.lifecycleScope
 import cash.z.ecc.android.bip39.Mnemonics
 import cash.z.ecc.android.bip39.toSeed
 import cash.z.ecc.android.sdk.demoapp.BaseDemoFragment
@@ -10,6 +11,7 @@ import cash.z.ecc.android.sdk.demoapp.ext.requireApplicationContext
 import cash.z.ecc.android.sdk.demoapp.util.fromResources
 import cash.z.ecc.android.sdk.tool.DerivationTool
 import cash.z.ecc.android.sdk.type.ZcashNetwork
+import kotlinx.coroutines.launch
 
 /**
  * Displays the viewing key and spending key associated with the seed used during the demo. The
@@ -37,13 +39,22 @@ class GetPrivateKeyFragment : BaseDemoFragment<FragmentGetPrivateKeyBinding>() {
     private fun displayKeys() {
         // derive the keys from the seed:
         // demonstrate deriving spending keys for five accounts but only take the first one
-        val spendingKey = DerivationTool.deriveSpendingKeys(seed, ZcashNetwork.fromResources(requireApplicationContext()), 5).first()
+        lifecycleScope.launchWhenStarted {
+            val spendingKey = DerivationTool.deriveSpendingKeys(
+                seed,
+                ZcashNetwork.fromResources(requireApplicationContext()),
+                5
+            ).first()
 
-        // derive the key that allows you to view but not spend transactions
-        val viewingKey = DerivationTool.deriveViewingKey(spendingKey, ZcashNetwork.fromResources(requireApplicationContext()))
+            // derive the key that allows you to view but not spend transactions
+            val viewingKey = DerivationTool.deriveViewingKey(
+                spendingKey,
+                ZcashNetwork.fromResources(requireApplicationContext())
+            )
 
-        // display the keys in the UI
-        binding.textInfo.setText("Spending Key:\n$spendingKey\n\nViewing Key:\n$viewingKey")
+            // display the keys in the UI
+            binding.textInfo.setText("Spending Key:\n$spendingKey\n\nViewing Key:\n$viewingKey")
+        }
     }
 
     //
@@ -65,10 +76,15 @@ class GetPrivateKeyFragment : BaseDemoFragment<FragmentGetPrivateKeyBinding>() {
     //
 
     override fun onActionButtonClicked() {
-        copyToClipboard(
-            DerivationTool.deriveUnifiedViewingKeys(seed, ZcashNetwork.fromResources(requireApplicationContext())).first().extpub,
-            "ViewingKey copied to clipboard!"
-        )
+        lifecycleScope.launch {
+            copyToClipboard(
+                DerivationTool.deriveUnifiedViewingKeys(
+                    seed,
+                    ZcashNetwork.fromResources(requireApplicationContext())
+                ).first().extpub,
+                "ViewingKey copied to clipboard!"
+            )
+        }
     }
 
     override fun inflateBinding(layoutInflater: LayoutInflater): FragmentGetPrivateKeyBinding =

--- a/demo-app/src/main/java/cash/z/ecc/android/sdk/demoapp/demos/listtransactions/ListTransactionsFragment.kt
+++ b/demo-app/src/main/java/cash/z/ecc/android/sdk/demoapp/demos/listtransactions/ListTransactionsFragment.kt
@@ -19,6 +19,7 @@ import cash.z.ecc.android.sdk.ext.collectWith
 import cash.z.ecc.android.sdk.internal.twig
 import cash.z.ecc.android.sdk.tool.DerivationTool
 import cash.z.ecc.android.sdk.type.ZcashNetwork
+import kotlinx.coroutines.runBlocking
 
 /**
  * List all transactions related to the given seed, since the given birthday. This begins by
@@ -47,11 +48,16 @@ class ListTransactionsFragment : BaseDemoFragment<FragmentListTransactionsBindin
         // have the seed stored
         val seed = Mnemonics.MnemonicCode(seedPhrase).toSeed()
 
-        initializer = Initializer(requireApplicationContext()) {
-            it.importWallet(seed, network = ZcashNetwork.fromResources(requireApplicationContext()))
+        initializer = runBlocking {Initializer.new(requireApplicationContext()) {
+            runBlocking { it.importWallet(seed, network = ZcashNetwork.fromResources(requireApplicationContext())) }
             it.setNetwork(ZcashNetwork.fromResources(requireApplicationContext()))
+        }}
+        address = runBlocking {
+            DerivationTool.deriveShieldedAddress(
+                seed,
+                ZcashNetwork.fromResources(requireApplicationContext())
+            )
         }
-        address = DerivationTool.deriveShieldedAddress(seed, ZcashNetwork.fromResources(requireApplicationContext()))
         synchronizer = Synchronizer(initializer)
     }
 

--- a/demo-app/src/main/java/cash/z/ecc/android/sdk/demoapp/demos/send/SendFragment.kt
+++ b/demo-app/src/main/java/cash/z/ecc/android/sdk/demoapp/demos/send/SendFragment.kt
@@ -32,6 +32,7 @@ import cash.z.ecc.android.sdk.internal.twig
 import cash.z.ecc.android.sdk.tool.DerivationTool
 import cash.z.ecc.android.sdk.type.WalletBalance
 import cash.z.ecc.android.sdk.type.ZcashNetwork
+import kotlinx.coroutines.runBlocking
 
 /**
  * Demonstrates sending funds to an address. This is the most complex example that puts all of the
@@ -63,13 +64,13 @@ class SendFragment : BaseDemoFragment<FragmentSendBinding>() {
         // have the seed stored
         val seed = Mnemonics.MnemonicCode(seedPhrase).toSeed()
 
-        Initializer(requireApplicationContext()) {
-            it.importWallet(seed, network = ZcashNetwork.fromResources(requireApplicationContext()))
+        runBlocking { Initializer.new(requireApplicationContext()) {
+            runBlocking { it.importWallet(seed, network = ZcashNetwork.fromResources(requireApplicationContext())) }
             it.setNetwork(ZcashNetwork.fromResources(requireApplicationContext()))
-        }.let { initializer ->
+        }}.let { initializer ->
             synchronizer = Synchronizer(initializer)
         }
-        spendingKey = DerivationTool.deriveSpendingKeys(seed, ZcashNetwork.fromResources(requireApplicationContext())).first()
+        spendingKey = runBlocking { DerivationTool.deriveSpendingKeys(seed, ZcashNetwork.fromResources(requireApplicationContext())).first() }
     }
 
     //

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/AssetTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/AssetTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.filters.SmallTest
 import cash.z.ecc.android.sdk.tool.WalletBirthdayTool
 import cash.z.ecc.android.sdk.type.ZcashNetwork
+import kotlinx.coroutines.runBlocking
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -92,9 +93,9 @@ class AssetTest {
     private data class JsonFile(val jsonObject: JSONObject, val filename: String)
 
     companion object {
-        fun listAssets(network: ZcashNetwork) = WalletBirthdayTool.listBirthdayDirectoryContents(
+        fun listAssets(network: ZcashNetwork) = runBlocking { WalletBirthdayTool.listBirthdayDirectoryContents(
             ApplicationProvider.getApplicationContext<Context>(),
-            WalletBirthdayTool.birthdayDirectory(network)
-        )
+            WalletBirthdayTool.birthdayDirectory(network))
+        }
     }
 }

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/ext/TestExtensions.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/ext/TestExtensions.kt
@@ -3,13 +3,14 @@ package cash.z.ecc.android.sdk.ext
 import cash.z.ecc.android.sdk.Initializer
 import cash.z.ecc.android.sdk.type.ZcashNetwork
 import cash.z.ecc.android.sdk.util.SimpleMnemonics
+import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.json.JSONObject
 import ru.gildor.coroutines.okhttp.await
 
 fun Initializer.Config.seedPhrase(seedPhrase: String, network: ZcashNetwork) {
-    setSeed(SimpleMnemonics().toSeed(seedPhrase.toCharArray()), network)
+    runBlocking { setSeed(SimpleMnemonics().toSeed(seedPhrase.toCharArray()), network) }
 }
 
 object BlockExplorer {

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/integration/TestnetIntegrationTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/integration/TestnetIntegrationTest.kt
@@ -46,7 +46,13 @@ class TestnetIntegrationTest : ScopedTest() {
 
     @Test
     fun testLoadBirthday() {
-        val (height, hash, time, tree) = WalletBirthdayTool.loadNearest(context, synchronizer.network, saplingActivation + 1)
+        val (height, hash, time, tree) = runBlocking {
+            WalletBirthdayTool.loadNearest(
+                context,
+                synchronizer.network,
+                saplingActivation + 1
+            )
+        }
         assertEquals(saplingActivation, height)
     }
 
@@ -118,9 +124,11 @@ class TestnetIntegrationTest : ScopedTest() {
         val toAddress = "zs1vp7kvlqr4n9gpehztr76lcn6skkss9p8keqs3nv8avkdtjrcctrvmk9a7u494kluv756jeee5k0"
 
         private val context = InstrumentationRegistry.getInstrumentation().context
-        private val initializer = Initializer(context) { config ->
-            config.setNetwork(ZcashNetwork.Testnet, host)
-            config.importWallet(seed, birthdayHeight, ZcashNetwork.Testnet)
+        private val initializer = runBlocking {
+            Initializer.new(context) { config ->
+                config.setNetwork(ZcashNetwork.Testnet, host)
+                runBlocking { config.importWallet(seed, birthdayHeight, ZcashNetwork.Testnet) }
+            }
         }
         private lateinit var synchronizer: Synchronizer
 

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/jni/BranchIdTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/jni/BranchIdTest.kt
@@ -3,6 +3,7 @@ package cash.z.ecc.android.sdk.jni
 import cash.z.ecc.android.sdk.annotation.MaintainedTest
 import cash.z.ecc.android.sdk.annotation.TestPurpose
 import cash.z.ecc.android.sdk.type.ZcashNetwork
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -43,8 +44,8 @@ class BranchIdTest(
             // is an abnormal use of the SDK because this really should run at the rust level
             // However, due to quirks on certain devices, we created this test at the Android level,
             // as a sanity check
-            val testnetBackend = RustBackend.init("", "", "", ZcashNetwork.Testnet)
-            val mainnetBackend = RustBackend.init("", "", "", ZcashNetwork.Mainnet)
+            val testnetBackend = runBlocking { RustBackend.init("", "", "", ZcashNetwork.Testnet) }
+            val mainnetBackend = runBlocking { RustBackend.init("", "", "", ZcashNetwork.Mainnet) }
             return listOf(
                 // Mainnet Cases
                 arrayOf("Sapling", 419_200, 1991772603L, "76b809bb", mainnetBackend),

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/jni/TransparentTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/jni/TransparentTest.kt
@@ -9,6 +9,7 @@ import cash.z.ecc.android.sdk.internal.TroubleshootingTwig
 import cash.z.ecc.android.sdk.internal.Twig
 import cash.z.ecc.android.sdk.tool.DerivationTool
 import cash.z.ecc.android.sdk.type.ZcashNetwork
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.BeforeClass
 import org.junit.Test
@@ -21,23 +22,23 @@ import org.junit.runners.Parameterized
 class TransparentTest(val expected: Expected, val network: ZcashNetwork) {
 
     @Test
-    fun deriveTransparentSecretKeyTest() {
+    fun deriveTransparentSecretKeyTest() = runBlocking {
         assertEquals(expected.tskCompressed, DerivationTool.deriveTransparentSecretKey(SEED, network = network))
     }
 
     @Test
-    fun deriveTransparentAddressTest() {
+    fun deriveTransparentAddressTest() = runBlocking {
         assertEquals(expected.tAddr, DerivationTool.deriveTransparentAddress(SEED, network = network))
     }
 
     @Test
-    fun deriveTransparentAddressFromSecretKeyTest() {
+    fun deriveTransparentAddressFromSecretKeyTest() = runBlocking {
         val pk = DerivationTool.deriveTransparentSecretKey(SEED, network = network)
         assertEquals(expected.tAddr, DerivationTool.deriveTransparentAddressFromPrivateKey(pk, network = network))
     }
 
     @Test
-    fun deriveUnifiedViewingKeysFromSeedTest() {
+    fun deriveUnifiedViewingKeysFromSeedTest() = runBlocking {
         val uvks = DerivationTool.deriveUnifiedViewingKeys(SEED, network = network)
         assertEquals(1, uvks.size)
         val uvk = uvks.first()

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/tool/WalletBirthdayToolTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/tool/WalletBirthdayToolTest.kt
@@ -4,7 +4,8 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
-import cash.z.ecc.android.sdk.tool.WalletBirthdayTool.Companion.IS_FALLBACK_ON_FAILURE
+import cash.z.ecc.android.sdk.tool.WalletBirthdayTool.IS_FALLBACK_ON_FAILURE
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -25,11 +26,13 @@ class WalletBirthdayToolTest {
         val directory = "saplingtree/goodnet"
 
         val context = ApplicationProvider.getApplicationContext<Context>()
-        val birthday = WalletBirthdayTool.getFirstValidWalletBirthday(
-            context,
-            directory,
-            listOf("1300000.json", "1290000.json")
-        )
+        val birthday = runBlocking {
+            WalletBirthdayTool.getFirstValidWalletBirthday(
+                context,
+                directory,
+                listOf("1300000.json", "1290000.json")
+            )
+        }
         assertEquals(1300000, birthday.height)
     }
 
@@ -42,11 +45,13 @@ class WalletBirthdayToolTest {
 
         val directory = "saplingtree/badnet"
         val context = ApplicationProvider.getApplicationContext<Context>()
-        val birthday = WalletBirthdayTool.getFirstValidWalletBirthday(
-            context,
-            directory,
-            listOf("1300000.json", "1290000.json")
-        )
+        val birthday = runBlocking {
+            WalletBirthdayTool.getFirstValidWalletBirthday(
+                context,
+                directory,
+                listOf("1300000.json", "1290000.json")
+            )
+        }
         assertEquals(1290000, birthday.height)
     }
 }

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/util/DataDbScannerUtil.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/util/DataDbScannerUtil.kt
@@ -64,7 +64,13 @@ class DataDbScannerUtil {
     @Test
     @Ignore("This test is broken")
     fun scanExistingDb() {
-        synchronizer = Synchronizer(Initializer(context) { it.setBirthdayHeight(birthdayHeight) })
+        synchronizer = Synchronizer(runBlocking {
+            Initializer.new(context) {
+                it.setBirthdayHeight(
+                    birthdayHeight
+                )
+            }
+        })
 
         println("sync!")
         synchronizer.start()

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
@@ -58,7 +58,6 @@ import io.grpc.ManagedChannel
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
@@ -247,7 +246,7 @@ class SdkSynchronizer internal constructor(
 
     override val latestBirthdayHeight: Int get() = processor.birthdayHeight
 
-    override fun prepare(): Synchronizer = apply {
+    override suspend fun prepare(): Synchronizer = apply {
         storage.prepare()
     }
 
@@ -336,15 +335,15 @@ class SdkSynchronizer internal constructor(
 
     // TODO: turn this section into the data access API. For now, just aggregate all the things that we want to do with the underlying data
 
-    fun findBlockHash(height: Int): ByteArray? {
+    suspend fun findBlockHash(height: Int): ByteArray? {
         return (storage as? PagedTransactionRepository)?.findBlockHash(height)
     }
 
-    fun findBlockHashAsHex(height: Int): String? {
+    suspend fun findBlockHashAsHex(height: Int): String? {
         return findBlockHash(height)?.toHexReversed()
     }
 
-    fun getTransactionCount(): Int {
+    suspend fun getTransactionCount(): Int {
         return (storage as? PagedTransactionRepository)?.getTransactionCount() ?: 0
     }
 
@@ -530,7 +529,7 @@ class SdkSynchronizer internal constructor(
         }
     }
 
-    private suspend fun refreshPendingTransactions() = withContext(IO) {
+    private suspend fun refreshPendingTransactions() = withContext(Dispatchers.IO) {
         twig("[cleanup] beginning to refresh and clean up pending transactions")
         // TODO: this would be the place to clear out any stale pending transactions. Remove filter
         //  logic and then delete any pending transaction with sufficient confirmations (all in one
@@ -737,7 +736,7 @@ class SdkSynchronizer internal constructor(
          *
          * @return true when content was found for the given alias. False otherwise.
          */
-        fun erase(appContext: Context, network: ZcashNetwork, alias: String = ZcashSdk.DEFAULT_ALIAS): Boolean
+        suspend fun erase(appContext: Context, network: ZcashNetwork, alias: String = ZcashSdk.DEFAULT_ALIAS): Boolean
     }
 }
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
@@ -35,7 +35,7 @@ interface Synchronizer {
      * where setup and maintenance can occur for various Synchronizers. One that uses a database
      * would take this opportunity to do data migrations or key migrations.
      */
-    fun prepare(): Synchronizer
+    suspend fun prepare(): Synchronizer
 
     /**
      * Starts this synchronizer within the given scope.

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/CompactBlockProcessor.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/CompactBlockProcessor.kt
@@ -526,7 +526,7 @@ class CompactBlockProcessor(
      *  @return [ERROR_CODE_NONE] when there is no problem. Otherwise, return the lowest height where an error was
      *  found. In other words, validation starts at the back of the chain and works toward the tip.
      */
-    private fun validateNewBlocks(range: IntRange?): Int {
+    private suspend fun validateNewBlocks(range: IntRange?): Int {
         if (range?.isEmpty() != false) {
             twig("no blocks to validate: $range")
             return ERROR_CODE_NONE

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/SdkDispatchers.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/SdkDispatchers.kt
@@ -1,0 +1,14 @@
+package cash.z.ecc.android.sdk.internal
+
+import kotlinx.coroutines.asCoroutineDispatcher
+import java.util.concurrent.Executors
+
+internal object SdkDispatchers {
+    /*
+     * Based on internal discussion, keep the SDK internals confined to a single IO thread.
+     *
+     * We don't expect things to break, but we don't have the WAL enabled for SQLite so this
+     * is a simple solution.
+     */
+    val IO = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+}

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/block/CompactBlockDownloader.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/block/CompactBlockDownloader.kt
@@ -7,6 +7,7 @@ import cash.z.ecc.android.sdk.internal.service.LightWalletService
 import cash.z.wallet.sdk.rpc.Service
 import io.grpc.StatusRuntimeException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -122,8 +123,10 @@ open class CompactBlockDownloader private constructor(val compactBlockStore: Com
     /**
      * Stop this downloader and cleanup any resources being used.
      */
-    fun stop() {
-        lightWalletService.shutdown()
+    suspend fun stop() {
+        withContext(Dispatchers.IO) {
+            lightWalletService.shutdown()
+        }
         compactBlockStore.close()
     }
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/block/CompactBlockStore.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/block/CompactBlockStore.kt
@@ -37,5 +37,5 @@ interface CompactBlockStore {
     /**
      * Close any connections to the block store.
      */
-    fun close()
+    suspend fun close()
 }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/ext/ContextExt.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/ext/ContextExt.kt
@@ -1,0 +1,11 @@
+package cash.z.ecc.android.sdk.internal.ext
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+suspend fun Context.getDatabasePathSuspend(fileName: String) =
+    withContext(Dispatchers.IO) { getDatabasePath(fileName) }
+
+suspend fun Context.getCacheDirSuspend() =
+    withContext(Dispatchers.IO) { cacheDir }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/ext/FileExt.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/ext/FileExt.kt
@@ -1,0 +1,7 @@
+package cash.z.ecc.android.sdk.internal.ext
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+suspend fun File.deleteSuspend() = withContext(Dispatchers.IO) { delete() }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/TransactionRepository.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/TransactionRepository.kt
@@ -87,7 +87,7 @@ interface TransactionRepository {
 
     suspend fun getAccountCount(): Int
 
-    fun prepare()
+    suspend fun prepare()
 
     //
     // Transactions

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/WalletTransactionEncoder.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/WalletTransactionEncoder.kt
@@ -8,7 +8,8 @@ import cash.z.ecc.android.sdk.internal.twigTask
 import cash.z.ecc.android.sdk.jni.RustBackend
 import cash.z.ecc.android.sdk.jni.RustBackendWelding
 import cash.z.ecc.android.sdk.internal.SaplingParamTool
-import kotlinx.coroutines.Dispatchers.IO
+import cash.z.ecc.android.sdk.internal.SdkDispatchers
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 /**
@@ -44,7 +45,7 @@ class WalletTransactionEncoder(
         toAddress: String,
         memo: ByteArray?,
         fromAccountIndex: Int
-    ): EncodedTransaction = withContext(IO) {
+    ): EncodedTransaction = withContext(SdkDispatchers.IO) {
         val transactionId = createSpend(spendingKey, zatoshi, toAddress, memo)
         repository.findEncodedTransactionById(transactionId)
             ?: throw TransactionEncoderException.TransactionNotFoundException(transactionId)
@@ -54,7 +55,7 @@ class WalletTransactionEncoder(
         spendingKey: String,
         transparentSecretKey: String,
         memo: ByteArray?
-    ): EncodedTransaction = withContext(IO) {
+    ): EncodedTransaction = withContext(SdkDispatchers.IO) {
         val transactionId = createShieldingSpend(spendingKey, transparentSecretKey, memo)
         repository.findEncodedTransactionById(transactionId)
             ?: throw TransactionEncoderException.TransactionNotFoundException(transactionId)
@@ -68,7 +69,7 @@ class WalletTransactionEncoder(
      *
      * @return true when the given address is a valid z-addr
      */
-    override suspend fun isValidShieldedAddress(address: String): Boolean = withContext(IO) {
+    override suspend fun isValidShieldedAddress(address: String): Boolean = withContext(Dispatchers.IO) {
         rustBackend.isValidShieldedAddr(address)
     }
 
@@ -80,7 +81,7 @@ class WalletTransactionEncoder(
      *
      * @return true when the given address is a valid t-addr
      */
-    override suspend fun isValidTransparentAddress(address: String): Boolean = withContext(IO) {
+    override suspend fun isValidTransparentAddress(address: String): Boolean = withContext(Dispatchers.IO) {
         rustBackend.isValidTransparentAddr(address)
     }
 
@@ -110,7 +111,7 @@ class WalletTransactionEncoder(
         toAddress: String,
         memo: ByteArray? = byteArrayOf(),
         fromAccountIndex: Int = 0
-    ): Long = withContext(IO) {
+    ): Long = withContext(Dispatchers.IO) {
         twigTask(
             "creating transaction to spend $zatoshi zatoshi to" +
                 " ${toAddress.masked()} with memo $memo"
@@ -140,7 +141,7 @@ class WalletTransactionEncoder(
         spendingKey: String,
         transparentSecretKey: String,
         memo: ByteArray? = byteArrayOf()
-    ): Long = withContext(IO) {
+    ): Long = withContext(Dispatchers.IO) {
         twigTask("creating transaction to shield all UTXOs") {
             try {
                 SaplingParamTool.ensureParams((rustBackend as RustBackend).pathParamsDir)

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/jni/NativeLibraryLoader.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/jni/NativeLibraryLoader.kt
@@ -1,0 +1,44 @@
+package cash.z.ecc.android.sdk.jni
+
+import cash.z.ecc.android.sdk.internal.twig
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Loads a native library once.  This class is thread-safe.
+ *
+ * To use this class, create a singleton instance for each given [libraryName].
+ *
+ * @param libraryName Name of the library to load.
+ */
+internal class NativeLibraryLoader(private val libraryName: String) {
+    private val isLoaded = AtomicBoolean(false)
+    private val mutex = Mutex()
+
+    suspend fun load() {
+        // Double-checked locking to avoid the Mutex unless necessary, as the hot path is
+        // for the library to be loaded since this should only run once for the lifetime
+        // of the application
+        if (!isLoaded.get()) {
+            mutex.withLock {
+                if (!isLoaded.get()) {
+                    loadRustLibrary()
+                }
+            }
+        }
+    }
+
+    private suspend fun loadRustLibrary() {
+        try {
+            withContext(Dispatchers.IO) {
+                twig("Loading native library $libraryName") { System.loadLibrary(libraryName) }
+            }
+            isLoaded.set(true)
+        } catch (e: Throwable) {
+            twig("Error while loading native library: ${e.message}")
+        }
+    }
+}

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/jni/RustBackendWelding.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/jni/RustBackendWelding.kt
@@ -14,7 +14,7 @@ interface RustBackendWelding {
 
     val network: ZcashNetwork
 
-    fun createToAddress(
+    suspend fun createToAddress(
         consensusBranchId: Long,
         account: Int,
         extsk: String,
@@ -23,51 +23,51 @@ interface RustBackendWelding {
         memo: ByteArray? = byteArrayOf()
     ): Long
 
-    fun shieldToAddress(
+    suspend fun shieldToAddress(
         extsk: String,
         tsk: String,
         memo: ByteArray? = byteArrayOf()
     ): Long
 
-    fun decryptAndStoreTransaction(tx: ByteArray)
+    suspend fun decryptAndStoreTransaction(tx: ByteArray)
 
-    fun initAccountsTable(seed: ByteArray, numberOfAccounts: Int): Array<UnifiedViewingKey>
+    suspend fun initAccountsTable(seed: ByteArray, numberOfAccounts: Int): Array<UnifiedViewingKey>
 
-    fun initAccountsTable(vararg keys: UnifiedViewingKey): Boolean
+    suspend fun initAccountsTable(vararg keys: UnifiedViewingKey): Boolean
 
-    fun initBlocksTable(height: Int, hash: String, time: Long, saplingTree: String): Boolean
+    suspend fun initBlocksTable(height: Int, hash: String, time: Long, saplingTree: String): Boolean
 
-    fun initDataDb(): Boolean
+    suspend fun initDataDb(): Boolean
 
     fun isValidShieldedAddr(addr: String): Boolean
 
     fun isValidTransparentAddr(addr: String): Boolean
 
-    fun getShieldedAddress(account: Int = 0): String
+    suspend fun getShieldedAddress(account: Int = 0): String
 
-    fun getTransparentAddress(account: Int = 0, index: Int = 0): String
+    suspend fun getTransparentAddress(account: Int = 0, index: Int = 0): String
 
-    fun getBalance(account: Int = 0): Long
+    suspend fun getBalance(account: Int = 0): Long
 
     fun getBranchIdForHeight(height: Int): Long
 
-    fun getReceivedMemoAsUtf8(idNote: Long): String
+    suspend fun getReceivedMemoAsUtf8(idNote: Long): String
 
-    fun getSentMemoAsUtf8(idNote: Long): String
+    suspend fun getSentMemoAsUtf8(idNote: Long): String
 
-    fun getVerifiedBalance(account: Int = 0): Long
+    suspend fun getVerifiedBalance(account: Int = 0): Long
 
 //    fun parseTransactionDataList(tdl: LocalRpcTypes.TransactionDataList): LocalRpcTypes.TransparentTransactionList
 
-    fun getNearestRewindHeight(height: Int): Int
+    suspend fun getNearestRewindHeight(height: Int): Int
 
-    fun rewindToHeight(height: Int): Boolean
+    suspend fun rewindToHeight(height: Int): Boolean
 
-    fun scanBlocks(limit: Int = -1): Boolean
+    suspend fun scanBlocks(limit: Int = -1): Boolean
 
-    fun validateCombinedChain(): Int
+    suspend fun validateCombinedChain(): Int
 
-    fun putUtxo(
+    suspend fun putUtxo(
         tAddress: String,
         txId: ByteArray,
         index: Int,
@@ -76,59 +76,59 @@ interface RustBackendWelding {
         height: Int
     ): Boolean
 
-    fun clearUtxos(tAddress: String, aboveHeight: Int = network.saplingActivationHeight - 1): Boolean
+    suspend fun clearUtxos(tAddress: String, aboveHeight: Int = network.saplingActivationHeight - 1): Boolean
 
-    fun getDownloadedUtxoBalance(address: String): WalletBalance
+    suspend fun getDownloadedUtxoBalance(address: String): WalletBalance
 
     // Implemented by `DerivationTool`
     interface Derivation {
-        fun deriveShieldedAddress(
+        suspend fun deriveShieldedAddress(
             viewingKey: String,
             network: ZcashNetwork
         ): String
 
-        fun deriveShieldedAddress(
+        suspend fun deriveShieldedAddress(
             seed: ByteArray,
             network: ZcashNetwork,
             accountIndex: Int = 0,
         ): String
 
-        fun deriveSpendingKeys(
+        suspend fun deriveSpendingKeys(
             seed: ByteArray,
             network: ZcashNetwork,
             numberOfAccounts: Int = 1,
         ): Array<String>
 
-        fun deriveTransparentAddress(
+        suspend fun deriveTransparentAddress(
             seed: ByteArray,
             network: ZcashNetwork,
             account: Int = 0,
             index: Int = 0,
         ): String
 
-        fun deriveTransparentAddressFromPublicKey(
+        suspend fun deriveTransparentAddressFromPublicKey(
             publicKey: String,
             network: ZcashNetwork
         ): String
 
-        fun deriveTransparentAddressFromPrivateKey(
+        suspend fun deriveTransparentAddressFromPrivateKey(
             privateKey: String,
             network: ZcashNetwork
         ): String
 
-        fun deriveTransparentSecretKey(
+        suspend fun deriveTransparentSecretKey(
             seed: ByteArray,
             network: ZcashNetwork,
             account: Int = 0,
             index: Int = 0,
         ): String
 
-        fun deriveViewingKey(
+        suspend fun deriveViewingKey(
             spendingKey: String,
             network: ZcashNetwork
         ): String
 
-        fun deriveUnifiedViewingKeys(
+        suspend fun deriveUnifiedViewingKeys(
             seed: ByteArray,
             network: ZcashNetwork,
             numberOfAccounts: Int = 1,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/tool/DerivationTool.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/tool/DerivationTool.kt
@@ -18,7 +18,7 @@ class DerivationTool {
          *
          * @return the viewing keys that correspond to the seed, formatted as Strings.
          */
-        override fun deriveUnifiedViewingKeys(seed: ByteArray, network: ZcashNetwork, numberOfAccounts: Int): Array<UnifiedViewingKey> =
+        override suspend fun deriveUnifiedViewingKeys(seed: ByteArray, network: ZcashNetwork, numberOfAccounts: Int): Array<UnifiedViewingKey> =
             withRustBackendLoaded {
                 deriveUnifiedViewingKeysFromSeed(seed, numberOfAccounts, networkId = network.id).map {
                     UnifiedViewingKey(it[0], it[1])
@@ -32,7 +32,7 @@ class DerivationTool {
          *
          * @return the viewing key that corresponds to the spending key.
          */
-        override fun deriveViewingKey(spendingKey: String, network: ZcashNetwork): String = withRustBackendLoaded {
+        override suspend fun deriveViewingKey(spendingKey: String, network: ZcashNetwork): String = withRustBackendLoaded {
             deriveExtendedFullViewingKey(spendingKey, networkId = network.id)
         }
 
@@ -45,7 +45,7 @@ class DerivationTool {
          *
          * @return the spending keys that correspond to the seed, formatted as Strings.
          */
-        override fun deriveSpendingKeys(seed: ByteArray, network: ZcashNetwork, numberOfAccounts: Int): Array<String> =
+        override suspend fun deriveSpendingKeys(seed: ByteArray, network: ZcashNetwork, numberOfAccounts: Int): Array<String> =
             withRustBackendLoaded {
                 deriveExtendedSpendingKeys(seed, numberOfAccounts, networkId = network.id)
             }
@@ -59,7 +59,7 @@ class DerivationTool {
          *
          * @return the address that corresponds to the seed and account index.
          */
-        override fun deriveShieldedAddress(seed: ByteArray, network: ZcashNetwork, accountIndex: Int): String =
+        override suspend fun deriveShieldedAddress(seed: ByteArray, network: ZcashNetwork, accountIndex: Int): String =
             withRustBackendLoaded {
                 deriveShieldedAddressFromSeed(seed, accountIndex, networkId = network.id)
             }
@@ -72,26 +72,26 @@ class DerivationTool {
          *
          * @return the address that corresponds to the viewing key.
          */
-        override fun deriveShieldedAddress(viewingKey: String, network: ZcashNetwork): String = withRustBackendLoaded {
+        override suspend fun deriveShieldedAddress(viewingKey: String, network: ZcashNetwork): String = withRustBackendLoaded {
             deriveShieldedAddressFromViewingKey(viewingKey, networkId = network.id)
         }
 
         // WIP probably shouldn't be used just yet. Why?
         //  - because we need the private key associated with this seed and this function doesn't return it.
         //  - the underlying implementation needs to be split out into a few lower-level calls
-        override fun deriveTransparentAddress(seed: ByteArray, network: ZcashNetwork, account: Int, index: Int): String = withRustBackendLoaded {
+        override suspend fun deriveTransparentAddress(seed: ByteArray, network: ZcashNetwork, account: Int, index: Int): String = withRustBackendLoaded {
             deriveTransparentAddressFromSeed(seed, account, index, networkId = network.id)
         }
 
-        override fun deriveTransparentAddressFromPublicKey(transparentPublicKey: String, network: ZcashNetwork): String = withRustBackendLoaded {
+        override suspend fun deriveTransparentAddressFromPublicKey(transparentPublicKey: String, network: ZcashNetwork): String = withRustBackendLoaded {
             deriveTransparentAddressFromPubKey(transparentPublicKey, networkId = network.id)
         }
 
-        override fun deriveTransparentAddressFromPrivateKey(transparentPrivateKey: String, network: ZcashNetwork): String = withRustBackendLoaded {
+        override suspend fun deriveTransparentAddressFromPrivateKey(transparentPrivateKey: String, network: ZcashNetwork): String = withRustBackendLoaded {
             deriveTransparentAddressFromPrivKey(transparentPrivateKey, networkId = network.id)
         }
 
-        override fun deriveTransparentSecretKey(seed: ByteArray, network: ZcashNetwork, account: Int, index: Int): String = withRustBackendLoaded {
+        override suspend fun deriveTransparentSecretKey(seed: ByteArray, network: ZcashNetwork, account: Int, index: Int): String = withRustBackendLoaded {
             deriveTransparentSecretKeyFromSeed(seed, account, index, networkId = network.id)
         }
 
@@ -104,8 +104,8 @@ class DerivationTool {
          * class attempts to interact with it, indirectly, by invoking JNI functions. It would be
          * nice to have an annotation like @UsesSystemLibrary for this
          */
-        private fun <T> withRustBackendLoaded(block: () -> T): T {
-            RustBackend.load()
+        private suspend fun <T> withRustBackendLoaded(block: () -> T): T {
+            RustBackend.rustLibraryLoader.load()
             return block()
         }
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/tool/WalletBirthdayTool.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/tool/WalletBirthdayTool.kt
@@ -8,165 +8,156 @@ import cash.z.ecc.android.sdk.type.WalletBirthday
 import cash.z.ecc.android.sdk.type.ZcashNetwork
 import com.google.gson.Gson
 import com.google.gson.stream.JsonReader
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.IOException
 import java.io.InputStreamReader
 import java.util.Locale
 
 /**
  * Tool for loading checkpoints for the wallet, based on the height at which the wallet was born.
- *
- * @param appContext needed for loading checkpoints from the app's assets directory.
  */
-class WalletBirthdayTool(appContext: Context) {
-    private val context = appContext.applicationContext
+object WalletBirthdayTool {
+
+    // Behavior change implemented as a fix for issue #270.  Temporarily adding a boolean
+    // that allows the change to be rolled back quickly if needed, although long-term
+    // this flag should be removed.
+    @VisibleForTesting
+    internal val IS_FALLBACK_ON_FAILURE = true
 
     /**
      * Load the nearest checkpoint to the given birthday height. If null is given, then this
      * will load the most recent checkpoint available.
      */
-    fun loadNearest(network: ZcashNetwork, birthdayHeight: Int? = null): WalletBirthday {
+    suspend fun loadNearest(
+        context: Context,
+        network: ZcashNetwork,
+        birthdayHeight: Int? = null
+    ): WalletBirthday {
+        // TODO: potentially pull from shared preferences first
         return loadBirthdayFromAssets(context, network, birthdayHeight)
     }
 
-    companion object {
-
-        // Behavior change implemented as a fix for issue #270.  Temporarily adding a boolean
-        // that allows the change to be rolled back quickly if needed, although long-term
-        // this flag should be removed.
-        @VisibleForTesting
-        internal val IS_FALLBACK_ON_FAILURE = true
-
-        /**
-         * Load the nearest checkpoint to the given birthday height. If null is given, then this
-         * will load the most recent checkpoint available.
-         */
-        fun loadNearest(
-            context: Context,
-            network: ZcashNetwork,
-            birthdayHeight: Int? = null
-        ): WalletBirthday {
-            // TODO: potentially pull from shared preferences first
-            return loadBirthdayFromAssets(context, network, birthdayHeight)
-        }
-
-        /**
-         * Useful for when an exact checkpoint is needed, like for SAPLING_ACTIVATION_HEIGHT. In
-         * most cases, loading the nearest checkpoint is preferred for privacy reasons.
-         */
-        fun loadExact(context: Context, network: ZcashNetwork, birthdayHeight: Int) =
-            loadNearest(context, network, birthdayHeight).also {
-                if (it.height != birthdayHeight)
-                    throw BirthdayException.ExactBirthdayNotFoundException(
-                        birthdayHeight,
-                        it.height
-                    )
-            }
-
-        // TODO: This method performs disk IO; convert to suspending function
-        // Converting this to suspending will then propagate
-        @Throws(IOException::class)
-        internal fun listBirthdayDirectoryContents(context: Context, directory: String) =
-            context.assets.list(directory)
-
-        /**
-         * Returns the directory within the assets folder where birthday data
-         * (i.e. sapling trees for a given height) can be found.
-         */
-        @VisibleForTesting
-        internal fun birthdayDirectory(network: ZcashNetwork) =
-            "saplingtree/${(network.networkName as java.lang.String).toLowerCase(Locale.US)}"
-
-        internal fun birthdayHeight(fileName: String) = fileName.split('.').first().toInt()
-
-        private fun Array<String>.sortDescending() =
-            apply { sortByDescending { birthdayHeight(it) } }
-
-        /**
-         * Load the given birthday file from the assets of the given context. When no height is
-         * specified, we default to the file with the greatest name.
-         *
-         * @param context the context from which to load assets.
-         * @param birthdayHeight the height file to look for among the file names.
-         *
-         * @return a WalletBirthday that reflects the contents of the file or an exception when
-         * parsing fails.
-         */
-        private fun loadBirthdayFromAssets(
-            context: Context,
-            network: ZcashNetwork,
-            birthdayHeight: Int? = null
-        ): WalletBirthday {
-            twig("loading birthday from assets: $birthdayHeight")
-            val directory = birthdayDirectory(network)
-            val treeFiles = getFilteredFileNames(context, directory, birthdayHeight)
-
-            twig("found ${treeFiles.size} sapling tree checkpoints: $treeFiles")
-
-            return getFirstValidWalletBirthday(context, directory, treeFiles)
-        }
-
-        private fun getFilteredFileNames(
-            context: Context,
-            directory: String,
-            birthdayHeight: Int? = null,
-        ): List<String> {
-            val unfilteredTreeFiles = listBirthdayDirectoryContents(context, directory)
-            if (unfilteredTreeFiles.isNullOrEmpty()) {
-                throw BirthdayException.MissingBirthdayFilesException(directory)
-            }
-
-            val filteredTreeFiles = unfilteredTreeFiles
-                .sortDescending()
-                .filter { filename ->
-                    birthdayHeight?.let { birthdayHeight(filename) <= it } ?: true
-                }
-
-            if (filteredTreeFiles.isEmpty()) {
-                throw BirthdayException.BirthdayFileNotFoundException(
-                    directory,
-                    birthdayHeight
+    /**
+     * Useful for when an exact checkpoint is needed, like for SAPLING_ACTIVATION_HEIGHT. In
+     * most cases, loading the nearest checkpoint is preferred for privacy reasons.
+     */
+    suspend fun loadExact(context: Context, network: ZcashNetwork, birthdayHeight: Int) =
+        loadNearest(context, network, birthdayHeight).also {
+            if (it.height != birthdayHeight)
+                throw BirthdayException.ExactBirthdayNotFoundException(
+                    birthdayHeight,
+                    it.height
                 )
-            }
-
-            return filteredTreeFiles
         }
 
-        /**
-         * @param treeFiles A list of files, sorted in descending order based on `int` value of the first part of the filename.
-         */
-        @VisibleForTesting
-        internal fun getFirstValidWalletBirthday(
-            context: Context,
-            directory: String,
-            treeFiles: List<String>
-        ): WalletBirthday {
-            var lastException: Exception? = null
-            treeFiles.forEach { treefile ->
-                try {
+    // Converting this to suspending will then propagate
+    @Throws(IOException::class)
+    internal suspend fun listBirthdayDirectoryContents(context: Context, directory: String) =
+        withContext(Dispatchers.IO) {
+            context.assets.list(directory)
+        }
+
+    /**
+     * Returns the directory within the assets folder where birthday data
+     * (i.e. sapling trees for a given height) can be found.
+     */
+    @VisibleForTesting
+    internal fun birthdayDirectory(network: ZcashNetwork) =
+        "saplingtree/${(network.networkName as java.lang.String).toLowerCase(Locale.US)}"
+
+    internal fun birthdayHeight(fileName: String) = fileName.split('.').first().toInt()
+
+    private fun Array<String>.sortDescending() =
+        apply { sortByDescending { birthdayHeight(it) } }
+
+    /**
+     * Load the given birthday file from the assets of the given context. When no height is
+     * specified, we default to the file with the greatest name.
+     *
+     * @param context the context from which to load assets.
+     * @param birthdayHeight the height file to look for among the file names.
+     *
+     * @return a WalletBirthday that reflects the contents of the file or an exception when
+     * parsing fails.
+     */
+    private suspend fun loadBirthdayFromAssets(
+        context: Context,
+        network: ZcashNetwork,
+        birthdayHeight: Int? = null
+    ): WalletBirthday {
+        twig("loading birthday from assets: $birthdayHeight")
+        val directory = birthdayDirectory(network)
+        val treeFiles = getFilteredFileNames(context, directory, birthdayHeight)
+
+        twig("found ${treeFiles.size} sapling tree checkpoints: $treeFiles")
+
+        return getFirstValidWalletBirthday(context, directory, treeFiles)
+    }
+
+    private suspend fun getFilteredFileNames(
+        context: Context,
+        directory: String,
+        birthdayHeight: Int? = null,
+    ): List<String> {
+        val unfilteredTreeFiles = listBirthdayDirectoryContents(context, directory)
+        if (unfilteredTreeFiles.isNullOrEmpty()) {
+            throw BirthdayException.MissingBirthdayFilesException(directory)
+        }
+
+        val filteredTreeFiles = unfilteredTreeFiles
+            .sortDescending()
+            .filter { filename ->
+                birthdayHeight?.let { birthdayHeight(filename) <= it } ?: true
+            }
+
+        if (filteredTreeFiles.isEmpty()) {
+            throw BirthdayException.BirthdayFileNotFoundException(
+                directory,
+                birthdayHeight
+            )
+        }
+
+        return filteredTreeFiles
+    }
+
+    /**
+     * @param treeFiles A list of files, sorted in descending order based on `int` value of the first part of the filename.
+     */
+    @VisibleForTesting
+    internal suspend fun getFirstValidWalletBirthday(
+        context: Context,
+        directory: String,
+        treeFiles: List<String>
+    ): WalletBirthday {
+        var lastException: Exception? = null
+        treeFiles.forEach { treefile ->
+            try {
+                return withContext(Dispatchers.IO) {
                     context.assets.open("$directory/$treefile").use { inputStream ->
                         InputStreamReader(inputStream).use { inputStreamReader ->
                             JsonReader(inputStreamReader).use { jsonReader ->
-                                return Gson().fromJson(jsonReader, WalletBirthday::class.java)
+                                Gson().fromJson(jsonReader, WalletBirthday::class.java)
                             }
                         }
                     }
-                } catch (t: Throwable) {
-                    val exception = BirthdayException.MalformattedBirthdayFilesException(
-                        directory,
-                        treefile
-                    )
-                    lastException = exception
+                }
+            } catch (t: Throwable) {
+                val exception = BirthdayException.MalformattedBirthdayFilesException(
+                    directory,
+                    treefile
+                )
+                lastException = exception
 
-                    if (IS_FALLBACK_ON_FAILURE) {
-                        // TODO: If we ever add crash analytics hooks, this would be something to report
-                        twig("Malformed birthday file $t")
-                    } else {
-                        throw exception
-                    }
+                if (IS_FALLBACK_ON_FAILURE) {
+                    // TODO: If we ever add crash analytics hooks, this would be something to report
+                    twig("Malformed birthday file $t")
+                } else {
+                    throw exception
                 }
             }
-
-            throw lastException!!
         }
+
+        throw lastException!!
     }
 }


### PR DESCRIPTION
This enhances the public API, to eliminate blocking calls that can trigger ANR (Application Not Responding) errors on Android.  These trigger after 5 seconds, which is common when performing IO.  Actual performance doesn't change, but the UI thread will not be blocked.

This is a breaking API change for the public interface.  Existing clients can do a quick and dirty migration by using `runBlocking` to wrap API calls until they're able to complete a more appropriate migration.

Implementing this now will ease leveraging the SDK in secant-android-wallet.

This strategy was applied to the demo-app, and a followup issue #308 was filed to come back to this.