### PR TITLE
Expose fully scanned height on Synchronizer

### DIFF
--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
@@ -386,6 +386,8 @@ class SdkSynchronizer private constructor(
      */
     override val networkHeight: StateFlow<BlockHeight?> = processor.networkHeight
 
+    override val fullyScannedHeight: StateFlow<BlockHeight?> = processor.fullyScannedHeight
+
     //
     // Error Handling
     //

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
@@ -102,6 +102,15 @@ interface Synchronizer {
     val networkHeight: StateFlow<BlockHeight?>
 
     /**
+     * The height to which the wallet has been fully scanned.
+     *
+     * This is the height for which the wallet has fully trial-decrypted this and all preceding
+     * blocks above the wallet's birthday height. This value is useful for determining whether the
+     * wallet has scanned up to a specific snapshot height.
+     */
+    val fullyScannedHeight: StateFlow<BlockHeight?>
+
+    /**
      * A stream of wallet balances
      */
     val walletBalances: StateFlow<Map<AccountUuid, AccountBalance>?>


### PR DESCRIPTION
## Summary

Expose the existing `CompactBlockProcessor.fullyScannedHeight` state through the public `Synchronizer` interface.

This gives callers a direct signal for the height below which the wallet has fully trial-decrypted all blocks above its birthday height. It is useful for snapshot-height workflows that need scan progress rather than chain tip or max scanned height.

This PR is intentionally narrow: no Rust changes, no voting dependency, and no voting backend surface.

## Testing

- `./gradlew :sdk-lib:compileReleaseKotlin`
