### PR TITLE
MOB-1030: Fixed runtime crashes

### DIFF
--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImpl.kt
@@ -347,7 +347,7 @@ internal class TypesafeBackendImpl(
         }
 
     override suspend fun suggestScanRanges(): List<ScanRange> =
-        backend.suggestScanRanges().map { jniScanRange ->
+        backend.suggestScanRanges().mapNotNull { jniScanRange ->
             ScanRange.new(jniScanRange)
         }
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/ScanRange.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/ScanRange.kt
@@ -1,5 +1,6 @@
 package cash.z.ecc.android.sdk.internal.model
 
+import cash.z.ecc.android.sdk.internal.Twig
 import cash.z.ecc.android.sdk.model.BlockHeight
 
 internal data class ScanRange(
@@ -19,14 +20,23 @@ internal data class ScanRange(
 
     companion object {
         /**
-         *  Note that this function subtracts 1 from [JniScanRange.endHeight] as the rest of the logic works with
-         *  [ClosedRange] and the endHeight is exclusive.
+         * Note that this function subtracts 1 from [JniScanRange.endHeight] as the rest of the logic works with
+         * [ClosedRange] and the endHeight is exclusive.
+         *
+         * Returns null for empty or invalid ranges (where [JniScanRange.endHeight] <= [JniScanRange.startHeight]),
+         * which can occur after a resync reset when the Rust layer returns a zero-height range. Such ranges contain
+         * no blocks and can be safely skipped.
          */
-        fun new(jni: JniScanRange): ScanRange =
-            ScanRange(
+        fun new(jni: JniScanRange): ScanRange? {
+            if (jni.endHeight <= jni.startHeight) {
+                Twig.warn { "Skipping empty scan range returned by Rust: startHeight=${jni.startHeight}, endHeight=${jni.endHeight}" }
+                return null
+            }
+            return ScanRange(
                 range = BlockHeight.new(jni.startHeight)..(BlockHeight.new(jni.endHeight) - 1),
                 priority = jni.priority
             )
+        }
     }
 }
 

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/model/ScanRangeTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/model/ScanRangeTest.kt
@@ -7,6 +7,7 @@ import cash.z.ecc.android.sdk.model.ZcashNetwork
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ScanRangeTest {
@@ -37,6 +38,24 @@ class ScanRangeTest {
                 priority = Long.MIN_VALUE
             )
         }
+    }
+
+    @Test
+    fun empty_scan_range_returns_null() {
+        val jni = JniScanRange(startHeight = 0L, endHeight = 0L, priority = SuggestScanRangePriority.Verify.priority)
+        assertNull(ScanRange.new(jni))
+    }
+
+    @Test
+    fun non_zero_empty_scan_range_returns_null() {
+        val jni = JniScanRange(startHeight = 100L, endHeight = 100L, priority = SuggestScanRangePriority.Verify.priority)
+        assertNull(ScanRange.new(jni))
+    }
+
+    @Test
+    fun inverted_scan_range_returns_null() {
+        val jni = JniScanRange(startHeight = 200L, endHeight = 100L, priority = SuggestScanRangePriority.Verify.priority)
+        assertNull(ScanRange.new(jni))
     }
 
     @Test


### PR DESCRIPTION
<!-- Write any additional comments here when opening the pull request -->

Root cause
                                                                                                                                                                                                                                        
  When the Rust layer returns a scan range where endHeight == startHeight (observed after a resync reset), ScanRange.new() attempts to subtract 1 from endHeight to convert the exclusive bound into a ClosedRange. This produces     
  BlockHeight(-1), which immediately throws IllegalArgumentException — BlockHeight validates that its value fits within the UInt32 range (0..4294967295).                                                                               
   
  Fix                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                      
  ScanRange.new() now returns null for ranges where endHeight <= startHeight and logs a warning for observability. The caller in TypesafeBackendImpl.suggestScanRanges() uses mapNotNull to skip these ranges silently, as they contain 
  no blocks.
                                                                                                                                                                                                                                        
  The condition uses <= rather than == to also cover inverted ranges (endHeight < startHeight). Rust should not produce these, but if it did, the original code would silently create an empty ClosedRange with no blocks scanned and no
   indication of the problem.
                                                                                                                                                                                                                                        
  Tests added                                                                                                                                                                                                                           
  - empty_scan_range_returns_null — zero heights (0, 0)
  - non_zero_empty_scan_range_returns_null — equal non-zero heights (100, 100)                                                                                                                                                          
  - inverted_scan_range_returns_null — inverted range (200, 100)    

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [ ] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [README.md](../blob/main/README.md), [Architecture.md](../blob/main/docs/Architecture.md), etc.)
- [ ] **Run the demo app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [README.md](../blob/main/README.md), [Architecture.md](/blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the demo app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the SDK, some aspects require manual testing. If you had to manually test 
something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the demo app to look for build failures or crashes, humans running the demo app are 
more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._