### PR TITLE
[#1241][#1243][#1222] Rewinding when ContinuityError

### DIFF
--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessor.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessor.kt
@@ -409,13 +409,6 @@ class CompactBlockProcessor internal constructor(
         while (verifyRangeResult is VerifySuggestedScanRange.ShouldVerify) {
             Twig.info { "Starting verification of range: $verifyRangeResult" }
 
-            // Remove existing blocks as they'll be re-downloaded
-            downloader.rewindToHeight(verifyRangeResult.scanRange.range.start)
-            deleteAllBlockFiles(
-                downloader = downloader,
-                lastKnownHeight = verifyRangeResult.scanRange.range.start
-            )
-
             var syncingResult: SyncingResult = SyncingResult.AllSuccess
             runSyncingAndEnhancingOnRange(
                 backend = backend,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/model/SyncingResult.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/model/SyncingResult.kt
@@ -48,5 +48,11 @@ internal sealed class SyncingResult {
     data class ContinuityError(
         override val failedAtHeight: BlockHeight,
         override val exception: CompactBlockProcessorException
-    ) : Failure, SyncingResult()
+    ) : Failure, SyncingResult() {
+        override fun toBlockProcessingResult(): CompactBlockProcessor.BlockProcessingResult =
+            CompactBlockProcessor.BlockProcessingResult.ContinuityError(
+                this.failedAtHeight,
+                this.exception
+            )
+    }
 }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/exception/Exceptions.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/exception/Exceptions.kt
@@ -7,6 +7,8 @@ import cash.z.ecc.android.sdk.model.FirstClassByteArray
 import cash.z.ecc.android.sdk.model.ZcashNetwork
 import co.electriccoin.lightwallet.client.model.BlockHeightUnsafe
 
+// TODO [#1248]: Clean up unused exceptions
+// TODO [#1248]: https://github.com/zcash/zcash-android-wallet-sdk/issues/1248
 /**
  * Marker for all custom exceptions from the SDK. Making it an interface would result in more typing
  * so it's a supertype, instead.
@@ -88,6 +90,11 @@ sealed class CompactBlockProcessorException(message: String, cause: Throwable? =
     )
     object NoAccount : CompactBlockProcessorException(
         "Attempting to scan without an account. This is probably a setup error or a race condition."
+    )
+
+    class FailedSynchronizationException(message: String, cause: Throwable) : CompactBlockProcessorException(
+        "Common error while running the block synchronization. This is typically caused by a failed underlying " +
+            "synchronization operation. See failure description: $message OR the root cause: $cause"
     )
 
     class FailedDownloadException(cause: Throwable? = null) : CompactBlockProcessorException(

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/ext/ZcashSdk.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/ext/ZcashSdk.kt
@@ -28,6 +28,12 @@ object ZcashSdk {
     const val EXPIRY_OFFSET = 20
 
     /**
+     * A short amount of time, in milliseconds, to poll for new blocks used typically when a block synchronization error
+     * occurs.
+     */
+    const val POLL_INTERVAL_SHORT = 5_000L
+
+    /**
      * Default amount of time, in milliseconds, to poll for new blocks. Typically, this should be about half the average
      * block time.
      */


### PR DESCRIPTION
- Closes #1241
- The original solution came from the pseudocode requirement: _Download the blocks in `scan_range` into the block source, overwriting any existing blocks in this range._ Removed now.
- Closes #1243
- Closes #1222 as it was created to determine which failure type comes and don’t rewind for all of them
- Closes #1239 since it is the last required post-v2.0.0-rc1 cleanup.
- Rewind is done only when Continuity-error appears now. In case of other sync failures, the sync loop sleeps for a short time and then retries. Internal actions like fetching subtree roots, fetching chain tip, downloading, scanning, etc., still have their internal retry mechanisms.
- For the calculation of the rewind height, we use the existing `checkContinuityErrorResult` method, originally used only for validation use cases but later incorrectly used for other failures too.
- Tested manually in several scenarios, e.g. lost internet connection or app going to background
---

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [x] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [README.md](../blob/main/README.md), [Architecture.md](../blob/main/docs/Architecture.md), etc.)
- [x] **Run the demo app** and try the changes
- [x] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [README.md](../blob/main/README.md), [Architecture.md](/blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the demo app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the SDK, some aspects require manual testing. If you had to manually test 
something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the demo app to look for build failures or crashes, humans running the demo app are 
more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._