### PR TITLE
Migrate to Rust crate revision with spent UTXOs balance fix

### DIFF
--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -465,8 +465,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab579d7cf78477773b03e80bc2f89702ef02d7112c711d54ca93dcdce68533d5"
+source = "git+https://github.com/zcash/librustzcash?rev=9d4863b762c0eab4fbb867217707d325c7296018#9d4863b762c0eab4fbb867217707d325c7296018"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -502,8 +501,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a83e8d7fd0c526af4aad893b7c9fe41e2699ed8a776a6c74aecdeafe05afc75"
+source = "git+https://github.com/zcash/librustzcash?rev=9d4863b762c0eab4fbb867217707d325c7296018#9d4863b762c0eab4fbb867217707d325c7296018"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2101,8 +2099,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8944af5c206cf2e37020ad54618e1825501b98548d35a638b73e0ec5762df8d5"
+source = "git+https://github.com/zcash/librustzcash?rev=9d4863b762c0eab4fbb867217707d325c7296018#9d4863b762c0eab4fbb867217707d325c7296018"
 dependencies = [
  "bech32",
  "bs58",
@@ -2113,8 +2110,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.10.0-rc.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc33f71747a93d509f7e1c047961e359a271bdf4869cc07f7f65ee1ba7df8c2"
+source = "git+https://github.com/zcash/librustzcash?rev=9d4863b762c0eab4fbb867217707d325c7296018#9d4863b762c0eab4fbb867217707d325c7296018"
 dependencies = [
  "base64",
  "bech32",
@@ -2148,8 +2144,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.8.0-rc.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7a6c73b247bc22b6d3d4a46333a0720a24d0357636d3ebc265e4f16f1280f3d"
+source = "git+https://github.com/zcash/librustzcash?rev=9d4863b762c0eab4fbb867217707d325c7296018#9d4863b762c0eab4fbb867217707d325c7296018"
 dependencies = [
  "bs58",
  "byteorder",
@@ -2175,8 +2170,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03391b81727875efa6ac0661a20883022b6fba92365dc121c48fa9b00c5aac0"
+source = "git+https://github.com/zcash/librustzcash?rev=9d4863b762c0eab4fbb867217707d325c7296018#9d4863b762c0eab4fbb867217707d325c7296018"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -2198,8 +2192,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.13.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc4391d9325e0a51a7cbff02b5c4b5472d66087bd9c903ddb12dea7ec22f3e0"
+source = "git+https://github.com/zcash/librustzcash?rev=9d4863b762c0eab4fbb867217707d325c7296018#9d4863b762c0eab4fbb867217707d325c7296018"
 dependencies = [
  "aes",
  "bip0039",
@@ -2234,8 +2227,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.13.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f22eff3bdc382327ef28f809024ddc89ec6d903ba71be629b2cbea34afdda2"
+source = "git+https://github.com/zcash/librustzcash?rev=9d4863b762c0eab4fbb867217707d325c7296018#9d4863b762c0eab4fbb867217707d325c7296018"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -41,6 +41,13 @@ tracing-subscriber = "0.3"
 dlopen2 = "0.6"
 libc = "0.2"
 
+[patch.crates-io]
+zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "9d4863b762c0eab4fbb867217707d325c7296018" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "9d4863b762c0eab4fbb867217707d325c7296018" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "9d4863b762c0eab4fbb867217707d325c7296018" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "9d4863b762c0eab4fbb867217707d325c7296018" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "9d4863b762c0eab4fbb867217707d325c7296018" }
+
 ## Uncomment this to test librustzcash changes locally
 #[patch.crates-io]
 #zcash_address = { path = '../../clones/librustzcash/components/zcash_address' }


### PR DESCRIPTION
Closes #1268.

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [ ] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [README.md](../blob/main/README.md), [Architecture.md](../blob/main/docs/Architecture.md), etc.)
- [ ] **Run the demo app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

# Reviewer

- [x] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [README.md](../blob/main/README.md), [Architecture.md](/blob/main/docs/Architecture.md), etc. as appropriate
- [x] **Run the demo app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the SDK, some aspects require manual testing. If you had to manually test 
something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the demo app to look for build failures or crashes, humans running the demo app are 
more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._