### PR TITLE
[#1921] Expose Synchronizer snapshot accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,16 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `Synchronizer.fullyScannedHeight` and `Synchronizer.getTreeState` accessors
+  for snapshot-height consumers.
+
 ### Changed
 - `Synchronizer.importAccountByUfvk` now calls `TypesafeBackend.rewindToChainState` after importing
   an account. This enables imported accounts to discover their history and funds, at the cost of
   other accounts being temporarily blocked by a short resync (specifically rescanning the incomplete
   shard at the tip).
-- 
+
 ## [2.4.8] - 2025-04-02
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ ZCASH_ASCII_GPG_KEY=
 # Configures whether release is an unstable snapshot, therefore published to the snapshot repository.
 IS_SNAPSHOT=true
 
-LIBRARY_VERSION=2.4.9
+LIBRARY_VERSION=2.4.8
 
 # Kotlin compiler warnings can be considered errors, failing the build.
 ZCASH_IS_TREAT_WARNINGS_AS_ERRORS=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ ZCASH_ASCII_GPG_KEY=
 # Configures whether release is an unstable snapshot, therefore published to the snapshot repository.
 IS_SNAPSHOT=true
 
-LIBRARY_VERSION=2.4.8
+LIBRARY_VERSION=2.4.9
 
 # Kotlin compiler warnings can be considered errors, failing the build.
 ZCASH_IS_TREAT_WARNINGS_AS_ERRORS=true
@@ -139,4 +139,3 @@ BIP39_VERSION=1.0.9
 
 # This shouldn't be changed, as Android doesn't support targets beyond Java 8
 ANDROID_JVM_TARGET=1.8
-

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
@@ -696,10 +696,10 @@ class SdkSynchronizer private constructor(
             }
 
             is Response.Failure -> {
-                val message =
-                    "Failed to fetch tree state at height ${height.value}: ${response.toThrowable()}"
+                val throwable = response.toThrowable()
+                val message = "Failed to fetch tree state at height ${height.value}: $throwable"
                 Twig.error { message }
-                throw response.toThrowable()
+                throw throwable
             }
         }
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
@@ -692,7 +692,7 @@ class SdkSynchronizer private constructor(
                 )
         ) {
             is Response.Success -> {
-                TreeState.new(response.result).encoded
+                response.result.encoded
             }
 
             is Response.Failure -> {

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
@@ -85,6 +85,7 @@ import cash.z.ecc.android.sdk.type.ServerValidation
 import cash.z.ecc.android.sdk.util.WalletClientFactory
 import co.electriccoin.lightwallet.client.CombinedWalletClient
 import co.electriccoin.lightwallet.client.ServiceMode
+import co.electriccoin.lightwallet.client.model.BlockHeightUnsafe
 import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
 import co.electriccoin.lightwallet.client.model.Response
 import co.electriccoin.lightwallet.client.util.use
@@ -386,6 +387,8 @@ class SdkSynchronizer private constructor(
      */
     override val networkHeight: StateFlow<BlockHeight?> = processor.networkHeight
 
+    override val fullyScannedHeight: StateFlow<BlockHeight?> = processor.fullyScannedHeight
+
     //
     // Error Handling
     //
@@ -678,6 +681,26 @@ class SdkSynchronizer private constructor(
     override suspend fun deleteAccount(accountUuid: AccountUuid) =
         backend.deleteAccount(accountUuid).also {
             refreshAccountsBus.emit(Unit)
+        }
+
+    override suspend fun getTreeState(height: BlockHeight): ByteArray =
+        when (
+            val response =
+                processor.downloader.getTreeState(
+                    height = BlockHeightUnsafe(height.value),
+                    serviceMode = sdkFlags ifTor ServiceMode.UniqueTor
+                )
+        ) {
+            is Response.Success -> {
+                TreeState.new(response.result).encoded
+            }
+
+            is Response.Failure -> {
+                val message =
+                    "Failed to fetch tree state at height ${height.value}: ${response.toThrowable()}"
+                Twig.error { message }
+                throw response.toThrowable()
+            }
         }
 
     suspend fun isValidAddress(address: String): Boolean = !validateAddress(address).isNotValid

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
@@ -680,6 +680,10 @@ interface Synchronizer {
      *
      * This lets app-layer consumers generate witnesses or verify inclusion proofs against a
      * specific Orchard note commitment tree snapshot without exposing the lightwalletd transport.
+     *
+     * This performs a live lightwalletd request and does not wait for the local wallet scan state.
+     * Callers that use the returned tree state together with local wallet data at the same height
+     * should first verify that [fullyScannedHeight] has reached at least [height].
      */
     suspend fun getTreeState(height: BlockHeight): ByteArray
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
@@ -102,6 +102,15 @@ interface Synchronizer {
     val networkHeight: StateFlow<BlockHeight?>
 
     /**
+     * The height to which the wallet has been fully scanned.
+     *
+     * This is the height for which the wallet has fully trial-decrypted this and all preceding
+     * blocks above the wallet's birthday height. This value is useful for determining whether the
+     * wallet has scanned up to a specific snapshot height.
+     */
+    val fullyScannedHeight: StateFlow<BlockHeight?>
+
+    /**
      * A stream of wallet balances
      */
     val walletBalances: StateFlow<Map<AccountUuid, AccountBalance>?>
@@ -665,6 +674,14 @@ interface Synchronizer {
     suspend fun debugQuery(query: String): String
 
     suspend fun deleteAccount(accountUuid: AccountUuid): Boolean
+
+    /**
+     * Returns the commitment tree state at the given block height, encoded as a protobuf [ByteArray].
+     *
+     * This lets app-layer consumers generate witnesses or verify inclusion proofs against a
+     * specific Orchard note commitment tree snapshot without exposing the lightwalletd transport.
+     */
+    suspend fun getTreeState(height: BlockHeight): ByteArray
 
     //
     // Error Handling


### PR DESCRIPTION
## Summary

Refs zcash/zcash-android-wallet-sdk#1921.

Expose two narrow Synchronizer accessors needed by snapshot-height workflows:

- `fullyScannedHeight`, delegated from `CompactBlockProcessor.fullyScannedHeight`
- `getTreeState(height)`, returning protobuf-encoded tree state bytes from lightwalletd

This PR intentionally has no Rust changes, no voting dependency, and no voting backend/JNI surface.

Contribution-guide follow-ups included:

- ~~bumps `LIBRARY_VERSION` to `2.4.9` because this adds public API~~ removed, [per discussion](https://github.com/zcash/zcash-android-wallet-sdk/pull/1933#discussion_r3202096598)
- adds a `CHANGELOG.md` entry

## Testing

- `./gradlew checkProperties`
- `./gradlew ktlint`
- `./gradlew detektAll`
- `./gradlew :sdk-lib:compileReleaseKotlin`
