### PR TITLE
[#1076] Fix Runtime.exec() in Rosetta build script

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
       - name: Setup
         id: setup
-        timeout-minutes: 5
+        timeout-minutes: 10
         uses: ./.github/actions/setup
       - name: Check properties
         timeout-minutes: 4

--- a/build-conventions/src/main/kotlin/zcash-sdk.rosetta-conventions.gradle.kts
+++ b/build-conventions/src/main/kotlin/zcash-sdk.rosetta-conventions.gradle.kts
@@ -17,9 +17,9 @@ fun isRosetta(): Boolean {
         // Counterintuitive, but running under Rosetta is reported as Intel64 to the JVM
         if (!System.getProperty("os.arch").lowercase(java.util.Locale.ROOT).contains("aarch64")) {
             val outputValue = Runtime.getRuntime()
-                .exec(arrayOf("sysctl -in sysctl.proc_translated"))
+                .exec(arrayOf("sysctl", "-in", "sysctl.proc_translated"))
                 .scanOutputLine()
-                ?.toIntOrNull()
+                .toIntOrNull()
 
             if (1 == outputValue) {
                 return true
@@ -30,7 +30,7 @@ fun isRosetta(): Boolean {
     return false
 }
 
-fun Process.scanOutputLine(): String? {
+fun Process.scanOutputLine(): String {
     var outputString = ""
 
     inputStream.use { inputStream ->


### PR DESCRIPTION
Closes https://github.com/zcash/zcash-android-wallet-sdk/issues/1076.

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [ ] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [README.md](../blob/main/README.md), [Architecture.md](../blob/main/docs/Architecture.md), etc.)
- [ ] **Run the demo app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [README.md](../blob/main/README.md), [Architecture.md](/blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the demo app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the SDK, some aspects require manual testing. If you had to manually test 
something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the demo app to look for build failures or crashes, humans running the demo app are 
more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._