### PR TITLE
Only restore/save the Rust cache from jobs that compile Rust

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,5 +1,10 @@
 name: 'Setup Java, Rust, and Dependency Cache'
 description: "Configures the build environment and caches Gradle, dependencies, and build outputs."
+inputs:
+  rust-cache:
+    description: "Whether to restore and save the Rust build cache for jobs that compile Rust."
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -65,7 +70,8 @@ runs:
         restore-keys: |
           ${{ runner.os }}-gradle-build-
     - name: Rust Cache
-      id: rust-cache-restore
+      if: inputs.rust-cache == 'true'
+      id: rust-cache
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: "3"
@@ -73,9 +79,9 @@ runs:
         path: |
           backend-lib/target
           ~/.cargo
-        key: ${{ runner.os }}-rust-${{ hashFiles(format('{0}{1}', github.workspace, '/backend-lib/Cargo.lock'), format('{0}{1}', github.workspace, '/backend-lib/Cargo.toml'), format('{0}{1}', github.workspace, '/backend-lib/build.gradle.kts'), format('{0}{1}', github.workspace, '/backend-lib/build.rs'), format('{0}{1}', github.workspace, '/rust-toolchain.toml'), format('{0}{1}', github.workspace, '/gradle.properties'), format('{0}{1}', github.workspace, '/.github/actions/setup/action.yml')) }}
+        key: ${{ runner.os }}-rust-v2-${{ hashFiles(format('{0}{1}', github.workspace, '/backend-lib/Cargo.lock'), format('{0}{1}', github.workspace, '/backend-lib/Cargo.toml'), format('{0}{1}', github.workspace, '/backend-lib/build.gradle.kts'), format('{0}{1}', github.workspace, '/backend-lib/build.rs'), format('{0}{1}', github.workspace, '/rust-toolchain.toml'), format('{0}{1}', github.workspace, '/gradle.properties'), format('{0}{1}', github.workspace, '/.github/actions/setup/action.yml')) }}
         restore-keys: |
-          ${{ runner.os }}-rust-
+          ${{ runner.os }}-rust-v2-
 
     - name: Gradle Binary Download
       if: steps.gradle-binary-cache-restore.outputs.cache-hit != 'true'
@@ -88,7 +94,7 @@ runs:
       run: |
         ./gradlew dependencies :sdk-lib:dependencies :demo-app:dependencies
     - name: Gradle Build
-      if: github.event.pull_request.head.sha == '' && (steps.gradle-binary-cache-restore.outputs.cache-hit != 'true' || steps.gradle-dependency-cache-restore.outputs.cache-hit != 'true' || steps.rust-cache-restore.outputs.cache-hit != 'true' || steps.gradle-build-cache-restore.outputs.cache-hit != 'true')
+      if: github.event.pull_request.head.sha == '' && (steps.gradle-binary-cache-restore.outputs.cache-hit != 'true' || steps.gradle-dependency-cache-restore.outputs.cache-hit != 'true' || (inputs.rust-cache == 'true' && steps.rust-cache.outputs.cache-hit != 'true') || steps.gradle-build-cache-restore.outputs.cache-hit != 'true')
       env:
         ORG_GRADLE_PROJECT_IS_MINIFY_APP_ENABLED: "false"
       shell: bash

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -54,6 +54,8 @@ jobs:
         id: setup
         timeout-minutes: 50
         uses: ./.github/actions/setup
+        with:
+          rust-cache: true
       # Note that GitHub Actions appears to have issues with environment variables that contain periods,
       # so the GPG variables are done as command line arguments instead.
       - name: Deploy to Maven Central

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -65,6 +65,8 @@ jobs:
         id: setup
         timeout-minutes: 50
         uses: ./.github/actions/setup
+        with:
+          rust-cache: true
       # Note that GitHub Actions appears to have issues with environment variables that contain periods,
       # so the GPG variables are done as command line arguments instead.
       - name: Deploy to Maven Central

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -159,6 +159,8 @@ jobs:
         id: setup
         timeout-minutes: 30
         uses: ./.github/actions/setup
+        with:
+          rust-cache: true
       - name: Android Lint
         timeout-minutes: 25
         env:
@@ -196,6 +198,8 @@ jobs:
         id: setup
         timeout-minutes: 30
         uses: ./.github/actions/setup
+        with:
+          rust-cache: true
       - name: Build and test
         timeout-minutes: 30
         run: |
@@ -234,6 +238,8 @@ jobs:
         id: setup
         timeout-minutes: 30
         uses: ./.github/actions/setup
+        with:
+          rust-cache: true
       - name: Build
         timeout-minutes: 20
         run: |
@@ -289,6 +295,8 @@ jobs:
         id: setup
         timeout-minutes: 30
         uses: ./.github/actions/setup
+        with:
+          rust-cache: true
       - name: Build and test
         timeout-minutes: 30
         env:
@@ -326,6 +334,8 @@ jobs:
         id: setup
         timeout-minutes: 30
         uses: ./.github/actions/setup
+        with:
+          rust-cache: true
       # A fake signing key to satisfy creating a "release" build
       - name: Export Signing Key
         env:


### PR DESCRIPTION
## Problem

The shared `actions/setup` composite restores **and saves** the Rust
cache (`backend-lib/target` + `~/.cargo`) for every job that uses it,
including jobs that never invoke `cargo`. Non-Rust jobs finish first,
and at end-of-job the cache action saves the restored-but-untouched
contents back under the shared key. Later Rust-heavy jobs (and reruns)
then see a primary-key hit and restore almost nothing.

Observed sizes on recent upstream runs:

- Poisoned cache: `Linux-rust-*`, ~7 MB
- Valid warm cache: `Linux-rust-v2-77edbb…`, ~1334 MB

Direct evidence in #1924: a later run restored a 7 MB
`Linux-rust-7cfaf…` as a primary-key hit, and Rust-heavy jobs still
took 27–32m as if cold. With this fix that rerun would have restored a
real Rust cache.

## Fix

- Add `inputs.rust-cache` to `.github/actions/setup`, default `false`.
- Run the **Rust Cache** step only when `inputs.rust-cache == 'true'`.
- Pass `rust-cache: true` from jobs that actually compile Rust:
  `static_analysis_android_lint`, `test_android_modules_unit`,
  `test_android_modules_ftl`, `test_android_modules_wtf`,
  `demo_app_release_build`, and the deploy jobs.
- Leave fast non-Rust jobs (`check_properties`,
  `static_analysis_detekt`, `static_analysis_ktlint`) out of the Rust
  cache entirely.
- Rename the cache key namespace to `<runner.os>-rust-v2-` (templated
  as `${{ runner.os }}-rust-v2-` in the workflow) so any
  already-poisoned `Linux-rust-*` entries are abandoned rather than
  restored.

## Validation

Cold run (no prior cache) created a real cache:

- key: `Linux-rust-v2-77edbb3be63ae096dd8a809b77645821d0f8596068028a00683c37e904d08c71`
- size: ~1334 MB, saved by a Rust-building job

Warm rerun:

- "Cache hit for: `Linux-rust-v2-77edbb…`"
- "Cache Size: ~1334 MB"
- post-job: "Cache hit occurred on the primary key …, not saving cache."

Job times (cold → warm):

| Job                            | Cold    | Warm    | Saved  |
|--------------------------------|---------|---------|--------|
| `test_android_modules_unit`    | 24m17s  | 9m07s   | ~15m   |
| `static_analysis_android_lint` | 24m32s  | 9m43s   | ~15m   |
| `demo_app_release_build`       | 29m43s  | 14m16s  | ~15m   |

For comparison, recent upstream PRs without the fix:

- #1938: unit 26.2m, lint 27.3m, demo 31.1m
- #1937: unit 25.1m, lint 23.8m, demo 30.8m
- #1924: unit 28.0m, lint 27.3m, demo 31.9m

## Why this matters

A check across open + last 20 merged upstream PRs: ~59% (20/34) don't
touch Rust, so it would benefit from using the cache.