### PR TITLE
Fix backend Rust cache path

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -64,16 +64,18 @@ runs:
         key: ${{ runner.os }}-gradle-build-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-gradle-build-
-    - name: Rust Cache Restore
+    - name: Rust Cache
       id: rust-cache-restore
-      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: "3"
       with:
         path: |
-          sdk-lib/target
+          backend-lib/target
           ~/.cargo
-        key: ${{ runner.os }}-rust-${{ hashFiles(format('{0}{1}', github.workspace, '/sdk-lib/Cargo.lock'), format('{0}{1}', github.workspace, '/sdk-lib/Cargo.toml'), format('{0}{1}', github.workspace, '/sdk-lib/build.gradle.kts'), format('{0}{1}', github.workspace, '/gradle.properties')) }}
+        key: ${{ runner.os }}-rust-${{ hashFiles(format('{0}{1}', github.workspace, '/backend-lib/Cargo.lock'), format('{0}{1}', github.workspace, '/backend-lib/Cargo.toml'), format('{0}{1}', github.workspace, '/backend-lib/build.gradle.kts'), format('{0}{1}', github.workspace, '/backend-lib/build.rs'), format('{0}{1}', github.workspace, '/rust-toolchain.toml'), format('{0}{1}', github.workspace, '/gradle.properties'), format('{0}{1}', github.workspace, '/.github/actions/setup/action.yml')) }}
+        restore-keys: |
+          ${{ runner.os }}-rust-
 
     - name: Gradle Binary Download
       if: steps.gradle-binary-cache-restore.outputs.cache-hit != 'true'
@@ -112,13 +114,3 @@ runs:
         path: |
           ~/.gradle/caches/modules-2
         key: ${{ steps.gradle-dependency-cache-restore.key }}
-    - name: Rust Cache Save
-      id: rust-cache-save
-      uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7
-      env:
-        SEGMENT_DOWNLOAD_TIMEOUT_MINS: "3"
-      with:
-        path: |
-          sdk-lib/target
-          ~/.cargo
-        key: ${{ steps.rust-cache-restore.key }}


### PR DESCRIPTION
Closes #1935.

The CI Rust cache pointed at `sdk-lib/target` and hashed `sdk-lib/Cargo.{lock,toml}` — paths that haven't existed since the FFI moved to `backend-lib` in `bc197971` (`[#971] Refactor Rust FFI to separate module`). `hashFiles` over missing inputs returns empty, so the key collapsed to `${{ runner.os }}-rust-` and never invalidated, while the saved payload was empty. The result was that each PR job re-ran the full 21–23 min Rust compile from scratch on every run.

This points the cache at `backend-lib/target`, hashes inputs that actually exist (`backend-lib/Cargo.lock`, `backend-lib/Cargo.toml`, `backend-lib/build.gradle.kts`, `backend-lib/build.rs`, `rust-toolchain.toml`, `gradle.properties`, `.github/actions/setup/action.yml`), and adds a `restore-keys` fallback so input churn produces partial reuse rather than a cold start.

The split `actions/cache/restore@` + `actions/cache/save@` pair is collapsed into a single `actions/cache@`. The bespoke save step had no `if:` gate (unlike its Gradle siblings), and re-deriving cache key composition by hand is what produced this bug — keeping the surface small reduces the chance of similar drift in the future.

## Test plan

- [ ] CI passes on this PR.
- [ ] First run after merge repopulates the cache; subsequent runs of `static_analysis_android_lint`, `test_android_modules_unit`, `test_android_modules_wtf`, and `demo_app_release_build` show meaningfully shorter Rust compile spans against the warm cache.
- [ ] A `backend-lib/Cargo.lock` change invalidates the exact key but hits the `restore-keys` fallback for partial reuse.