### PR TITLE
[#612] Make dependency locking configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,5 +222,6 @@ Publishing instructions for maintainers of this repository can be found in [PUBL
 [Back to contents](#contents)
 
 # Known Issues
+1. Intel-based machines may have trouble building in Android Studio.  The workaround is to add the following line to `~/.gradle/gradle.properties` `ZCASH_IS_DEPENDENCY_LOCKING_ENABLED=false`
 1. During builds, a warning will be printed that says "Unable to detect AGP versions for included builds. All projects in the build should use the same AGP version."  This can be safely ignored.  The version under build-conventions is the same as the version used elsewhere in the application.
 1. Android Studio will warn about the Gradle checksum.  This is a [known issue](https://github.com/gradle/gradle/issues/9361) and can be safely ignored.

--- a/build-conventions/build.gradle.kts
+++ b/build-conventions/build.gradle.kts
@@ -6,12 +6,34 @@ plugins {
 
 buildscript {
     dependencyLocking {
-        lockAllConfigurations()
+        // This property is treated specially, as it is not defined by default in the root gradle.properties
+        // and declaring it in the root gradle.properties is ignored by included builds. This only picks up
+        // a value declared as a system property, a command line argument, or a an environment variable.
+        val isDependencyLockingEnabled = if (project.hasProperty("ZCASH_IS_DEPENDENCY_LOCKING_ENABLED")) {
+            project.property("ZCASH_IS_DEPENDENCY_LOCKING_ENABLED").toString().toBoolean()
+        } else {
+            true
+        }
+
+        if (isDependencyLockingEnabled) {
+            lockAllConfigurations()
+        }
     }
 }
 
 dependencyLocking {
-    lockAllConfigurations()
+    // This property is treated specially, as it is not defined by default in the root gradle.properties
+    // and declaring it in the root gradle.properties is ignored by included builds. This only picks up
+    // a value declared as a system property, a command line argument, or a an environment variable.
+    val isDependencyLockingEnabled = if (project.hasProperty("ZCASH_IS_DEPENDENCY_LOCKING_ENABLED")) {
+        project.property("ZCASH_IS_DEPENDENCY_LOCKING_ENABLED").toString().toBoolean()
+    } else {
+        true
+    }
+
+    if (isDependencyLockingEnabled) {
+        lockAllConfigurations()
+    }
 }
 
 // Per conversation in the KotlinLang Slack, Gradle uses Java 8 compatibility internally

--- a/build-conventions/src/main/kotlin/zcash-sdk.dependency-conventions.gradle.kts
+++ b/build-conventions/src/main/kotlin/zcash-sdk.dependency-conventions.gradle.kts
@@ -1,6 +1,17 @@
 
 //dependencyLocking {
-//    lockAllConfigurations()
+// This property is treated specially, as it is not defined by default in the root gradle.properties
+// and declaring it in the root gradle.properties is ignored by included builds. This only picks up
+// a value declared as a system property, a command line argument, or a an environment variable.
+// val isDependencyLockingEnabled = if (project.hasProperty("ZCASH_IS_DEPENDENCY_LOCKING_ENABLED")) {
+//     project.property("ZCASH_IS_DEPENDENCY_LOCKING_ENABLED").toString().toBoolean()
+// } else {
+//     true
+// }
+//
+// if (isDependencyLockingEnabled) {
+//     lockAllConfigurations()
+// }
 //}
 
 tasks {

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -68,6 +68,7 @@ Start by making sure the command line with Gradle works first, because **all the
         1. Note: When first opening the project, Android Studio will warn that Gradle checksums are not fully supported.  Choose the "Use checksum" option.  This is a security feature that we have explicitly enabled.
         1. Shortly after opening the project, Android Studio may prompt about updating the Android Gradle Plugin.  DO NOT DO THIS.  If you do so, the build will fail because the project also has dependency locking enabled as a security feature.  To learn more, see [Build integrity.md](Build%20Integrity.md)
         1. Android Studio may prompt about updating the Kotlin plugin.  Do this.  Our application often uses a newer version of Kotlin than is bundled with Android Studio.
+        1. Note that some versions of Android Studio on Intel machines have trouble with dependency locks.  If you experience this issue, the workaround is to add the following line to `~/.gradle/gradle.properties` `ZCASH_IS_DEPENDENCY_LOCKING_ENABLED=false`
     1. After Android Studio finishes syncing with Gradle, look for the green "play" run button in the toolbar.  To the left of it, choose the "demo-app" run configuration under the dropdown menu.  Then hit the run button.
         1. Note: The SDK supports both testnet and mainnet.  The decision to switch between them is made at the application level.  To switch between build variants, look for "Build Variants" which is usually a small button in the left gutter of the Android Studio window.
 


### PR DESCRIPTION
I made a similar change in the Secant repo last week.  https://github.com/zcash/secant-android-wallet/pull/548

This implementation is somewhat special from our other Gradle properties, because it does not get declared in the root gradle.properties.  The reason is that included builds are supposed to have their own properties e.g.

root_project/gradle.properties
root_project/build-conventions/gradle.properties

Instead of declaring the property in different places which might lead to confusion, this leaves the property undeclared, with the Gradle scripts assuming a default value of true.  The only time this is expected to be overridden is due to a workaround for an Android Studio bug.

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Manual tests: Did you update the [manual tests](../blob/main/docs/tests) as appropriate? _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
- [ ] Documentation: Did you update documentation as appropriate? (e.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the demo app and try the changes?
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage before and after changes and when possible, leave it in a better place._
- [ ] Documentation: Did you review Docs, [README.md](../blob/main/README.md), and [Architecture.md](../blob/main/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the demo app and try the changes? _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._