### PR TITLE
Prepare 1.3.0-beta19 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 Change Log
 ==========
 
-Upcoming
+Version 1.3.0-beta19 *(2021-11-22)*
 ------------------------------------
-- Repackaged internal classes to a new `internal` package name
+- New: Updated checkpoints for Mainnet and Testnet
+- Fix: Repackaged internal classes to a new `internal` package name
+- Fix: Testnet checkpoints have been corrected
+- Updated dependencies
 
 Version 1.3.0-beta18 *(2021-08-10)*
 ------------------------------------

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -1,9 +1,9 @@
 Troubleshooting Migrations
 ==========
 
-Upcoming Migrating to Version 1.4.* from 1.3.*
+Upcoming Migrating to Version 1.3.0-beta18 from 1.3.0-beta19
 --------------------------------------
-Various APIs that have always been considered private have been moved into a new package called `internal`.  While this should not be a breaking change, clients that might have relied on these internal classes should stop doing so.
+Various APIs that have always been considered private have been moved into a new package called `internal`.  While this should not be a breaking change, clients that might have relied on these internal classes should stop doing so.  If necessary, these calls can be migrated by changing the import to the new `internal` package name.
 
 Migrating to Version 1.3.* from 1.2.*
 --------------------------------------

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -4,7 +4,7 @@ Publishing requires:
 
 ### One time only
 * Get your dev environment setup to [compile the SDK](https://github.com/zcash/zcash-android-wallet-sdk/#compiling-sources)
-* copy the GPG key to a directory with proper permissions (chmod 600). Note: If you'd like to quickly locally without subsequently publishing to Maven Central, configure a Gradle property `RELEASE_SIGNING_ENABLED=false`
+* copy the GPG key to a directory with proper permissions (chmod 600). Note: If you'd like to quickly publish locally without subsequently publishing to Maven Central, configure a Gradle property `RELEASE_SIGNING_ENABLED=false`
 * Create file `~/.gradle/gradle.properties` per the [instructions in this guide](https://proandroiddev.com/publishing-a-maven-artifact-3-3-step-by-step-instructions-to-mavencentral-publishing-bd661081645d)
   * add your sonotype credentials to it
   * point it to the GPG key

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ android.useAndroidX=true
 android.builder.sdkDownload=true
 
 # Publishing
-LIBRARY_VERSION=1.3.0-beta18
+LIBRARY_VERSION=1.3.0-beta19
 POM_NAME=Zcash Android Wallet SDK
 POM_ARTIFACT_ID=zcash-android-sdk
 POM_DESCRIPTION=This lightweight SDK connects Android to Zcash. It welds together Rust and Kotlin in a minimal way, allowing third-party Android apps to send and receive shielded transactions easily, securely and privately.


### PR DESCRIPTION
We'll make the release from this branch, to skip the suspending API changes from going into this release.  Then we'll merge this to master to update the readme and other documentation.