### PR TITLE
[#1924] Add zcash_voting dependency foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Synchronizer.fullyScannedHeight` and `Synchronizer.getTreeState` accessors
   for snapshot-height consumers.
 
+### Internal
+- Added the Rust `zcash_voting` dependency foundation for future shielded voting backend work.
+
 ### Changed
 - `Synchronizer.importAccountByUfvk` now calls `TypesafeBackend.rewindToChainState` after importing
   an account. This enables imported accounts to discover their history and funds, at the cost of

--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -5959,6 +5959,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
+name = "voting-circuits"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba6635f8e207689c290634f6e34f7eddaf1b254aa0f9b0ef65418d89d1d1ae7"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "halo2_gadgets",
+ "halo2_poseidon",
+ "halo2_proofs",
+ "incrementalmerkletree",
+ "lazy_static",
+ "orchard",
+ "pasta_curves",
+ "rand 0.8.5",
+ "sinsemilla",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6710,6 +6730,7 @@ dependencies = [
  "zcash_protocol",
  "zcash_script",
  "zcash_transparent",
+ "zcash_voting",
  "zip32",
 ]
 
@@ -7011,6 +7032,37 @@ dependencies = [
  "zcash_protocol",
  "zcash_script",
  "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_voting"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90abca13341b344d82315895bf50f26e93a66b5c4d2fbd8591728af604d4d4db"
+dependencies = [
+ "anyhow",
+ "blake2b_simd",
+ "ff",
+ "group",
+ "halo2_gadgets",
+ "halo2_proofs",
+ "hex",
+ "incrementalmerkletree",
+ "nonempty",
+ "orchard",
+ "pasta_curves",
+ "pczt",
+ "rand 0.8.5",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "subtle",
+ "thiserror 2.0.18",
+ "voting-circuits",
+ "zcash_keys",
+ "zcash_primitives",
+ "zcash_protocol",
  "zip32",
 ]
 

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.92"
 
 [dependencies]
 # Zcash dependencies
-orchard = "0.13"
+orchard = { version = "=0.13.1", features = ["unstable-voting-circuits"] }
 pczt = { version = "0.6", features = ["prover", "orchard", "sapling"] }
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
 transparent = { package = "zcash_transparent", version = "0.7", default-features = false }
@@ -76,6 +76,24 @@ rust_decimal = { version = "1", default-features = false, features = ["c-repr"] 
 xz2 = { version = "0.1", features = ["static"] }
 component = "0.1.1"
 rust-analyzer = "0.0.1"
+
+# Shielded voting
+#
+# `zcash_voting` provides client-side primitives for shielded voting. It depends
+# on Orchard's unstable voting-circuits APIs, so the direct Orchard dependency is
+# pinned to the same version and enables the same feature. Remove the exact pin
+# once these circuit APIs are available through a stable Orchard feature.
+# The Android JNI boundary for voting code is `src/main/rust/voting.rs`.
+# Its share-nullifier entry point forwards to
+# `zcash_voting::share_tracking::compute_share_nullifier`:
+# https://github.com/valargroup/zcash_voting/blob/zcash_voting-v0.5.3/zcash_voting/src/share_tracking.rs
+#
+# The transitive `voting-circuits` dependency contains the share-reveal circuit
+# and the Poseidon-based `share_nullifier_hash` implementation:
+# https://github.com/valargroup/voting-circuits/blob/v0.4.1/voting-circuits/src/share_reveal/circuit.rs
+# Default features stay disabled so this foundation change does not pull in the
+# optional client PIR, tree-sync, or networking stacks.
+zcash_voting = { version = "0.5.3", default-features = false }
 
 ## Uncomment this to test librustzcash changes locally
 #[patch.crates-io]

--- a/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
+++ b/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
@@ -1,0 +1,48 @@
+package cash.z.ecc.android.sdk.internal.jni
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+
+@OptIn(ExperimentalStdlibApi::class)
+class VotingRustBackendTest {
+    companion object {
+        private const val FIELD_BYTES = 32
+        private const val SHARE_INDEX = 5
+        private const val OUT_OF_RANGE_SHARE_INDEX = 16
+        private val VOTE_COMMITMENT = ByteArray(FIELD_BYTES) { 1 }
+        private val BLIND = ByteArray(FIELD_BYTES) { 2 }
+        private val SHORT_FIELD = ByteArray(FIELD_BYTES - 1)
+        private val EXPECTED_NULLIFIER =
+            "8d6d97caa19a20e5e67e7cc24aaaa7beb72b4a513863f6adbe7b62ba1b1b0010".hexToByteArray()
+    }
+
+    @Test
+    fun compute_share_nullifier_returns_known_vector() =
+        runTest {
+            val backend = VotingRustBackend.new()
+            val nullifier = backend.computeShareNullifier(VOTE_COMMITMENT, SHARE_INDEX, BLIND)
+            val swappedNullifier = backend.computeShareNullifier(BLIND, SHARE_INDEX, VOTE_COMMITMENT)
+
+            assertContentEquals(EXPECTED_NULLIFIER, nullifier)
+            assertFalse(EXPECTED_NULLIFIER.contentEquals(swappedNullifier))
+        }
+
+    @Test
+    fun compute_share_nullifier_rejects_malformed_inputs() =
+        runTest {
+            val backend = VotingRustBackend.new()
+
+            assertFailsWith<RuntimeException> {
+                backend.computeShareNullifier(SHORT_FIELD, SHARE_INDEX, BLIND)
+            }
+            assertFailsWith<RuntimeException> {
+                backend.computeShareNullifier(VOTE_COMMITMENT, SHARE_INDEX, SHORT_FIELD)
+            }
+            assertFailsWith<RuntimeException> {
+                backend.computeShareNullifier(VOTE_COMMITMENT, OUT_OF_RANGE_SHARE_INDEX, BLIND)
+            }
+        }
+}

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackend.kt
@@ -1,0 +1,26 @@
+package cash.z.ecc.android.sdk.internal.jni
+
+class VotingRustBackend private constructor() {
+    @Throws(RuntimeException::class)
+    fun computeShareNullifier(
+        voteCommitment: ByteArray,
+        shareIndex: Int,
+        blind: ByteArray
+    ): ByteArray = computeShareNullifierNative(voteCommitment, shareIndex, blind)
+
+    companion object {
+        suspend fun new(): VotingRustBackend {
+            RustBackend.loadLibrary()
+
+            return VotingRustBackend()
+        }
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun computeShareNullifierNative(
+            voteCommitment: ByteArray,
+            shareIndex: Int,
+            blind: ByteArray
+        ): ByteArray
+    }
+}

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -103,6 +103,7 @@ use crate::utils::{
 mod eip681;
 mod tor;
 mod utils;
+mod voting;
 
 #[cfg(debug_assertions)]
 fn print_debug_state() {

--- a/backend-lib/src/main/rust/voting.rs
+++ b/backend-lib/src/main/rust/voting.rs
@@ -1,0 +1,68 @@
+//! JNI bindings for the zcash_voting crate.
+
+use std::ptr;
+
+use anyhow::anyhow;
+use jni::{
+    JNIEnv,
+    objects::{JByteArray, JClass},
+    sys::{jbyteArray, jint},
+};
+use zcash_voting as voting;
+
+use crate::utils::{self, catch_unwind, exception::unwrap_exc_or};
+
+const VOTE_COMMITMENT_BYTES: usize = 32;
+const BLIND_BYTES: usize = 32;
+const SHARE_NULLIFIER_BYTES: usize = 32;
+
+/// Compute the share reveal nullifier from client-known inputs.
+///
+/// Returns the 32-byte nullifier, or throws a RuntimeException and returns null
+/// on malformed inputs.
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_computeShareNullifierNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    vote_commitment: JByteArray<'local>,
+    share_index: jint,
+    blind: JByteArray<'local>,
+) -> jbyteArray {
+    let res = catch_unwind(&mut env, |env| {
+        let share_index =
+            u32::try_from(share_index).map_err(|_| anyhow!("shareIndex must be non-negative"))?;
+        let vote_commitment =
+            java_fixed_bytes::<VOTE_COMMITMENT_BYTES>(env, &vote_commitment, "voteCommitment")?;
+        let blind = java_fixed_bytes::<BLIND_BYTES>(env, &blind, "blind")?;
+
+        let nullifier =
+            voting::share_tracking::compute_share_nullifier(&vote_commitment, share_index, &blind)
+                .map_err(|e| anyhow!("compute_share_nullifier failed: {}", e))?;
+        let nullifier_len = nullifier.len();
+        let nullifier: [u8; SHARE_NULLIFIER_BYTES] = nullifier.try_into().map_err(|_| {
+            anyhow!(
+                "shareNullifier must be exactly {} bytes, got {}",
+                SHARE_NULLIFIER_BYTES,
+                nullifier_len
+            )
+        })?;
+
+        Ok(utils::rust_bytes_to_java(env, &nullifier)?.into_raw())
+    });
+    unwrap_exc_or(&mut env, res, ptr::null_mut())
+}
+
+fn java_fixed_bytes<const N: usize>(
+    env: &JNIEnv<'_>,
+    array: &JByteArray<'_>,
+    field: &str,
+) -> anyhow::Result<[u8; N]> {
+    let bytes = utils::java_bytes_to_rust(env, array)?;
+    let len = bytes.len();
+
+    bytes
+        .try_into()
+        .map_err(|_| anyhow!("{field} must be exactly {N} bytes, got {len}"))
+}


### PR DESCRIPTION
Refs #1924.
Resolves MOB-1109

Associated issue: zodl-inc/zodl-android#2193.

Android analogue of zcash/zcash-swift-wallet-sdk#1699.

## Summary

- add released `zcash_voting 0.5.3` to `backend-lib` with default features disabled
- pin `orchard` to `=0.13.1` with `unstable-voting-circuits`
- add a narrow internal JNI linkage symbol, `VotingRustBackend.computeShareNullifier`, to prove dispatch into `zcash_voting`
- place the Kotlin JNI holder in `sdk-lib`, matching the umbrella `shielded-vote` implementation
- align `computeShareNullifier` with the umbrella signature: `(voteCommitment, shareIndex, blind)`
- update `Cargo.lock` and `CHANGELOG.md`

## Non-goals

- no public SDK voting API
- no voting database lifecycle
- no wallet database access
- no PIR or vote-tree-sync feature graph
- no app-facing Kotlin voting backend surface

## Testing

- `cargo fmt --manifest-path backend-lib/Cargo.toml --check`
- `cargo check --manifest-path backend-lib/Cargo.toml --locked`
- `./gradlew :backend-lib:compileReleaseKotlin :sdk-lib:compileReleaseKotlin`
- `git diff --check`