### PR TITLE
[#1924] Add Android voting snapshot wallet notes and note witnesses

### DIFF
--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -1230,7 +1230,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1480,7 +1480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2164,7 +2164,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2389,7 +2389,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2679,7 +2679,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3791,7 +3791,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4320,7 +4320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4495,7 +4495,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6054,9 +6054,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "voting-circuits"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ba6635f8e207689c290634f6e34f7eddaf1b254aa0f9b0ef65418d89d1d1ae7"
+checksum = "0436d69b5884ca107db3de1be5e3e92981a35cd15dbfc6919361316a5dfa8e89"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -6260,7 +6260,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6276,7 +6276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -6288,7 +6288,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6300,21 +6300,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -6323,7 +6310,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -6368,7 +6355,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 
@@ -6382,30 +6369,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7133,9 +7102,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1bb9e0ae40320acb03358d257a6fdc951866a21fb5fdd94ce5a09d0bccf25d2"
+checksum = "d7835b7e3d823bfc889279f9c7ab3d4033d3d707004dbf3a0fa158f6f1ef8b43"
 dependencies = [
  "anyhow",
  "blake2b_simd",

--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -6795,6 +6795,7 @@ dependencies = [
  "hex",
  "http",
  "http-body-util",
+ "incrementalmerkletree",
  "jni",
  "libc",
  "log-panics",

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -38,6 +38,7 @@ zcash_protocol = "0.8"
 zcash_script = "0.4"
 zip32 = "0.2"
 eip681 = "0.1.0"
+incrementalmerkletree = { version = "0.8", default-features = false }
 
 # Infrastructure
 prost = "0.14"

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -103,7 +103,7 @@ rust-analyzer = "0.0.1"
 # delegation proof precompute and proof generation; tree-sync remains later.
 # Expected PIR/networking transitives include `pir-client`, `pir-types`,
 # `valar-ypir`, `valar-spiral-rs`, and `hyper-rustls`.
-zcash_voting = { version = "0.5.9", default-features = false, features = ["client-pir"] }
+zcash_voting = { version = "0.5.11", default-features = false, features = ["client-pir"] }
 
 ## Uncomment this to test librustzcash changes locally
 #[patch.crates-io]

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -38,6 +38,7 @@ zcash_protocol = "0.8"
 zcash_script = "0.4"
 zip32 = "0.2"
 eip681 = "0.1.0"
+# Used by voting/notes.rs to construct historical Orchard witness positions.
 incrementalmerkletree = { version = "0.8", default-features = false }
 
 # Infrastructure

--- a/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
+++ b/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
@@ -375,7 +375,7 @@ class VotingRustBackendTest {
         }
 
     @Test
-    fun store_tree_state_accepts_cached_bytes() =
+    fun store_tree_state_rejects_invalid_cached_bytes() =
         runTest {
             val db = VotingRustBackend.new().openVotingDb(newDbPath(), WALLET_ID)
             try {
@@ -388,7 +388,30 @@ class VotingRustBackendTest {
                     sessionJson = null
                 )
 
-                db.storeTreeState(ROUND_ID, byteArrayOf(1, 2, 3))
+                assertFailsWith<RuntimeException> {
+                    db.storeTreeState(ROUND_ID, byteArrayOf(1, 2, 3))
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+    @Test
+    fun store_tree_state_accepts_matching_snapshot_fixture() =
+        runTest {
+            val backend = VotingRustBackend.new()
+            val db = backend.openVotingDb(newDbPath(), WALLET_ID)
+            try {
+                db.initRound(
+                    roundId = ROUND_ID,
+                    snapshotHeight = 1,
+                    eaPK = EA_PK,
+                    ncRoot = EMPTY_ORCHARD_WITNESS_ROOT.hexToByteArray(),
+                    nullifierIMTRoot = NULLIFIER_IMT_ROOT,
+                    sessionJson = null
+                )
+
+                db.storeTreeState(ROUND_ID, backend.treeStateFixtureForTesting())
             } finally {
                 db.close()
             }

--- a/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
+++ b/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
@@ -397,6 +397,52 @@ class VotingRustBackendTest {
         }
 
     @Test
+    fun store_tree_state_rejects_snapshot_height_mismatch() =
+        runTest {
+            val backend = VotingRustBackend.new()
+            val db = backend.openVotingDb(newDbPath(), WALLET_ID)
+            try {
+                db.initRound(
+                    roundId = ROUND_ID,
+                    snapshotHeight = SNAPSHOT_HEIGHT,
+                    eaPK = EA_PK,
+                    ncRoot = EMPTY_ORCHARD_WITNESS_ROOT.hexToByteArray(),
+                    nullifierIMTRoot = NULLIFIER_IMT_ROOT,
+                    sessionJson = null
+                )
+
+                assertFailsWith<RuntimeException> {
+                    db.storeTreeState(ROUND_ID, backend.treeStateFixtureForTesting())
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+    @Test
+    fun store_tree_state_rejects_nc_root_mismatch() =
+        runTest {
+            val backend = VotingRustBackend.new()
+            val db = backend.openVotingDb(newDbPath(), WALLET_ID)
+            try {
+                db.initRound(
+                    roundId = ROUND_ID,
+                    snapshotHeight = 1,
+                    eaPK = EA_PK,
+                    ncRoot = NC_ROOT,
+                    nullifierIMTRoot = NULLIFIER_IMT_ROOT,
+                    sessionJson = null
+                )
+
+                assertFailsWith<RuntimeException> {
+                    db.storeTreeState(ROUND_ID, backend.treeStateFixtureForTesting())
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+    @Test
     fun store_tree_state_accepts_matching_snapshot_fixture() =
         runTest {
             val backend = VotingRustBackend.new()

--- a/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
+++ b/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
@@ -22,6 +22,7 @@ class VotingRustBackendTest {
         private const val SHARE_INDEX = 5
         private const val OUT_OF_RANGE_SHARE_INDEX = 16
         private const val DIVERSIFIER_BYTES = 11
+        private const val ORCHARD_FVK_BYTES = 96
         private const val ORCHARD_WITNESS_PATH_DEPTH = 32
         private val VOTE_COMMITMENT = ByteArray(FIELD_BYTES) { 1 }
         private val BLIND = ByteArray(FIELD_BYTES) { 2 }
@@ -125,6 +126,52 @@ class VotingRustBackendTest {
     fun warm_proving_caches_smoke() =
         runTest {
             VotingRustBackend.new().warmProvingCaches()
+        }
+
+    @Test
+    fun extract_orchard_fvk_from_ufvk_is_deterministic() =
+        runTest {
+            val backend = VotingRustBackend.new()
+            val ufvk = deriveTestUfvk()
+
+            val first = backend.extractOrchardFvkFromUfvk(ufvk, TESTNET_NETWORK_ID)
+            val second = backend.extractOrchardFvkFromUfvk(ufvk, TESTNET_NETWORK_ID)
+
+            assertEquals(ORCHARD_FVK_BYTES, first.size)
+            assertContentEquals(first, second)
+            assertFailsWith<RuntimeException> {
+                backend.extractOrchardFvkFromUfvk("not-a-ufvk", TESTNET_NETWORK_ID)
+            }
+        }
+
+    @Test
+    fun extract_nc_root_decodes_tree_state() =
+        runTest {
+            val backend = VotingRustBackend.new()
+
+            val root = backend.extractNcRoot(backend.treeStateFixtureForTesting())
+
+            assertContentEquals(EMPTY_ORCHARD_WITNESS_ROOT.hexToByteArray(), root)
+            assertFailsWith<RuntimeException> {
+                backend.extractNcRoot(byteArrayOf(1, 2, 3))
+            }
+        }
+
+    @Test
+    fun verify_witness_returns_boolean() =
+        runTest {
+            val backend = VotingRustBackend.new()
+            val validWitness = witnesses().single()
+
+            assertTrue(backend.verifyWitness(validWitness))
+            assertFalse(backend.verifyWitness(validWitness.copy(root = NC_ROOT)))
+            assertFailsWith<RuntimeException> {
+                backend.verifyWitness(
+                    validWitness.copy(
+                        authPath = validWitness.authPath.dropLast(1)
+                    )
+                )
+            }
         }
 
     @Test
@@ -322,6 +369,26 @@ class VotingRustBackendTest {
                 val deletedRows = db.deleteSkippedBundles(ROUND_ID, keepCount = 1)
                 assertEquals(1L, deletedRows)
                 assertEquals(1, db.getBundleCount(ROUND_ID))
+            } finally {
+                db.close()
+            }
+        }
+
+    @Test
+    fun store_tree_state_accepts_cached_bytes() =
+        runTest {
+            val db = VotingRustBackend.new().openVotingDb(newDbPath(), WALLET_ID)
+            try {
+                db.initRound(
+                    roundId = ROUND_ID,
+                    snapshotHeight = SNAPSHOT_HEIGHT,
+                    eaPK = EA_PK,
+                    ncRoot = NC_ROOT,
+                    nullifierIMTRoot = NULLIFIER_IMT_ROOT,
+                    sessionJson = null
+                )
+
+                db.storeTreeState(ROUND_ID, byteArrayOf(1, 2, 3))
             } finally {
                 db.close()
             }
@@ -630,6 +697,30 @@ class VotingRustBackendTest {
             assertContentEquals(ByteArray(FIELD_BYTES) { 0x10 }, result.publicInputs.first())
             assertEquals(5, result.govNullifiers.size)
             assertContentEquals(ByteArray(FIELD_BYTES) { 0x42 }, result.rk)
+        }
+
+    @Test
+    fun note_and_witness_array_fixtures_cross_rust_to_kotlin_construction() =
+        runTest {
+            val backend = VotingRustBackend.new()
+
+            val note = backend.noteInfoArrayFixtureForTesting().single()
+            assertContentEquals(ByteArray(FIELD_BYTES) { 0x01 }, note.commitment)
+            assertContentEquals(ByteArray(FIELD_BYTES) { 0x02 }, note.nullifier)
+            assertEquals(123_456L, note.value)
+            assertEquals(7L, note.position)
+            assertContentEquals(ByteArray(DIVERSIFIER_BYTES) { 0x03 }, note.diversifier)
+            assertContentEquals(ByteArray(FIELD_BYTES) { 0x04 }, note.rho)
+            assertContentEquals(ByteArray(FIELD_BYTES) { 0x05 }, note.rseed)
+            assertEquals(1, note.scope)
+            assertEquals("ufvk-fixture", note.ufvk)
+
+            val witness = backend.witnessDataArrayFixtureForTesting().single()
+            assertContentEquals(ByteArray(FIELD_BYTES) { 0x11 }, witness.noteCommitment)
+            assertEquals(9L, witness.position)
+            assertContentEquals(ByteArray(FIELD_BYTES) { 0x12 }, witness.root)
+            assertEquals(ORCHARD_WITNESS_PATH_DEPTH, witness.authPath.size)
+            assertContentEquals(ByteArray(FIELD_BYTES) { 0x20 }, witness.authPath.first())
         }
 
     @Test

--- a/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
+++ b/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
@@ -464,6 +464,44 @@ class VotingRustBackendTest {
         }
 
     @Test
+    fun generate_note_witnesses_rejects_missing_wallet_db_path() =
+        runTest {
+            val backend = VotingRustBackend.new()
+            val db = backend.openVotingDb(newDbPath(), WALLET_ID)
+            try {
+                val notes = witnessNotes()
+                db.initRound(
+                    roundId = PCZT_ROUND_ID,
+                    snapshotHeight = 1,
+                    eaPK = EA_PK,
+                    ncRoot = EMPTY_ORCHARD_WITNESS_ROOT.hexToByteArray(),
+                    nullifierIMTRoot = NULLIFIER_IMT_ROOT,
+                    sessionJson = null
+                )
+                db.setupBundles(PCZT_ROUND_ID, notes)
+                db.storeTreeState(PCZT_ROUND_ID, backend.treeStateFixtureForTesting())
+
+                val missingWalletDbPath =
+                    createTempDirectory("wallet-db-")
+                        .resolve("missing-wallet.db")
+                        .toFile()
+                        .absolutePath
+
+                assertFailsWith<RuntimeException> {
+                    db.generateNoteWitnesses(
+                        roundId = PCZT_ROUND_ID,
+                        bundleIndex = 0,
+                        walletDbPath = missingWalletDbPath,
+                        networkId = TESTNET_NETWORK_ID,
+                        notes = notes
+                    )
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+    @Test
     fun generate_hotkey_is_deterministic_and_rejects_short_seed() =
         runTest {
             val db = VotingRustBackend.new().openVotingDb(newDbPath(), WALLET_ID)

--- a/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
+++ b/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
@@ -1,10 +1,13 @@
 package cash.z.ecc.android.sdk.internal.jni
 
+import android.content.ContentValues
+import android.database.sqlite.SQLiteDatabase
 import cash.z.ecc.android.sdk.internal.model.voting.JniNoteInfo
 import cash.z.ecc.android.sdk.internal.model.voting.JniRoundPhase
 import cash.z.ecc.android.sdk.internal.model.voting.JniWitnessData
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
+import java.io.File
 import kotlin.io.path.createTempDirectory
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -24,6 +27,7 @@ class VotingRustBackendTest {
         private const val DIVERSIFIER_BYTES = 11
         private const val ORCHARD_FVK_BYTES = 96
         private const val ORCHARD_WITNESS_PATH_DEPTH = 32
+        private const val SCANNED_PRIORITY = 10
         private val VOTE_COMMITMENT = ByteArray(FIELD_BYTES) { 1 }
         private val BLIND = ByteArray(FIELD_BYTES) { 2 }
         private val SHORT_FIELD = ByteArray(FIELD_BYTES - 1)
@@ -464,7 +468,99 @@ class VotingRustBackendTest {
         }
 
     @Test
+    fun get_wallet_notes_rejects_unknown_account() =
+        runTest {
+            val wallet = newWalletDbWithAccount()
+            markWalletScannedThrough(wallet.path, walletBirthdayHeight(wallet.path))
+
+            assertRuntimeExceptionContains("account not found in wallet DB") {
+                VotingRustBackend.new().getWalletNotes(
+                    walletDbPath = wallet.path,
+                    snapshotHeight = walletBirthdayHeight(wallet.path),
+                    networkId = TESTNET_NETWORK_ID,
+                    accountUuidBytes = ByteArray(16) { 9 }
+                )
+            }
+        }
+
+    @Test
+    fun get_wallet_notes_rejects_account_without_ufvk() =
+        runTest {
+            val wallet = newWalletDbWithAccount()
+            markWalletScannedThrough(wallet.path, walletBirthdayHeight(wallet.path))
+            downgradeAccountToUivkOnly(wallet.path, wallet.accountUuid)
+
+            assertRuntimeExceptionContains("account has no UFVK") {
+                VotingRustBackend.new().getWalletNotes(
+                    walletDbPath = wallet.path,
+                    snapshotHeight = walletBirthdayHeight(wallet.path),
+                    networkId = TESTNET_NETWORK_ID,
+                    accountUuidBytes = wallet.accountUuid
+                )
+            }
+        }
+
+    @Test
+    fun get_wallet_notes_rejects_snapshot_above_fully_scanned_height() =
+        runTest {
+            val wallet = newWalletDbWithAccount()
+            val fullyScannedHeight = walletBirthdayHeight(wallet.path)
+            markWalletScannedThrough(wallet.path, fullyScannedHeight)
+
+            assertRuntimeExceptionContains(
+                "wallet DB fully scanned height $fullyScannedHeight is below snapshot_height " +
+                    "${fullyScannedHeight + 1}"
+            ) {
+                VotingRustBackend.new().getWalletNotes(
+                    walletDbPath = wallet.path,
+                    snapshotHeight = fullyScannedHeight + 1,
+                    networkId = TESTNET_NETWORK_ID,
+                    accountUuidBytes = wallet.accountUuid
+                )
+            }
+        }
+
+    @Test
     fun generate_note_witnesses_rejects_missing_wallet_db_path() =
+        runTest {
+            val backend = VotingRustBackend.new()
+            val db = backend.openVotingDb(newDbPath(), WALLET_ID)
+            try {
+                val notes = witnessNotes()
+                val treeState = backend.nonEmptyTreeStateFixtureForTesting()
+                db.initRound(
+                    roundId = PCZT_ROUND_ID,
+                    snapshotHeight = 1,
+                    eaPK = EA_PK,
+                    ncRoot = backend.extractNcRoot(treeState),
+                    nullifierIMTRoot = NULLIFIER_IMT_ROOT,
+                    sessionJson = null
+                )
+                db.setupBundles(PCZT_ROUND_ID, notes)
+                db.storeTreeState(PCZT_ROUND_ID, treeState)
+
+                val missingWalletDbPath =
+                    createTempDirectory("wallet-db-")
+                        .resolve("missing-wallet.db")
+                        .toFile()
+                        .absolutePath
+
+                assertRuntimeExceptionContains("open wallet DB read-only") {
+                    db.generateNoteWitnesses(
+                        roundId = PCZT_ROUND_ID,
+                        bundleIndex = 0,
+                        walletDbPath = missingWalletDbPath,
+                        networkId = TESTNET_NETWORK_ID,
+                        notes = notes
+                    )
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+    @Test
+    fun generate_note_witnesses_rejects_empty_snapshot_frontier() =
         runTest {
             val backend = VotingRustBackend.new()
             val db = backend.openVotingDb(newDbPath(), WALLET_ID)
@@ -481,17 +577,13 @@ class VotingRustBackendTest {
                 db.setupBundles(PCZT_ROUND_ID, notes)
                 db.storeTreeState(PCZT_ROUND_ID, backend.treeStateFixtureForTesting())
 
-                val missingWalletDbPath =
-                    createTempDirectory("wallet-db-")
-                        .resolve("missing-wallet.db")
-                        .toFile()
-                        .absolutePath
-
-                assertFailsWith<RuntimeException> {
+                assertRuntimeExceptionContains(
+                    "empty orchard frontier - no Orchard activity at snapshot"
+                ) {
                     db.generateNoteWitnesses(
                         roundId = PCZT_ROUND_ID,
                         bundleIndex = 0,
-                        walletDbPath = missingWalletDbPath,
+                        walletDbPath = newDbPath(),
                         networkId = TESTNET_NETWORK_ID,
                         notes = notes
                     )
@@ -891,6 +983,120 @@ class VotingRustBackendTest {
     private fun newDbPath() =
         createTempDirectory("voting-db-").resolve("voting.db").toFile().absolutePath
 
+    private suspend fun newWalletDbWithAccount(): WalletDbFixture {
+        val walletDbFile =
+            createTempDirectory("wallet-db-")
+                .resolve("data.db")
+                .toFile()
+        val rustBackend =
+            RustBackend.new(
+                fsBlockDbRoot = createTempDirectory("fs-block-db-").toFile(),
+                dataDbFile = walletDbFile,
+                saplingSpendFile =
+                    createTempDirectory("sapling-spend-")
+                        .resolve("sapling-spend.params")
+                        .toFile(),
+                saplingOutputFile =
+                    createTempDirectory("sapling-output-")
+                        .resolve("sapling-output.params")
+                        .toFile(),
+                zcashNetworkId = TESTNET_NETWORK_ID
+            )
+        assertEquals(0, rustBackend.initDataDb(HOTKEY_SEED))
+
+        val account =
+            rustBackend.createAccount(
+                accountName = "account",
+                keySource = null,
+                seed = HOTKEY_SEED,
+                treeState = VotingRustBackend.new().treeStateFixtureForTesting(),
+                recoverUntil = null
+            )
+
+        return WalletDbFixture(walletDbFile.absolutePath, account.accountUuid)
+    }
+
+    private fun walletBirthdayHeight(walletDbPath: String): Long =
+        SQLiteDatabase
+            .openDatabase(walletDbPath, null, SQLiteDatabase.OPEN_READONLY)
+            .use { db ->
+                db.rawQuery("SELECT MIN(birthday_height) FROM accounts", null).use { cursor ->
+                    assertTrue(cursor.moveToFirst())
+                    cursor.getLong(0)
+                }
+            }
+
+    private fun markWalletScannedThrough(walletDbPath: String, fullyScannedHeight: Long) {
+        val birthdayHeight = walletBirthdayHeight(walletDbPath)
+        require(fullyScannedHeight >= birthdayHeight)
+
+        SQLiteDatabase
+            .openDatabase(walletDbPath, null, SQLiteDatabase.OPEN_READWRITE)
+            .use { db ->
+                val blockValues =
+                    ContentValues().apply {
+                        put("height", fullyScannedHeight)
+                        put("hash", ByteArray(FIELD_BYTES) { fullyScannedHeight.toByte() })
+                        put("time", 0L)
+                        put("sapling_tree", byteArrayOf(0))
+                        put("sapling_commitment_tree_size", 0)
+                        put("orchard_commitment_tree_size", 0)
+                        put("sapling_output_count", 0)
+                        put("orchard_action_count", 0)
+                    }
+                db.insertWithOnConflict(
+                    "blocks",
+                    null,
+                    blockValues,
+                    SQLiteDatabase.CONFLICT_REPLACE
+                )
+
+                db.delete("scan_queue", null, null)
+                val scanValues =
+                    ContentValues().apply {
+                        put("block_range_start", birthdayHeight)
+                        put("block_range_end", fullyScannedHeight + 1)
+                        put("priority", SCANNED_PRIORITY)
+                    }
+                db.insert("scan_queue", null, scanValues)
+            }
+    }
+
+    private fun downgradeAccountToUivkOnly(walletDbPath: String, accountUuid: ByteArray) {
+        SQLiteDatabase
+            .openDatabase(walletDbPath, null, SQLiteDatabase.OPEN_READWRITE)
+            .use { db ->
+                db.execSQL(
+                    """
+                    UPDATE accounts
+                    SET account_kind = 1,
+                        has_spend_key = 0,
+                        ufvk = NULL
+                    WHERE uuid = ?
+                    """.trimIndent(),
+                    arrayOf(accountUuid)
+                )
+            }
+    }
+
+    private suspend fun assertRuntimeExceptionContains(
+        expectedMessage: String,
+        block: suspend () -> Unit
+    ) {
+        val error =
+            try {
+                block()
+                null
+            } catch (e: RuntimeException) {
+                e
+            }
+        assertNotNull(error)
+        assertTrue(
+            error.message.orEmpty().contains(expectedMessage),
+            "Expected '${error.message}' to contain '$expectedMessage'"
+        )
+    }
+
     private suspend fun deriveTestUfvk(
         seed: ByteArray = HOTKEY_SEED,
         networkId: Int = TESTNET_NETWORK_ID
@@ -998,4 +1204,9 @@ class VotingRustBackendTest {
         byteValue: Int,
         size: Int = FIELD_BYTES
     ) = ByteArray(size) { byteValue.toByte() }.toHexString()
+
+    private data class WalletDbFixture(
+        val path: String,
+        val accountUuid: ByteArray
+    )
 }

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackend.kt
@@ -98,7 +98,7 @@ class VotingRustBackend private constructor() {
         networkId: Int,
         accountUuidBytes: ByteArray
     ): Array<JniNoteInfo> =
-        withContext(Dispatchers.IO) {
+        withContext(SdkDispatchers.DATABASE_IO) {
             getWalletNotesNative(
                 walletDbPath,
                 snapshotHeight,

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackend.kt
@@ -86,7 +86,7 @@ class VotingRustBackend private constructor() {
         }
 
     @Throws(RuntimeException::class)
-    suspend fun verifyWitness(witness: JniWitnessData): Int =
+    suspend fun verifyWitness(witness: JniWitnessData): Boolean =
         withContext(Dispatchers.IO) {
             verifyWitnessNative(witness)
         }
@@ -129,6 +129,27 @@ class VotingRustBackend private constructor() {
         withContext(Dispatchers.IO) {
             delegationProofResultFixtureNative()
                 ?: error("delegationProofResultFixture returned null")
+        }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal suspend fun noteInfoArrayFixtureForTesting(): Array<JniNoteInfo> =
+        withContext(Dispatchers.IO) {
+            noteInfoArrayFixtureNative()
+                ?: error("noteInfoArrayFixture returned null")
+        }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal suspend fun witnessDataArrayFixtureForTesting(): Array<JniWitnessData> =
+        withContext(Dispatchers.IO) {
+            witnessDataArrayFixtureNative()
+                ?: error("witnessDataArrayFixture returned null")
+        }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal suspend fun treeStateFixtureForTesting(): ByteArray =
+        withContext(Dispatchers.IO) {
+            treeStateFixtureNative()
+                ?: error("treeStateFixture returned null")
         }
 
     suspend fun openVotingDb(dbPath: String, walletId: String): VotingDb =
@@ -360,9 +381,7 @@ class VotingRustBackend private constructor() {
             roundId: String,
             treeStateBytes: ByteArray
         ) = withHandle { handle ->
-            check(storeTreeStateNative(handle, roundId, treeStateBytes)) {
-                "storeTreeState failed for roundId=$roundId"
-            }
+            storeTreeStateNative(handle, roundId, treeStateBytes)
         }
 
         @Throws(RuntimeException::class)
@@ -456,7 +475,7 @@ class VotingRustBackend private constructor() {
 
         @JvmStatic
         @Throws(RuntimeException::class)
-        private external fun verifyWitnessNative(witness: JniWitnessData): Int
+        private external fun verifyWitnessNative(witness: JniWitnessData): Boolean
 
         @JvmStatic
         @Throws(RuntimeException::class)
@@ -568,6 +587,18 @@ class VotingRustBackend private constructor() {
 
         @JvmStatic
         @Throws(RuntimeException::class)
+        private external fun noteInfoArrayFixtureNative(): Array<JniNoteInfo>?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun witnessDataArrayFixtureNative(): Array<JniWitnessData>?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun treeStateFixtureNative(): ByteArray?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
         private external fun storeWitnessesNative(
             dbHandle: Long,
             roundId: String,
@@ -629,7 +660,7 @@ class VotingRustBackend private constructor() {
             dbHandle: Long,
             roundId: String,
             treeStateBytes: ByteArray
-        ): Boolean
+        )
 
         @JvmStatic
         @Throws(RuntimeException::class)

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackend.kt
@@ -152,6 +152,13 @@ class VotingRustBackend private constructor() {
                 ?: error("treeStateFixture returned null")
         }
 
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal suspend fun nonEmptyTreeStateFixtureForTesting(): ByteArray =
+        withContext(Dispatchers.IO) {
+            nonEmptyTreeStateFixtureNative()
+                ?: error("nonEmptyTreeStateFixture returned null")
+        }
+
     suspend fun openVotingDb(dbPath: String, walletId: String): VotingDb =
         withContext(SdkDispatchers.DATABASE_IO) {
             openVotingDbNative(dbPath, walletId).let { dbHandle ->
@@ -596,6 +603,10 @@ class VotingRustBackend private constructor() {
         @JvmStatic
         @Throws(RuntimeException::class)
         private external fun treeStateFixtureNative(): ByteArray?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun nonEmptyTreeStateFixtureNative(): ByteArray?
 
         @JvmStatic
         @Throws(RuntimeException::class)

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackend.kt
@@ -69,6 +69,45 @@ class VotingRustBackend private constructor() {
         }
 
     @Throws(RuntimeException::class)
+    suspend fun extractOrchardFvkFromUfvk(
+        ufvk: String,
+        networkId: Int
+    ): ByteArray =
+        withContext(Dispatchers.IO) {
+            extractOrchardFvkFromUfvkNative(ufvk, networkId)
+                ?: error("extractOrchardFvkFromUfvk returned null")
+        }
+
+    @Throws(RuntimeException::class)
+    suspend fun extractNcRoot(treeStateBytes: ByteArray): ByteArray =
+        withContext(Dispatchers.IO) {
+            extractNcRootNative(treeStateBytes)
+                ?: error("extractNcRoot returned null")
+        }
+
+    @Throws(RuntimeException::class)
+    suspend fun verifyWitness(witness: JniWitnessData): Int =
+        withContext(Dispatchers.IO) {
+            verifyWitnessNative(witness)
+        }
+
+    @Throws(RuntimeException::class)
+    suspend fun getWalletNotes(
+        walletDbPath: String,
+        snapshotHeight: Long,
+        networkId: Int,
+        accountUuidBytes: ByteArray
+    ): Array<JniNoteInfo> =
+        withContext(Dispatchers.IO) {
+            getWalletNotesNative(
+                walletDbPath,
+                snapshotHeight,
+                networkId,
+                accountUuidBytes
+            ) ?: error("getWalletNotes returned null")
+        }
+
+    @Throws(RuntimeException::class)
     suspend fun extractPcztSighash(pcztBytes: ByteArray): ByteArray =
         withContext(Dispatchers.IO) {
             extractPcztSighashNative(pcztBytes)
@@ -316,6 +355,35 @@ class VotingRustBackend private constructor() {
                 ) ?: error("getDelegationSubmissionWithKeystoneSig returned null")
             }
 
+        @Throws(RuntimeException::class)
+        suspend fun storeTreeState(
+            roundId: String,
+            treeStateBytes: ByteArray
+        ) = withHandle { handle ->
+            check(storeTreeStateNative(handle, roundId, treeStateBytes)) {
+                "storeTreeState failed for roundId=$roundId"
+            }
+        }
+
+        @Throws(RuntimeException::class)
+        suspend fun generateNoteWitnesses(
+            roundId: String,
+            bundleIndex: Int,
+            walletDbPath: String,
+            networkId: Int,
+            notes: List<JniNoteInfo>
+        ): Array<JniWitnessData> =
+            withHandle { handle ->
+                generateNoteWitnessesNative(
+                    handle,
+                    roundId,
+                    bundleIndex,
+                    walletDbPath,
+                    networkId,
+                    notes.toTypedArray()
+                ) ?: error("generateNoteWitnesses returned null")
+            }
+
         @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
         internal suspend fun storeDelegationProofFixtureForTesting(
             roundId: String,
@@ -374,6 +442,30 @@ class VotingRustBackend private constructor() {
         @JvmStatic
         @Throws(RuntimeException::class)
         private external fun warmProvingCachesNative()
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun extractOrchardFvkFromUfvkNative(
+            ufvk: String,
+            networkId: Int
+        ): ByteArray?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun extractNcRootNative(treeStateBytes: ByteArray): ByteArray?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun verifyWitnessNative(witness: JniWitnessData): Int
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun getWalletNotesNative(
+            walletDbPath: String,
+            snapshotHeight: Long,
+            networkId: Int,
+            accountUuidBytes: ByteArray
+        ): Array<JniNoteInfo>?
 
         @JvmStatic
         @Throws(RuntimeException::class)
@@ -530,6 +622,25 @@ class VotingRustBackend private constructor() {
             keystoneSig: ByteArray,
             keystoneSighash: ByteArray
         ): JniDelegationSubmissionResult?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun storeTreeStateNative(
+            dbHandle: Long,
+            roundId: String,
+            treeStateBytes: ByteArray
+        ): Boolean
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun generateNoteWitnessesNative(
+            dbHandle: Long,
+            roundId: String,
+            bundleIndex: Int,
+            walletDbPath: String,
+            networkId: Int,
+            notes: Array<JniNoteInfo>
+        ): Array<JniWitnessData>?
 
         @JvmStatic
         @Throws(RuntimeException::class)

--- a/backend-lib/src/main/rust/voting.rs
+++ b/backend-lib/src/main/rust/voting.rs
@@ -7,7 +7,6 @@ use jni::{
     sys::{JNI_FALSE, JNI_TRUE, jboolean, jbyteArray, jint, jlong, jobject, jobjectArray},
 };
 use orchard::keys::Scope;
-use rusqlite::named_params;
 use secrecy::{ExposeSecret, SecretVec};
 use std::{
     collections::HashMap,

--- a/backend-lib/src/main/rust/voting.rs
+++ b/backend-lib/src/main/rust/voting.rs
@@ -4,9 +4,10 @@ use anyhow::anyhow;
 use jni::{
     JNIEnv, JavaVM,
     objects::{GlobalRef, JByteArray, JClass, JObject, JObjectArray, JString, JValue},
-    sys::{jboolean, jbyteArray, jint, jlong, jobject, jobjectArray},
+    sys::{JNI_FALSE, JNI_TRUE, jboolean, jbyteArray, jint, jlong, jobject, jobjectArray},
 };
 use orchard::keys::Scope;
+use rusqlite::named_params;
 use secrecy::{ExposeSecret, SecretVec};
 use std::{
     collections::HashMap,

--- a/backend-lib/src/main/rust/voting/helpers.rs
+++ b/backend-lib/src/main/rust/voting/helpers.rs
@@ -932,39 +932,8 @@ pub(super) fn update_round_phase_forward(
     round_id: &str,
     phase: RoundPhase,
 ) -> anyhow::Result<()> {
-    let conn = db.conn();
-    let wallet_id = db.wallet_id();
-    let requested_rank = round_phase_to_u32(phase);
-
-    let rows = conn
-        .execute(
-            "UPDATE rounds
-             SET phase = ?1
-             WHERE round_id = ?2
-               AND wallet_id = ?3
-               AND phase < ?1",
-            rusqlite::params![phase as i32, round_id, wallet_id],
-        )
-        .map_err(|e| anyhow!("update_round_phase: {}", e))?;
-    if rows > 0 {
-        return Ok(());
-    }
-
-    let current = voting::storage::queries::get_round_state(&conn, round_id, &wallet_id)
-        .map_err(|e| anyhow!("get_round_state after phase update: {}", e))?
-        .phase;
-    let current_rank = round_phase_to_u32(current);
-    if current_rank < requested_rank {
-        return Err(anyhow!(
-            "failed to advance round phase for {round_id}: current={current_rank}, requested={requested_rank}"
-        ));
-    } else if current_rank > requested_rank {
-        return Err(anyhow!(
-            "refusing to regress round phase for {round_id}: current={current_rank}, requested={requested_rank}"
-        ));
-    }
-
-    Ok(())
+    db.advance_round_phase(round_id, phase)
+        .map_err(|e| anyhow!("advance_round_phase: {}", e))
 }
 
 /// Requires the hotkey step before PCZT construction and rejects calls after
@@ -1049,43 +1018,13 @@ pub(super) fn select_bundle_notes(
 }
 
 pub(super) fn replace_bundle_witnesses(
-    conn: &mut rusqlite::Connection,
+    db: &VotingDb,
     round_id: &str,
-    wallet_id: &str,
     bundle_index: u32,
     witnesses: &[WitnessData],
 ) -> anyhow::Result<()> {
-    for witness in witnesses {
-        let valid = voting::witness::verify_witness(witness)
-            .map_err(|e| anyhow!("verify_witness: {}", e))?;
-        if !valid {
-            return Err(anyhow!(
-                "witness verification failed for position {}",
-                witness.position
-            ));
-        }
-    }
-
-    let tx = conn
-        .transaction()
-        .map_err(|e| anyhow!("begin replace witnesses transaction: {}", e))?;
-
-    tx.execute(
-        "DELETE FROM witnesses
-         WHERE round_id = :round_id AND wallet_id = :wallet_id AND bundle_index = :bundle_index",
-        named_params! {
-            ":round_id": round_id,
-            ":wallet_id": wallet_id,
-            ":bundle_index": bundle_index as i64,
-        },
-    )
-    .map_err(|e| anyhow!("clear_witnesses: {}", e))?;
-
-    voting::storage::queries::store_witnesses(&tx, round_id, wallet_id, bundle_index, witnesses)
-        .map_err(|e| anyhow!("store_witnesses: {}", e))?;
-
-    tx.commit()
-        .map_err(|e| anyhow!("commit replace witnesses transaction: {}", e))
+    db.replace_bundle_witnesses(round_id, bundle_index, witnesses)
+        .map_err(|e| anyhow!("replace_bundle_witnesses: {}", e))
 }
 
 pub(super) fn received_note_to_note_info(

--- a/backend-lib/src/main/rust/voting/helpers.rs
+++ b/backend-lib/src/main/rust/voting/helpers.rs
@@ -9,6 +9,8 @@ const PHASE_VOTE_READY: u32 = 4;
 
 const JNI_ROUND_SUMMARY: &str = "cash/z/ecc/android/sdk/internal/model/voting/JniRoundSummary";
 const JNI_VOTE_RECORD: &str = "cash/z/ecc/android/sdk/internal/model/voting/JniVoteRecord";
+const JNI_NOTE_INFO: &str = "cash/z/ecc/android/sdk/internal/model/voting/JniNoteInfo";
+const JNI_WITNESS_DATA: &str = "cash/z/ecc/android/sdk/internal/model/voting/JniWitnessData";
 const JNI_VOTING_HOTKEY: &str = "cash/z/ecc/android/sdk/internal/model/voting/JniVotingHotkey";
 const JNI_BUNDLE_SETUP_RESULT: &str =
     "cash/z/ecc/android/sdk/internal/model/voting/JniBundleSetupResult";
@@ -20,6 +22,12 @@ const JNI_DELEGATION_PROOF_RESULT: &str =
 const JNI_DELEGATION_SUBMISSION_RESULT: &str =
     "cash/z/ecc/android/sdk/internal/model/voting/JniDelegationSubmissionResult";
 
+// Must match JniNoteInfo(ByteArray, ByteArray, Long, Long, ByteArray,
+// ByteArray, ByteArray, Int, String) in JniVotingModels.kt.
+const JNI_NOTE_INFO_CTOR_SIG: &str = "([B[BJJ[B[B[BILjava/lang/String;)V";
+// Must match JniWitnessData(ByteArray, Long, ByteArray, Array<ByteArray>)
+// in JniVotingModels.kt.
+const JNI_WITNESS_DATA_CTOR_SIG: &str = "([BJ[B[[B)V";
 // Must match JniVotingHotkey(ByteArray, String) in JniVotingModels.kt.
 const JNI_VOTING_HOTKEY_CTOR_SIG: &str = "([BLjava/lang/String;)V";
 // Must match JniBundleSetupResult(Int, Long, LongArray) in JniVotingModels.kt.
@@ -51,6 +59,7 @@ pub(super) const ORCHARD_DIVERSIFIER_BYTES: usize = 11;
 pub(super) const ORCHARD_WITNESS_PATH_DEPTH: usize = 32;
 pub(super) const DELEGATION_PUBLIC_INPUT_COUNT: usize = 14;
 pub(super) const GOVERNANCE_NULLIFIER_COUNT: usize = 5;
+pub(super) const ACCOUNT_UUID_BYTES: usize = 16;
 pub(super) const NETWORK_ID_TESTNET: jint = 0;
 pub(super) const NETWORK_ID_MAINNET: jint = 1;
 
@@ -74,6 +83,10 @@ pub(super) fn jint_to_u32(value: jint, field: &str) -> anyhow::Result<u32> {
 
 pub(super) fn jlong_to_u64(value: jlong, field: &str) -> anyhow::Result<u64> {
     u64::try_from(value).map_err(|_| anyhow!("{field} must be non-negative, got {value}"))
+}
+
+pub(super) fn jlong_to_u32(value: jlong, field: &str) -> anyhow::Result<u32> {
+    u32::try_from(value).map_err(|_| anyhow!("{field} must be in range 0..=u32::MAX, got {value}"))
 }
 
 pub(super) fn jint_to_usize(value: jint, field: &str) -> anyhow::Result<usize> {
@@ -527,6 +540,118 @@ impl TryFrom<VoteRecord> for JniVoteRecordPayload {
     }
 }
 
+pub(super) fn make_jni_note_info_array<'local>(
+    env: &mut JNIEnv<'local>,
+    notes: Vec<NoteInfo>,
+) -> anyhow::Result<jobjectArray> {
+    let len = usize_to_jint(notes.len(), "notes length")?;
+    let class = env.find_class(JNI_NOTE_INFO)?;
+    let mut notes = notes.into_iter().enumerate();
+    if let Some((_, first)) = notes.next() {
+        let first = make_jni_note_info(env, first)?;
+        let array = env.new_object_array(len, &class, &first)?;
+        for (index, note) in notes {
+            let note = make_jni_note_info(env, note)?;
+            env.set_object_array_element(&array, usize_to_jint(index, "notes index")?, note)?;
+        }
+        Ok(array.into_raw())
+    } else {
+        Ok(env.new_object_array(0, &class, JObject::null())?.into_raw())
+    }
+}
+
+fn make_jni_note_info<'local>(
+    env: &mut JNIEnv<'local>,
+    note: NoteInfo,
+) -> anyhow::Result<JObject<'local>> {
+    let class = env.find_class(JNI_NOTE_INFO)?;
+    let commitment =
+        make_jni_fixed_bytes(env, note.commitment, "commitment", PROTOCOL_FIELD_BYTES)?;
+    let nullifier = make_jni_fixed_bytes(env, note.nullifier, "nullifier", PROTOCOL_FIELD_BYTES)?;
+    let diversifier = make_jni_fixed_bytes(
+        env,
+        note.diversifier,
+        "diversifier",
+        ORCHARD_DIVERSIFIER_BYTES,
+    )?;
+    let rho = make_jni_fixed_bytes(env, note.rho, "rho", PROTOCOL_FIELD_BYTES)?;
+    let rseed = make_jni_fixed_bytes(env, note.rseed, "rseed", PROTOCOL_FIELD_BYTES)?;
+    let ufvk: JObject<'local> = env.new_string(note.ufvk_str)?.into();
+
+    Ok(env.new_object(
+        &class,
+        JNI_NOTE_INFO_CTOR_SIG,
+        &[
+            JValue::Object(&commitment),
+            JValue::Object(&nullifier),
+            JValue::Long(u64_to_jlong(note.value, "value")?),
+            JValue::Long(u64_to_jlong(note.position, "position")?),
+            JValue::Object(&diversifier),
+            JValue::Object(&rho),
+            JValue::Object(&rseed),
+            JValue::Int(u32_to_jint(note.scope, "scope")?),
+            JValue::Object(&ufvk),
+        ],
+    )?)
+}
+
+pub(super) fn make_jni_witness_data_array<'local>(
+    env: &mut JNIEnv<'local>,
+    witnesses: Vec<WitnessData>,
+) -> anyhow::Result<jobjectArray> {
+    let len = usize_to_jint(witnesses.len(), "witnesses length")?;
+    let class = env.find_class(JNI_WITNESS_DATA)?;
+    let mut witnesses = witnesses.into_iter().enumerate();
+    if let Some((_, first)) = witnesses.next() {
+        let first = make_jni_witness_data(env, first)?;
+        let array = env.new_object_array(len, &class, &first)?;
+        for (index, witness) in witnesses {
+            let witness = make_jni_witness_data(env, witness)?;
+            env.set_object_array_element(
+                &array,
+                usize_to_jint(index, "witnesses index")?,
+                witness,
+            )?;
+        }
+        Ok(array.into_raw())
+    } else {
+        Ok(env.new_object_array(0, &class, JObject::null())?.into_raw())
+    }
+}
+
+fn make_jni_witness_data<'local>(
+    env: &mut JNIEnv<'local>,
+    witness: WitnessData,
+) -> anyhow::Result<JObject<'local>> {
+    let class = env.find_class(JNI_WITNESS_DATA)?;
+    let note_commitment = make_jni_fixed_bytes(
+        env,
+        witness.note_commitment,
+        "note_commitment",
+        PROTOCOL_FIELD_BYTES,
+    )?;
+    let root = make_jni_fixed_bytes(env, witness.root, "root", PROTOCOL_FIELD_BYTES)?;
+    let auth_path = make_jni_fixed_byte_array_vec(
+        env,
+        witness.auth_path,
+        "auth_path",
+        ORCHARD_WITNESS_PATH_DEPTH,
+        PROTOCOL_FIELD_BYTES,
+    )?;
+    let auth_path = JObject::from(auth_path);
+
+    Ok(env.new_object(
+        &class,
+        JNI_WITNESS_DATA_CTOR_SIG,
+        &[
+            JValue::Object(&note_commitment),
+            JValue::Long(u64_to_jlong(witness.position, "position")?),
+            JValue::Object(&root),
+            JValue::Object(&auth_path),
+        ],
+    )?)
+}
+
 /// Builds the Kotlin hotkey JNI model after enforcing the expected key widths.
 /// The secret key is intentionally not surfaced across JNI.
 pub(super) fn make_jni_voting_hotkey<'local>(
@@ -869,6 +994,101 @@ pub(super) fn require_round_phase_for_delegation_construction(
     }
 
     Ok(())
+}
+
+pub(super) fn select_bundle_notes(
+    conn: &rusqlite::Connection,
+    round_id: &str,
+    wallet_id: &str,
+    bundle_index: u32,
+    notes: &[NoteInfo],
+) -> anyhow::Result<Vec<NoteInfo>> {
+    let positions = voting::storage::queries::load_bundle_note_positions(
+        conn,
+        round_id,
+        wallet_id,
+        bundle_index,
+    )
+    .map_err(|e| anyhow!("load_bundle_note_positions: {}", e))?;
+
+    let mut notes_by_position = HashMap::with_capacity(notes.len());
+    for note in notes.iter().cloned() {
+        let position = note.position;
+        if notes_by_position.insert(position, note).is_some() {
+            return Err(anyhow!(
+                "duplicate note position {} in provided notes",
+                position
+            ));
+        }
+    }
+
+    positions
+        .into_iter()
+        .map(|position| {
+            notes_by_position.remove(&position).ok_or_else(|| {
+                anyhow!(
+                    "bundle {} is missing note position {} from provided notes",
+                    bundle_index,
+                    position
+                )
+            })
+        })
+        .collect()
+}
+
+pub(super) fn replace_bundle_witnesses(
+    conn: &rusqlite::Connection,
+    round_id: &str,
+    wallet_id: &str,
+    bundle_index: u32,
+    witnesses: &[WitnessData],
+) -> anyhow::Result<()> {
+    conn.execute(
+        "DELETE FROM witnesses
+         WHERE round_id = :round_id AND wallet_id = :wallet_id AND bundle_index = :bundle_index",
+        named_params! {
+            ":round_id": round_id,
+            ":wallet_id": wallet_id,
+            ":bundle_index": bundle_index as i64,
+        },
+    )
+    .map_err(|e| anyhow!("clear_witnesses: {}", e))?;
+
+    voting::storage::queries::store_witnesses(conn, round_id, wallet_id, bundle_index, witnesses)
+        .map_err(|e| anyhow!("store_witnesses: {}", e))
+}
+
+pub(super) fn received_note_to_note_info(
+    note: &zcash_client_backend::wallet::ReceivedNote<
+        zcash_client_sqlite::ReceivedNoteId,
+        orchard::note::Note,
+    >,
+    ufvk: &UnifiedFullViewingKey,
+    network: &Network,
+) -> anyhow::Result<NoteInfo> {
+    let orchard_note = note.note();
+    let fvk = ufvk
+        .orchard()
+        .ok_or_else(|| anyhow!("UFVK has no Orchard component"))?;
+
+    let nullifier = orchard_note.nullifier(fvk);
+    let cmx: orchard::note::ExtractedNoteCommitment = orchard_note.commitment().into();
+    let scope = match note.spending_key_scope() {
+        Scope::External => 0u32,
+        Scope::Internal => 1u32,
+    };
+
+    Ok(NoteInfo {
+        commitment: cmx.to_bytes().to_vec(),
+        nullifier: nullifier.to_bytes().to_vec(),
+        value: orchard_note.value().inner(),
+        position: u64::from(note.note_commitment_tree_position()),
+        diversifier: orchard_note.recipient().diversifier().as_array().to_vec(),
+        rho: orchard_note.rho().to_bytes().to_vec(),
+        rseed: orchard_note.rseed().as_bytes().to_vec(),
+        scope,
+        ufvk_str: ufvk.encode(network),
+    })
 }
 
 #[cfg(test)]

--- a/backend-lib/src/main/rust/voting/helpers.rs
+++ b/backend-lib/src/main/rust/voting/helpers.rs
@@ -551,9 +551,11 @@ pub(super) fn make_jni_note_info_array<'local>(
     if let Some((_, first)) = notes.next() {
         let first = make_jni_note_info(env, first)?;
         let array = env.new_object_array(len, &class, &first)?;
+        env.delete_local_ref(first)?;
         for (index, note) in notes {
             let note = make_jni_note_info(env, note)?;
-            env.set_object_array_element(&array, usize_to_jint(index, "notes index")?, note)?;
+            env.set_object_array_element(&array, usize_to_jint(index, "notes index")?, &note)?;
+            env.delete_local_ref(note)?;
         }
         Ok(array.into_raw())
     } else {
@@ -565,35 +567,38 @@ fn make_jni_note_info<'local>(
     env: &mut JNIEnv<'local>,
     note: NoteInfo,
 ) -> anyhow::Result<JObject<'local>> {
-    let class = env.find_class(JNI_NOTE_INFO)?;
-    let commitment =
-        make_jni_fixed_bytes(env, note.commitment, "commitment", PROTOCOL_FIELD_BYTES)?;
-    let nullifier = make_jni_fixed_bytes(env, note.nullifier, "nullifier", PROTOCOL_FIELD_BYTES)?;
-    let diversifier = make_jni_fixed_bytes(
-        env,
-        note.diversifier,
-        "diversifier",
-        ORCHARD_DIVERSIFIER_BYTES,
-    )?;
-    let rho = make_jni_fixed_bytes(env, note.rho, "rho", PROTOCOL_FIELD_BYTES)?;
-    let rseed = make_jni_fixed_bytes(env, note.rseed, "rseed", PROTOCOL_FIELD_BYTES)?;
-    let ufvk: JObject<'local> = env.new_string(note.ufvk_str)?.into();
+    env.with_local_frame_returning_local(16, |env| {
+        let class = env.find_class(JNI_NOTE_INFO)?;
+        let commitment =
+            make_jni_fixed_bytes(env, note.commitment, "commitment", PROTOCOL_FIELD_BYTES)?;
+        let nullifier =
+            make_jni_fixed_bytes(env, note.nullifier, "nullifier", PROTOCOL_FIELD_BYTES)?;
+        let diversifier = make_jni_fixed_bytes(
+            env,
+            note.diversifier,
+            "diversifier",
+            ORCHARD_DIVERSIFIER_BYTES,
+        )?;
+        let rho = make_jni_fixed_bytes(env, note.rho, "rho", PROTOCOL_FIELD_BYTES)?;
+        let rseed = make_jni_fixed_bytes(env, note.rseed, "rseed", PROTOCOL_FIELD_BYTES)?;
+        let ufvk: JObject<'_> = env.new_string(note.ufvk_str)?.into();
 
-    Ok(env.new_object(
-        &class,
-        JNI_NOTE_INFO_CTOR_SIG,
-        &[
-            JValue::Object(&commitment),
-            JValue::Object(&nullifier),
-            JValue::Long(u64_to_jlong(note.value, "value")?),
-            JValue::Long(u64_to_jlong(note.position, "position")?),
-            JValue::Object(&diversifier),
-            JValue::Object(&rho),
-            JValue::Object(&rseed),
-            JValue::Int(u32_to_jint(note.scope, "scope")?),
-            JValue::Object(&ufvk),
-        ],
-    )?)
+        Ok(env.new_object(
+            &class,
+            JNI_NOTE_INFO_CTOR_SIG,
+            &[
+                JValue::Object(&commitment),
+                JValue::Object(&nullifier),
+                JValue::Long(u64_to_jlong(note.value, "value")?),
+                JValue::Long(u64_to_jlong(note.position, "position")?),
+                JValue::Object(&diversifier),
+                JValue::Object(&rho),
+                JValue::Object(&rseed),
+                JValue::Int(u32_to_jint(note.scope, "scope")?),
+                JValue::Object(&ufvk),
+            ],
+        )?)
+    })
 }
 
 pub(super) fn make_jni_witness_data_array<'local>(
@@ -606,13 +611,15 @@ pub(super) fn make_jni_witness_data_array<'local>(
     if let Some((_, first)) = witnesses.next() {
         let first = make_jni_witness_data(env, first)?;
         let array = env.new_object_array(len, &class, &first)?;
+        env.delete_local_ref(first)?;
         for (index, witness) in witnesses {
             let witness = make_jni_witness_data(env, witness)?;
             env.set_object_array_element(
                 &array,
                 usize_to_jint(index, "witnesses index")?,
-                witness,
+                &witness,
             )?;
+            env.delete_local_ref(witness)?;
         }
         Ok(array.into_raw())
     } else {
@@ -624,33 +631,35 @@ fn make_jni_witness_data<'local>(
     env: &mut JNIEnv<'local>,
     witness: WitnessData,
 ) -> anyhow::Result<JObject<'local>> {
-    let class = env.find_class(JNI_WITNESS_DATA)?;
-    let note_commitment = make_jni_fixed_bytes(
-        env,
-        witness.note_commitment,
-        "note_commitment",
-        PROTOCOL_FIELD_BYTES,
-    )?;
-    let root = make_jni_fixed_bytes(env, witness.root, "root", PROTOCOL_FIELD_BYTES)?;
-    let auth_path = make_jni_fixed_byte_array_vec(
-        env,
-        witness.auth_path,
-        "auth_path",
-        ORCHARD_WITNESS_PATH_DEPTH,
-        PROTOCOL_FIELD_BYTES,
-    )?;
-    let auth_path = JObject::from(auth_path);
+    env.with_local_frame_returning_local(48, |env| {
+        let class = env.find_class(JNI_WITNESS_DATA)?;
+        let note_commitment = make_jni_fixed_bytes(
+            env,
+            witness.note_commitment,
+            "note_commitment",
+            PROTOCOL_FIELD_BYTES,
+        )?;
+        let root = make_jni_fixed_bytes(env, witness.root, "root", PROTOCOL_FIELD_BYTES)?;
+        let auth_path = make_jni_fixed_byte_array_vec(
+            env,
+            witness.auth_path,
+            "auth_path",
+            ORCHARD_WITNESS_PATH_DEPTH,
+            PROTOCOL_FIELD_BYTES,
+        )?;
+        let auth_path = JObject::from(auth_path);
 
-    Ok(env.new_object(
-        &class,
-        JNI_WITNESS_DATA_CTOR_SIG,
-        &[
-            JValue::Object(&note_commitment),
-            JValue::Long(u64_to_jlong(witness.position, "position")?),
-            JValue::Object(&root),
-            JValue::Object(&auth_path),
-        ],
-    )?)
+        Ok(env.new_object(
+            &class,
+            JNI_WITNESS_DATA_CTOR_SIG,
+            &[
+                JValue::Object(&note_commitment),
+                JValue::Long(u64_to_jlong(witness.position, "position")?),
+                JValue::Object(&root),
+                JValue::Object(&auth_path),
+            ],
+        )?)
+    })
 }
 
 /// Builds the Kotlin hotkey JNI model after enforcing the expected key widths.

--- a/backend-lib/src/main/rust/voting/helpers.rs
+++ b/backend-lib/src/main/rust/voting/helpers.rs
@@ -24,9 +24,10 @@ const JNI_DELEGATION_SUBMISSION_RESULT: &str =
 
 // Must match JniNoteInfo(ByteArray, ByteArray, Long, Long, ByteArray,
 // ByteArray, ByteArray, Int, String) in JniVotingModels.kt.
+// Guarded by JniVotingModelsTest.
 const JNI_NOTE_INFO_CTOR_SIG: &str = "([B[BJJ[B[B[BILjava/lang/String;)V";
 // Must match JniWitnessData(ByteArray, Long, ByteArray, Array<ByteArray>)
-// in JniVotingModels.kt.
+// in JniVotingModels.kt. Guarded by JniVotingModelsTest.
 const JNI_WITNESS_DATA_CTOR_SIG: &str = "([BJ[B[[B)V";
 // Must match JniVotingHotkey(ByteArray, String) in JniVotingModels.kt.
 const JNI_VOTING_HOTKEY_CTOR_SIG: &str = "([BLjava/lang/String;)V";

--- a/backend-lib/src/main/rust/voting/helpers.rs
+++ b/backend-lib/src/main/rust/voting/helpers.rs
@@ -1022,7 +1022,7 @@ pub(super) fn select_bundle_notes(
         }
     }
 
-    positions
+    let bundle_notes = positions
         .into_iter()
         .map(|position| {
             notes_by_position.remove(&position).ok_or_else(|| {
@@ -1033,7 +1033,18 @@ pub(super) fn select_bundle_notes(
                 )
             })
         })
-        .collect()
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    voting::storage::queries::require_bundle_notes(
+        conn,
+        round_id,
+        wallet_id,
+        bundle_index,
+        &bundle_notes,
+    )
+    .map_err(|e| anyhow!("require_bundle_notes: {}", e))?;
+
+    Ok(bundle_notes)
 }
 
 pub(super) fn replace_bundle_witnesses(
@@ -1043,7 +1054,22 @@ pub(super) fn replace_bundle_witnesses(
     bundle_index: u32,
     witnesses: &[WitnessData],
 ) -> anyhow::Result<()> {
-    conn.execute(
+    for witness in witnesses {
+        let valid = voting::witness::verify_witness(witness)
+            .map_err(|e| anyhow!("verify_witness: {}", e))?;
+        if !valid {
+            return Err(anyhow!(
+                "witness verification failed for position {}",
+                witness.position
+            ));
+        }
+    }
+
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| anyhow!("begin replace witnesses transaction: {}", e))?;
+
+    tx.execute(
         "DELETE FROM witnesses
          WHERE round_id = :round_id AND wallet_id = :wallet_id AND bundle_index = :bundle_index",
         named_params! {
@@ -1054,8 +1080,11 @@ pub(super) fn replace_bundle_witnesses(
     )
     .map_err(|e| anyhow!("clear_witnesses: {}", e))?;
 
-    voting::storage::queries::store_witnesses(conn, round_id, wallet_id, bundle_index, witnesses)
-        .map_err(|e| anyhow!("store_witnesses: {}", e))
+    voting::storage::queries::store_witnesses(&tx, round_id, wallet_id, bundle_index, witnesses)
+        .map_err(|e| anyhow!("store_witnesses: {}", e))?;
+
+    tx.commit()
+        .map_err(|e| anyhow!("commit replace witnesses transaction: {}", e))
 }
 
 pub(super) fn received_note_to_note_info(
@@ -1074,8 +1103,8 @@ pub(super) fn received_note_to_note_info(
     let nullifier = orchard_note.nullifier(fvk);
     let cmx: orchard::note::ExtractedNoteCommitment = orchard_note.commitment().into();
     let scope = match note.spending_key_scope() {
-        Scope::External => 0u32,
-        Scope::Internal => 1u32,
+        Scope::External => NOTE_SCOPE_EXTERNAL,
+        Scope::Internal => NOTE_SCOPE_INTERNAL,
     };
 
     Ok(NoteInfo {

--- a/backend-lib/src/main/rust/voting/helpers.rs
+++ b/backend-lib/src/main/rust/voting/helpers.rs
@@ -1049,7 +1049,7 @@ pub(super) fn select_bundle_notes(
 }
 
 pub(super) fn replace_bundle_witnesses(
-    conn: &rusqlite::Connection,
+    conn: &mut rusqlite::Connection,
     round_id: &str,
     wallet_id: &str,
     bundle_index: u32,
@@ -1067,7 +1067,7 @@ pub(super) fn replace_bundle_witnesses(
     }
 
     let tx = conn
-        .unchecked_transaction()
+        .transaction()
         .map_err(|e| anyhow!("begin replace witnesses transaction: {}", e))?;
 
     tx.execute(

--- a/backend-lib/src/main/rust/voting/notes.rs
+++ b/backend-lib/src/main/rust/voting/notes.rs
@@ -2,6 +2,39 @@ use super::db::*;
 use super::helpers::*;
 use super::*;
 
+/// Validate that a cached lightwalletd TreeState is anchored to the voting
+/// round it will be used for.
+///
+/// Witness generation trusts the cached Orchard frontier as the historical
+/// checkpoint input. The generated Merkle path can verify against that
+/// frontier's own root, so also enforce that the frontier is exactly the round
+/// snapshot: same block height and same note commitment tree root.
+fn validate_cached_tree_state_for_round(
+    tree_state: &zcash_client_backend::proto::service::TreeState,
+    orchard_root: &[u8],
+    params: &voting::types::VotingRoundParams,
+) -> anyhow::Result<()> {
+    if tree_state.height != params.snapshot_height {
+        return Err(anyhow!(
+            "cached TreeState height {} does not match round snapshot_height {}",
+            tree_state.height,
+            params.snapshot_height
+        ));
+    }
+
+    if orchard_root != params.nc_root.as_slice() {
+        return Err(anyhow!(
+            "cached TreeState orchard root does not match round nc_root"
+        ));
+    }
+
+    Ok(())
+}
+
+// =============================================================================
+// C. Note setup
+// =============================================================================
+
 #[unsafe(no_mangle)]
 pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_computeBundleSetupNative<
     'local,
@@ -16,6 +49,186 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_com
         make_jni_bundle_setup_result(env, count, weight, &bundle_weights)
     });
     unwrap_exc_or(&mut env, res, JObject::null().into_raw())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_storeTreeStateNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_handle: jlong,
+    round_id: JString<'local>,
+    tree_state_bytes: JByteArray<'local>,
+) -> jboolean {
+    let res = catch_unwind(&mut env, |env| {
+        let db = db_from_handle(db_handle)?;
+        let _access_lock = db.access_lock()?;
+        let bytes = java_bytes(env, &tree_state_bytes, "treeStateBytes")?;
+        db.store_tree_state(&java_string_to_rust(env, &round_id)?, &bytes)
+            .map_err(|e| anyhow!("store_tree_state: {}", e))?;
+        Ok(JNI_TRUE)
+    });
+    unwrap_exc_or(&mut env, res, JNI_FALSE)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_getWalletNotesNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    wallet_db_path: JString<'local>,
+    snapshot_height: jlong,
+    network_id: jint,
+    account_uuid_bytes: JByteArray<'local>,
+) -> jobjectArray {
+    let res = catch_unwind(&mut env, |env| {
+        use zcash_client_backend::data_api::{Account, WalletRead};
+        use zcash_protocol::consensus::BlockHeight;
+
+        let path = java_string_to_rust(env, &wallet_db_path)?;
+        let network = network_from_id(network_id)?;
+        let height = BlockHeight::from_u32(jlong_to_u32(snapshot_height, "snapshot_height")?);
+        let account_uuid_bytes =
+            java_fixed_bytes::<ACCOUNT_UUID_BYTES>(env, &account_uuid_bytes, "accountUuidBytes")?;
+        let account_uuid =
+            zcash_client_sqlite::AccountUuid::from_uuid(uuid::Uuid::from_bytes(account_uuid_bytes));
+
+        let wallet_db = zcash_client_sqlite::WalletDb::for_path(
+            &path,
+            network,
+            zcash_client_sqlite::util::SystemClock,
+            rand::rngs::OsRng,
+        )
+        .map_err(|e| anyhow!("failed to open wallet DB: {}", e))?;
+
+        let account = wallet_db
+            .get_account(account_uuid)
+            .map_err(|e| anyhow!("get_account: {}", e))?
+            .ok_or_else(|| anyhow!("account not found in wallet DB"))?;
+        let ufvk = account
+            .ufvk()
+            .ok_or_else(|| anyhow!("account has no UFVK"))?
+            .clone();
+
+        let notes = wallet_db
+            .get_unspent_orchard_notes_at_historical_height(account_uuid, height)
+            .map_err(|e| anyhow!("get_unspent_orchard_notes_at_historical_height: {}", e))?;
+
+        let notes = notes
+            .iter()
+            .map(|note| received_note_to_note_info(note, &ufvk, &network))
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        make_jni_note_info_array(env, notes)
+    });
+    unwrap_exc_or(&mut env, res, std::ptr::null_mut())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_generateNoteWitnessesNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_handle: jlong,
+    round_id: JString<'local>,
+    bundle_index: jint,
+    wallet_db_path: JString<'local>,
+    network_id: jint,
+    notes: JObjectArray<'local>,
+) -> jobjectArray {
+    let res = catch_unwind(&mut env, |env| {
+        use incrementalmerkletree::Position;
+        use orchard::tree::MerkleHashOrchard;
+        use prost::Message;
+        use zcash_client_backend::proto::service::TreeState;
+        use zcash_protocol::consensus::BlockHeight;
+
+        let db = db_from_handle(db_handle)?;
+        let _access_lock = db.access_lock()?;
+        let round_id = java_string_to_rust(env, &round_id)?;
+        let wallet_path = java_string_to_rust(env, &wallet_db_path)?;
+        let bundle_index = jint_to_u32(bundle_index, "bundle_index")?;
+        let network = network_from_id(network_id)?;
+
+        let core_notes = java_note_info_array(env, &notes, "notes")?;
+
+        let conn = db.conn();
+        let wallet_id = db.wallet_id();
+        let bundle_notes =
+            select_bundle_notes(&conn, &round_id, &wallet_id, bundle_index, &core_notes)?;
+        let tree_state_bytes =
+            voting::storage::queries::load_tree_state(&conn, &round_id, &wallet_id)
+                .map_err(|e| anyhow!("load_tree_state: {}", e))?;
+        let params = voting::storage::queries::load_round_params(&conn, &round_id, &wallet_id)
+            .map_err(|e| anyhow!("load_round_params: {}", e))?;
+        drop(conn);
+
+        let tree_state = TreeState::decode(tree_state_bytes.as_slice())
+            .map_err(|e| anyhow!("decode TreeState: {}", e))?;
+        let orchard_ct = tree_state
+            .orchard_tree()
+            .map_err(|e| anyhow!("parse orchard_tree: {}", e))?;
+        let frontier_root = orchard_ct.root();
+        let frontier_root_bytes = frontier_root.to_bytes();
+        validate_cached_tree_state_for_round(&tree_state, &frontier_root_bytes[..], &params)?;
+        let nonempty_frontier = orchard_ct
+            .to_frontier()
+            .take()
+            .ok_or_else(|| anyhow!("empty orchard frontier - no Orchard activity at snapshot"))?;
+
+        let height =
+            BlockHeight::from_u32(u32::try_from(params.snapshot_height).map_err(|_| {
+                anyhow!(
+                    "stored snapshot_height must be in range 0..=u32::MAX, got {}",
+                    params.snapshot_height
+                )
+            })?);
+
+        let wallet_db = zcash_client_sqlite::WalletDb::for_path(
+            &wallet_path,
+            network,
+            zcash_client_sqlite::util::SystemClock,
+            rand::rngs::OsRng,
+        )
+        .map_err(|e| anyhow!("open wallet DB: {}", e))?;
+
+        let positions = bundle_notes
+            .iter()
+            .map(|note| Position::from(note.position))
+            .collect::<Vec<_>>();
+
+        let merkle_paths = wallet_db
+            .generate_orchard_witnesses_at_historical_height(&positions, nonempty_frontier, height)
+            .map_err(|e| anyhow!("generate_orchard_witnesses_at_historical_height: {}", e))?;
+
+        let root_bytes = frontier_root_bytes.to_vec();
+        let witnesses = merkle_paths
+            .into_iter()
+            .zip(bundle_notes.iter())
+            .map(|(path, note)| {
+                let auth_path = path
+                    .path_elems()
+                    .iter()
+                    .map(|hash: &MerkleHashOrchard| hash.to_bytes().to_vec())
+                    .collect();
+                WitnessData {
+                    note_commitment: note.commitment.clone(),
+                    position: note.position,
+                    root: root_bytes.clone(),
+                    auth_path,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let conn = db.conn();
+        replace_bundle_witnesses(&conn, &round_id, &wallet_id, bundle_index, &witnesses)?;
+
+        make_jni_witness_data_array(env, witnesses)
+    });
+    unwrap_exc_or(&mut env, res, std::ptr::null_mut())
 }
 
 #[unsafe(no_mangle)]

--- a/backend-lib/src/main/rust/voting/notes.rs
+++ b/backend-lib/src/main/rust/voting/notes.rs
@@ -162,32 +162,36 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_get
         let account_uuid =
             zcash_client_sqlite::AccountUuid::from_uuid(uuid::Uuid::from_bytes(account_uuid_bytes));
 
-        let wallet_db = open_wallet_db_read_only(&path, network)?;
-        let fully_scanned_height = wallet_db
-            .block_fully_scanned()
-            .map_err(|e| anyhow!("block_fully_scanned: {}", e))?
-            .map(|metadata| metadata.block_height());
-        require_fully_scanned_to_snapshot(fully_scanned_height, height)?;
+        let mut wallet_db = open_wallet_db_read_only(&path, network)?;
+        let notes = wallet_db.transactionally(|wallet_db| {
+            let fully_scanned_height = wallet_db
+                .block_fully_scanned()
+                .map_err(|e| anyhow!("block_fully_scanned: {}", e))?
+                .map(|metadata| metadata.block_height());
+            require_fully_scanned_to_snapshot(fully_scanned_height, height)?;
 
-        let account = wallet_db
-            .get_account(account_uuid)
-            .map_err(|e| anyhow!("get_account: {}", e))?
-            .ok_or_else(|| anyhow!("account not found in wallet DB"))?;
-        let ufvk = account
-            .ufvk()
-            .ok_or_else(|| anyhow!("account has no UFVK"))?
-            .clone();
+            let account = wallet_db
+                .get_account(account_uuid)
+                .map_err(|e| anyhow!("get_account: {}", e))?
+                .ok_or_else(|| anyhow!("account not found in wallet DB"))?;
+            let ufvk = account
+                .ufvk()
+                .ok_or_else(|| anyhow!("account has no UFVK"))?
+                .clone();
 
-        // Upstream interprets "unspent" at the requested height: spends mined
-        // after the snapshot remain eligible for that snapshot.
-        let notes = wallet_db
-            .get_unspent_orchard_notes_at_historical_height(account_uuid, height)
-            .map_err(|e| anyhow!("get_unspent_orchard_notes_at_historical_height: {}", e))?;
+            // Upstream interprets "unspent" at the requested height: spends mined
+            // after the snapshot remain eligible for that snapshot.
+            let notes = wallet_db
+                .get_unspent_orchard_notes_at_historical_height(account_uuid, height)
+                .map_err(|e| {
+                    anyhow!("get_unspent_orchard_notes_at_historical_height: {}", e)
+                })?;
 
-        let notes = notes
-            .iter()
-            .map(|note| received_note_to_note_info(note, &ufvk, &network))
-            .collect::<anyhow::Result<Vec<_>>>()?;
+            notes
+                .iter()
+                .map(|note| received_note_to_note_info(note, &ufvk, &network))
+                .collect::<anyhow::Result<Vec<_>>>()
+        })?;
 
         make_jni_note_info_array(env, notes)
     });

--- a/backend-lib/src/main/rust/voting/notes.rs
+++ b/backend-lib/src/main/rust/voting/notes.rs
@@ -255,15 +255,23 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_gen
                 )
             })?);
 
-        let wallet_db = open_wallet_db_read_only(&wallet_path, network)?;
-
         let positions = bundle_notes
             .iter()
             .map(|note| Position::from(note.position))
             .collect::<Vec<_>>();
 
+        let mut wallet_db = open_wallet_db_read_only(&wallet_path, network)?;
+        // Keep shard roots, shard rows, and cap reads on one read-transaction snapshot.
         let merkle_paths = wallet_db
-            .generate_orchard_witnesses_at_historical_height(&positions, nonempty_frontier, height)
+            .transactionally(|wallet_db| {
+                wallet_db
+                    .generate_orchard_witnesses_at_historical_height(
+                        &positions,
+                        nonempty_frontier,
+                        height,
+                    )
+                    .map_err(anyhow::Error::from)
+            })
             .map_err(|e| anyhow!("generate_orchard_witnesses_at_historical_height: {}", e))?;
 
         let root_bytes = frontier_root_bytes.to_vec();

--- a/backend-lib/src/main/rust/voting/notes.rs
+++ b/backend-lib/src/main/rust/voting/notes.rs
@@ -31,6 +31,28 @@ fn validate_cached_tree_state_for_round(
     Ok(())
 }
 
+type ReadOnlyWalletDb = zcash_client_sqlite::WalletDb<
+    rusqlite::Connection,
+    Network,
+    zcash_client_sqlite::util::SystemClock,
+    rand::rngs::OsRng,
+>;
+
+fn open_wallet_db_read_only(path: &str, network: Network) -> anyhow::Result<ReadOnlyWalletDb> {
+    let conn =
+        rusqlite::Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .map_err(|e| anyhow!("open wallet DB read-only: {}", e))?;
+    rusqlite::vtab::array::load_module(&conn)
+        .map_err(|e| anyhow!("load sqlite array module: {}", e))?;
+
+    Ok(zcash_client_sqlite::WalletDb::from_connection(
+        conn,
+        network,
+        zcash_client_sqlite::util::SystemClock,
+        rand::rngs::OsRng,
+    ))
+}
+
 // =============================================================================
 // C. Note setup
 // =============================================================================
@@ -95,13 +117,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_get
         let account_uuid =
             zcash_client_sqlite::AccountUuid::from_uuid(uuid::Uuid::from_bytes(account_uuid_bytes));
 
-        let wallet_db = zcash_client_sqlite::WalletDb::for_path(
-            &path,
-            network,
-            zcash_client_sqlite::util::SystemClock,
-            rand::rngs::OsRng,
-        )
-        .map_err(|e| anyhow!("failed to open wallet DB: {}", e))?;
+        let wallet_db = open_wallet_db_read_only(&path, network)?;
 
         let account = wallet_db
             .get_account(account_uuid)
@@ -187,13 +203,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_gen
                 )
             })?);
 
-        let wallet_db = zcash_client_sqlite::WalletDb::for_path(
-            &wallet_path,
-            network,
-            zcash_client_sqlite::util::SystemClock,
-            rand::rngs::OsRng,
-        )
-        .map_err(|e| anyhow!("open wallet DB: {}", e))?;
+        let wallet_db = open_wallet_db_read_only(&wallet_path, network)?;
 
         let positions = bundle_notes
             .iter()

--- a/backend-lib/src/main/rust/voting/notes.rs
+++ b/backend-lib/src/main/rust/voting/notes.rs
@@ -128,6 +128,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_get
             .ok_or_else(|| anyhow!("account has no UFVK"))?
             .clone();
 
+        // Upstream interprets "unspent" at the requested height: spends mined
+        // after the snapshot remain eligible for that snapshot.
         let notes = wallet_db
             .get_unspent_orchard_notes_at_historical_height(account_uuid, height)
             .map_err(|e| anyhow!("get_unspent_orchard_notes_at_historical_height: {}", e))?;

--- a/backend-lib/src/main/rust/voting/notes.rs
+++ b/backend-lib/src/main/rust/voting/notes.rs
@@ -235,8 +235,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_gen
             })
             .collect::<Vec<_>>();
 
-        let conn = db.conn();
-        replace_bundle_witnesses(&conn, &round_id, &wallet_id, bundle_index, &witnesses)?;
+        let mut conn = db.conn();
+        replace_bundle_witnesses(&mut conn, &round_id, &wallet_id, bundle_index, &witnesses)?;
 
         make_jni_witness_data_array(env, witnesses)
     });

--- a/backend-lib/src/main/rust/voting/notes.rs
+++ b/backend-lib/src/main/rust/voting/notes.rs
@@ -235,8 +235,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_gen
             })
             .collect::<Vec<_>>();
 
-        let mut conn = db.conn();
-        replace_bundle_witnesses(&mut conn, &round_id, &wallet_id, bundle_index, &witnesses)?;
+        replace_bundle_witnesses(&db, &round_id, bundle_index, &witnesses)?;
 
         make_jni_witness_data_array(env, witnesses)
     });

--- a/backend-lib/src/main/rust/voting/notes.rs
+++ b/backend-lib/src/main/rust/voting/notes.rs
@@ -31,6 +31,43 @@ fn validate_cached_tree_state_for_round(
     Ok(())
 }
 
+fn validate_tree_state_bytes_for_round(
+    tree_state_bytes: &[u8],
+    params: &voting::types::VotingRoundParams,
+) -> anyhow::Result<()> {
+    use prost::Message;
+    use zcash_client_backend::proto::service::TreeState;
+
+    let tree_state =
+        TreeState::decode(tree_state_bytes).map_err(|e| anyhow!("decode TreeState: {}", e))?;
+    let orchard_ct = tree_state
+        .orchard_tree()
+        .map_err(|e| anyhow!("parse orchard_tree: {}", e))?;
+    let orchard_root = orchard_ct.root().to_bytes();
+    validate_cached_tree_state_for_round(&tree_state, &orchard_root[..], params)
+}
+
+fn require_fully_scanned_to_snapshot(
+    fully_scanned_height: Option<zcash_protocol::consensus::BlockHeight>,
+    snapshot_height: zcash_protocol::consensus::BlockHeight,
+) -> anyhow::Result<()> {
+    let snapshot_height_u32 = u32::from(snapshot_height);
+    let Some(fully_scanned_height) = fully_scanned_height else {
+        return Err(anyhow!(
+            "wallet DB has no fully scanned height; snapshot_height={snapshot_height_u32}"
+        ));
+    };
+
+    let fully_scanned_height_u32 = u32::from(fully_scanned_height);
+    if fully_scanned_height_u32 < snapshot_height_u32 {
+        return Err(anyhow!(
+            "wallet DB fully scanned height {fully_scanned_height_u32} is below snapshot_height {snapshot_height_u32}"
+        ));
+    }
+
+    Ok(())
+}
+
 type ReadOnlyWalletDb = zcash_client_sqlite::WalletDb<
     rusqlite::Connection,
     Network,
@@ -87,7 +124,15 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_sto
         let db = db_from_handle(db_handle)?;
         let _access_lock = db.access_lock()?;
         let bytes = java_bytes(env, &tree_state_bytes, "treeStateBytes")?;
-        db.store_tree_state(&java_string_to_rust(env, &round_id)?, &bytes)
+        let round_id = java_string_to_rust(env, &round_id)?;
+        let params = {
+            let conn = db.conn();
+            let wallet_id = db.wallet_id();
+            voting::storage::queries::load_round_params(&conn, &round_id, &wallet_id)
+                .map_err(|e| anyhow!("load_round_params: {}", e))?
+        };
+        validate_tree_state_bytes_for_round(&bytes, &params)?;
+        db.store_tree_state(&round_id, &bytes)
             .map_err(|e| anyhow!("store_tree_state: {}", e))?;
         Ok(())
     });
@@ -118,6 +163,11 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_get
             zcash_client_sqlite::AccountUuid::from_uuid(uuid::Uuid::from_bytes(account_uuid_bytes));
 
         let wallet_db = open_wallet_db_read_only(&path, network)?;
+        let fully_scanned_height = wallet_db
+            .block_fully_scanned()
+            .map_err(|e| anyhow!("block_fully_scanned: {}", e))?
+            .map(|metadata| metadata.block_height());
+        require_fully_scanned_to_snapshot(fully_scanned_height, height)?;
 
         let account = wallet_db
             .get_account(account_uuid)
@@ -299,4 +349,38 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_gen
         make_jni_voting_hotkey(env, hotkey)
     });
     unwrap_exc_or(&mut env, res, JObject::null().into_raw())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zcash_protocol::consensus::BlockHeight;
+
+    #[test]
+    fn fully_scanned_guard_allows_snapshot_height() {
+        require_fully_scanned_to_snapshot(
+            Some(BlockHeight::from_u32(100)),
+            BlockHeight::from_u32(100),
+        )
+        .unwrap();
+        require_fully_scanned_to_snapshot(
+            Some(BlockHeight::from_u32(101)),
+            BlockHeight::from_u32(100),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn fully_scanned_guard_rejects_missing_or_low_height() {
+        let missing =
+            require_fully_scanned_to_snapshot(None, BlockHeight::from_u32(100)).unwrap_err();
+        assert!(missing.to_string().contains("no fully scanned height"));
+
+        let low = require_fully_scanned_to_snapshot(
+            Some(BlockHeight::from_u32(99)),
+            BlockHeight::from_u32(100),
+        )
+        .unwrap_err();
+        assert!(low.to_string().contains("below snapshot_height"));
+    }
 }

--- a/backend-lib/src/main/rust/voting/notes.rs
+++ b/backend-lib/src/main/rust/voting/notes.rs
@@ -60,16 +60,16 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_sto
     db_handle: jlong,
     round_id: JString<'local>,
     tree_state_bytes: JByteArray<'local>,
-) -> jboolean {
+) {
     let res = catch_unwind(&mut env, |env| {
         let db = db_from_handle(db_handle)?;
         let _access_lock = db.access_lock()?;
         let bytes = java_bytes(env, &tree_state_bytes, "treeStateBytes")?;
         db.store_tree_state(&java_string_to_rust(env, &round_id)?, &bytes)
             .map_err(|e| anyhow!("store_tree_state: {}", e))?;
-        Ok(JNI_TRUE)
+        Ok(())
     });
-    unwrap_exc_or(&mut env, res, JNI_FALSE)
+    unwrap_exc_or(&mut env, res, ())
 }
 
 #[unsafe(no_mangle)]

--- a/backend-lib/src/main/rust/voting/util.rs
+++ b/backend-lib/src/main/rust/voting/util.rs
@@ -1,6 +1,42 @@
 use super::helpers::*;
 use super::*;
 
+#[cfg(feature = "android-test-fixtures")]
+const TEST_TREE_STATE_HASH: &str =
+    "0000000000000000000000000000000000000000000000000000000000000000";
+
+#[cfg(feature = "android-test-fixtures")]
+fn tree_state_fixture(orchard_tree: String) -> zcash_client_backend::proto::service::TreeState {
+    zcash_client_backend::proto::service::TreeState {
+        network: "test".to_string(),
+        height: 1,
+        hash: TEST_TREE_STATE_HASH.to_string(),
+        time: 0,
+        sapling_tree: String::new(),
+        orchard_tree,
+    }
+}
+
+#[cfg(feature = "android-test-fixtures")]
+fn non_empty_orchard_tree_hex() -> anyhow::Result<String> {
+    use incrementalmerkletree::frontier::CommitmentTree;
+    use orchard::tree::MerkleHashOrchard;
+    use zcash_primitives::merkle_tree::write_commitment_tree;
+
+    let mut tree =
+        CommitmentTree::<MerkleHashOrchard, { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 }>::empty();
+    let mut leaf_bytes = [0u8; PROTOCOL_FIELD_BYTES];
+    leaf_bytes[0] = 1;
+    let leaf = MerkleHashOrchard::from_bytes(&leaf_bytes).unwrap();
+    tree.append(leaf)
+        .map_err(|_| anyhow!("append orchard commitment tree leaf"))?;
+
+    let mut tree_bytes = vec![];
+    write_commitment_tree(&tree, &mut tree_bytes)
+        .map_err(|e| anyhow!("write orchard commitment tree: {}", e))?;
+    Ok(hex::encode(tree_bytes))
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_warmProvingCachesNative<
     'local,
@@ -134,17 +170,27 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_tre
 ) -> jbyteArray {
     let res = catch_unwind(&mut env, |env| {
         use prost::Message;
-        use zcash_client_backend::proto::service::TreeState;
 
-        let tree_state = TreeState {
-            network: "test".to_string(),
-            height: 1,
-            hash: String::new(),
-            time: 0,
-            sapling_tree: String::new(),
-            orchard_tree: String::new(),
-        };
+        let tree_state = tree_state_fixture(String::new());
+        Ok(env
+            .byte_array_from_slice(&tree_state.encode_to_vec())?
+            .into_raw())
+    });
+    unwrap_exc_or(&mut env, res, std::ptr::null_mut())
+}
 
+#[cfg(feature = "android-test-fixtures")]
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_nonEmptyTreeStateFixtureNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+) -> jbyteArray {
+    let res = catch_unwind(&mut env, |env| {
+        use prost::Message;
+
+        let tree_state = tree_state_fixture(non_empty_orchard_tree_hex()?);
         Ok(env
             .byte_array_from_slice(&tree_state.encode_to_vec())?
             .into_raw())

--- a/backend-lib/src/main/rust/voting/util.rs
+++ b/backend-lib/src/main/rust/voting/util.rs
@@ -63,12 +63,91 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_ver
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
     witness: JObject<'local>,
-) -> jint {
+) -> jboolean {
     let res = catch_unwind(&mut env, |env| {
         let witness = java_witness_data(env, &witness)?;
         let valid = voting::witness::verify_witness(&witness)
             .map_err(|e| anyhow!("verify_witness: {}", e))?;
-        Ok(if valid { 1 } else { 0 })
+        Ok(if valid { JNI_TRUE } else { JNI_FALSE })
     });
-    unwrap_exc_or(&mut env, res, -1)
+    unwrap_exc_or(&mut env, res, JNI_FALSE)
+}
+
+#[cfg(feature = "android-test-fixtures")]
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_noteInfoArrayFixtureNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+) -> jobjectArray {
+    let res = catch_unwind(&mut env, |env| {
+        make_jni_note_info_array(
+            env,
+            vec![NoteInfo {
+                commitment: vec![0x01; PROTOCOL_FIELD_BYTES],
+                nullifier: vec![0x02; PROTOCOL_FIELD_BYTES],
+                value: 123_456,
+                position: 7,
+                diversifier: vec![0x03; ORCHARD_DIVERSIFIER_BYTES],
+                rho: vec![0x04; PROTOCOL_FIELD_BYTES],
+                rseed: vec![0x05; PROTOCOL_FIELD_BYTES],
+                scope: NOTE_SCOPE_INTERNAL,
+                ufvk_str: "ufvk-fixture".to_string(),
+            }],
+        )
+    });
+    unwrap_exc_or(&mut env, res, std::ptr::null_mut())
+}
+
+#[cfg(feature = "android-test-fixtures")]
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_witnessDataArrayFixtureNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+) -> jobjectArray {
+    let res = catch_unwind(&mut env, |env| {
+        make_jni_witness_data_array(
+            env,
+            vec![WitnessData {
+                note_commitment: vec![0x11; PROTOCOL_FIELD_BYTES],
+                position: 9,
+                root: vec![0x12; PROTOCOL_FIELD_BYTES],
+                auth_path: (0..ORCHARD_WITNESS_PATH_DEPTH)
+                    .map(|index| vec![0x20u8.wrapping_add(index as u8); PROTOCOL_FIELD_BYTES])
+                    .collect(),
+            }],
+        )
+    });
+    unwrap_exc_or(&mut env, res, std::ptr::null_mut())
+}
+
+#[cfg(feature = "android-test-fixtures")]
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_treeStateFixtureNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+) -> jbyteArray {
+    let res = catch_unwind(&mut env, |env| {
+        use prost::Message;
+        use zcash_client_backend::proto::service::TreeState;
+
+        let tree_state = TreeState {
+            network: "test".to_string(),
+            height: 1,
+            hash: String::new(),
+            time: 0,
+            sapling_tree: String::new(),
+            orchard_tree: String::new(),
+        };
+
+        Ok(env
+            .byte_array_from_slice(&tree_state.encode_to_vec())?
+            .into_raw())
+    });
+    unwrap_exc_or(&mut env, res, std::ptr::null_mut())
 }

--- a/backend-lib/src/main/rust/voting/util.rs
+++ b/backend-lib/src/main/rust/voting/util.rs
@@ -1,3 +1,4 @@
+use super::helpers::*;
 use super::*;
 
 #[unsafe(no_mangle)]
@@ -12,4 +13,62 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_war
         Ok(())
     });
     unwrap_exc_or(&mut env, res, ())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_extractOrchardFvkFromUfvkNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    ufvk: JString<'local>,
+    network_id: jint,
+) -> jbyteArray {
+    let res = catch_unwind(&mut env, |env| {
+        let network = network_from_id(network_id)?;
+        let bytes = orchard_fvk_bytes(&java_string_to_rust(env, &ufvk)?, network)?;
+        Ok(env.byte_array_from_slice(&bytes)?.into_raw())
+    });
+    unwrap_exc_or(&mut env, res, std::ptr::null_mut())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_extractNcRootNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    tree_state_bytes: JByteArray<'local>,
+) -> jbyteArray {
+    let res = catch_unwind(&mut env, |env| {
+        use prost::Message;
+        use zcash_client_backend::proto::service::TreeState;
+
+        let bytes = java_bytes(env, &tree_state_bytes, "treeStateBytes")?;
+        let tree_state =
+            TreeState::decode(bytes.as_slice()).map_err(|e| anyhow!("decode TreeState: {}", e))?;
+        let orchard_ct = tree_state
+            .orchard_tree()
+            .map_err(|e| anyhow!("parse orchard_tree: {}", e))?;
+        let nc_root = orchard_ct.root().to_bytes();
+        Ok(env.byte_array_from_slice(&nc_root)?.into_raw())
+    });
+    unwrap_exc_or(&mut env, res, std::ptr::null_mut())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_verifyWitnessNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    witness: JObject<'local>,
+) -> jint {
+    let res = catch_unwind(&mut env, |env| {
+        let witness = java_witness_data(env, &witness)?;
+        let valid = voting::witness::verify_witness(&witness)
+            .map_err(|e| anyhow!("verify_witness: {}", e))?;
+        Ok(if valid { 1 } else { 0 })
+    });
+    unwrap_exc_or(&mut env, res, -1)
 }

--- a/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModelsTest.kt
+++ b/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModelsTest.kt
@@ -1,0 +1,58 @@
+package cash.z.ecc.android.sdk.internal.model.voting
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class JniVotingModelsTest {
+    @Test
+    fun note_info_constructor_matches_rust_jni_signature() {
+        val constructor =
+            JniNoteInfo::class.java.getDeclaredConstructor(
+                ByteArray::class.java,
+                ByteArray::class.java,
+                Long::class.javaPrimitiveType,
+                Long::class.javaPrimitiveType,
+                ByteArray::class.java,
+                ByteArray::class.java,
+                ByteArray::class.java,
+                Int::class.javaPrimitiveType,
+                String::class.java
+            )
+
+        assertEquals(
+            "([B[BJJ[B[B[BILjava/lang/String;)V",
+            constructor.jniDescriptor()
+        )
+    }
+
+    @Test
+    fun witness_data_constructor_matches_rust_jni_signature() {
+        val constructor =
+            JniWitnessData::class.java.getDeclaredConstructor(
+                ByteArray::class.java,
+                Long::class.javaPrimitiveType,
+                ByteArray::class.java,
+                Array<ByteArray>::class.java
+            )
+
+        assertEquals(
+            "([BJ[B[[B)V",
+            constructor.jniDescriptor()
+        )
+    }
+
+    private fun java.lang.reflect.Constructor<*>.jniDescriptor() =
+        parameterTypes.joinToString(prefix = "(", postfix = ")V", separator = "") { parameter ->
+            parameter.jniDescriptor()
+        }
+
+    private fun Class<*>.jniDescriptor(): String =
+        when (this) {
+            java.lang.Long.TYPE -> "J"
+            java.lang.Integer.TYPE -> "I"
+            ByteArray::class.java -> "[B"
+            Array<ByteArray>::class.java -> "[[B"
+            String::class.java -> "Ljava/lang/String;"
+            else -> error("Unsupported JNI constructor parameter: $name")
+        }
+}

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImplTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImplTest.kt
@@ -150,17 +150,20 @@ class TypesafeVotingBackendImplTest {
                     proof = ByteArray(PROOF_BYTES) { 31 },
                     voteRoundId = "round-keystone"
                 )
+            val generatedWitnesses = arrayOf(jniWitnessData().copy(position = 11L))
             val backend =
                 RecordingVotingDbBackend(
                     proofResult = proofJniResult,
                     submissionResult = submissionJniResult,
-                    keystoneSubmissionResult = keystoneJniResult
+                    keystoneSubmissionResult = keystoneJniResult,
+                    generatedWitnesses = generatedWitnesses
                 )
             val db = TypesafeVotingDbImpl(backend)
             val walletSeed = byteArrayOf(1, 2, 3)
             val senderSeed = byteArrayOf(4, 5, 6)
             val keystoneSig = byteArrayOf(7, 8)
             val keystoneSighash = byteArrayOf(9, 10)
+            val treeStateBytes = byteArrayOf(11, 12, 13)
             val notes = listOf(jniNoteInfo())
             val witnesses = listOf(jniWitnessData())
             var progressValue: Double? = null
@@ -241,6 +244,25 @@ class TypesafeVotingBackendImplTest {
             assertContentEquals(keystoneSig, backend.keystoneSig)
             assertContentEquals(keystoneSighash, backend.keystoneSighash)
             assertEquals("round-keystone", keystoneSubmission.voteRoundId)
+
+            db.storeTreeState("round-6", treeStateBytes)
+            assertEquals("round-6", backend.storeTreeStateRoundId)
+            assertContentEquals(treeStateBytes, backend.storeTreeStateBytes)
+
+            val generated =
+                db.generateNoteWitnesses(
+                    roundId = "round-7",
+                    bundleIndex = 10,
+                    walletDbPath = "/tmp/wallet.db",
+                    networkId = 1,
+                    notes = notes
+                )
+            assertEquals("round-7", backend.generateNoteWitnessesRoundId)
+            assertEquals(10, backend.generateNoteWitnessesBundleIndex)
+            assertEquals("/tmp/wallet.db", backend.generateNoteWitnessesWalletDbPath)
+            assertEquals(1, backend.generateNoteWitnessesNetworkId)
+            assertEquals(notes, backend.generateNoteWitnessesNotes)
+            assertEquals(generatedWitnesses.asList(), generated)
         }
 
     private fun jniDelegationProofResult(
@@ -328,7 +350,8 @@ class TypesafeVotingBackendImplTest {
     private class RecordingVotingDbBackend(
         private val proofResult: JniDelegationProofResult,
         private val submissionResult: JniDelegationSubmissionResult,
-        private val keystoneSubmissionResult: JniDelegationSubmissionResult
+        private val keystoneSubmissionResult: JniDelegationSubmissionResult,
+        private val generatedWitnesses: Array<JniWitnessData>
     ) : VotingDbBackend {
         var storeWitnessesRoundId: String? = null
         var storeWitnessesBundleIndex: Int? = null
@@ -357,6 +380,13 @@ class TypesafeVotingBackendImplTest {
         var keystoneBundleIndex: Int? = null
         var keystoneSig: ByteArray = ByteArray(0)
         var keystoneSighash: ByteArray = ByteArray(0)
+        var storeTreeStateRoundId: String? = null
+        var storeTreeStateBytes: ByteArray = ByteArray(0)
+        var generateNoteWitnessesRoundId: String? = null
+        var generateNoteWitnessesBundleIndex: Int? = null
+        var generateNoteWitnessesWalletDbPath: String? = null
+        var generateNoteWitnessesNetworkId: Int? = null
+        var generateNoteWitnessesNotes: List<JniNoteInfo>? = null
 
         override suspend fun close() = unused()
 
@@ -485,7 +515,10 @@ class TypesafeVotingBackendImplTest {
             return keystoneSubmissionResult
         }
 
-        override suspend fun storeTreeState(roundId: String, treeStateBytes: ByteArray) = unused()
+        override suspend fun storeTreeState(roundId: String, treeStateBytes: ByteArray) {
+            storeTreeStateRoundId = roundId
+            storeTreeStateBytes = treeStateBytes
+        }
 
         override suspend fun generateNoteWitnesses(
             roundId: String,
@@ -493,7 +526,14 @@ class TypesafeVotingBackendImplTest {
             walletDbPath: String,
             networkId: Int,
             notes: List<JniNoteInfo>
-        ): Array<JniWitnessData> = unused()
+        ): Array<JniWitnessData> {
+            generateNoteWitnessesRoundId = roundId
+            generateNoteWitnessesBundleIndex = bundleIndex
+            generateNoteWitnessesWalletDbPath = walletDbPath
+            generateNoteWitnessesNetworkId = networkId
+            generateNoteWitnessesNotes = notes
+            return generatedWitnesses
+        }
 
         private fun unused(): Nothing = error("unused")
     }

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImplTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImplTest.kt
@@ -121,6 +121,16 @@ class TypesafeVotingBackendImplTest {
     }
 
     @Test
+    fun voting_note_info_maps_to_and_from_jni_shape() {
+        val jniNote = jniNoteInfo().copy(scope = 1)
+
+        val note = jniNote.toVotingNoteInfo()
+
+        assertEquals(VotingNoteScope.INTERNAL, note.scope)
+        assertEquals(jniNote, note.toJniNoteInfo())
+    }
+
+    @Test
     fun delegation_methods_forward_arguments_and_map_results() =
         runTest {
             val proofJniResult =
@@ -164,14 +174,15 @@ class TypesafeVotingBackendImplTest {
             val keystoneSig = byteArrayOf(7, 8)
             val keystoneSighash = byteArrayOf(9, 10)
             val treeStateBytes = byteArrayOf(11, 12, 13)
-            val notes = listOf(jniNoteInfo())
+            val notes = listOf(votingNoteInfo())
+            val jniNotes = notes.map { it.toJniNoteInfo() }
             val witnesses = listOf(jniWitnessData())
             var progressValue: Double? = null
 
             db.storeWitnesses("round-1", 2, notes, witnesses)
             assertEquals("round-1", backend.storeWitnessesRoundId)
             assertEquals(2, backend.storeWitnessesBundleIndex)
-            assertEquals(notes, backend.storeWitnessesNotes)
+            assertEquals(jniNotes, backend.storeWitnessesNotes)
             assertEquals(witnesses, backend.storeWitnessesWitnesses)
 
             val precompute =
@@ -188,7 +199,7 @@ class TypesafeVotingBackendImplTest {
             assertEquals(3, backend.precomputeBundleIndex)
             assertEquals("https://pir.example", backend.precomputePirServerUrl)
             assertEquals(0, backend.precomputeNetworkId)
-            assertEquals(notes, backend.precomputeNotes)
+            assertEquals(jniNotes, backend.precomputeNotes)
 
             val proof =
                 db.buildAndProveDelegation(
@@ -207,7 +218,7 @@ class TypesafeVotingBackendImplTest {
             assertEquals(4, backend.buildAndProveBundleIndex)
             assertEquals("https://pir.example", backend.buildAndProvePirServerUrl)
             assertEquals(1, backend.buildAndProveNetworkId)
-            assertEquals(notes, backend.buildAndProveNotes)
+            assertEquals(jniNotes, backend.buildAndProveNotes)
             assertContentEquals(walletSeed, backend.buildAndProveWalletSeed)
             assertEquals(5, backend.buildAndProveAccountIndex)
             assertEquals(6, backend.buildAndProveAddressIndex)
@@ -261,7 +272,7 @@ class TypesafeVotingBackendImplTest {
             assertEquals(10, backend.generateNoteWitnessesBundleIndex)
             assertEquals("/tmp/wallet.db", backend.generateNoteWitnessesWalletDbPath)
             assertEquals(1, backend.generateNoteWitnessesNetworkId)
-            assertEquals(notes, backend.generateNoteWitnessesNotes)
+            assertEquals(jniNotes, backend.generateNoteWitnessesNotes)
             assertEquals(generatedWitnesses.asList(), generated)
         }
 
@@ -338,6 +349,8 @@ class TypesafeVotingBackendImplTest {
             scope = 0,
             ufvk = "ufvk"
         )
+
+    private fun votingNoteInfo() = jniNoteInfo().toVotingNoteInfo()
 
     private fun jniWitnessData() =
         JniWitnessData(

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImplTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImplTest.kt
@@ -16,6 +16,8 @@ import cash.z.ecc.android.sdk.internal.model.voting.JniRoundSummary
 import cash.z.ecc.android.sdk.internal.model.voting.JniVoteRecord
 import cash.z.ecc.android.sdk.internal.model.voting.JniVotingHotkey
 import cash.z.ecc.android.sdk.internal.model.voting.JniWitnessData
+import cash.z.ecc.android.sdk.model.AccountUuid
+import cash.z.ecc.android.sdk.model.BlockHeight
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -129,6 +131,29 @@ class TypesafeVotingBackendImplTest {
         assertEquals(VotingNoteScope.INTERNAL, note.scope)
         assertEquals(jniNote, note.toJniNoteInfo())
     }
+
+    @Test
+    fun get_wallet_notes_forwards_arguments_and_maps_results() =
+        runTest {
+            val accountUuid = AccountUuid.new(ByteArray(16) { it.toByte() })
+            val jniNotes = arrayOf(jniNoteInfo().copy(scope = 1, ufvk = "ufvk"))
+            val bridge = RecordingVotingBackendBridge(walletNotes = jniNotes)
+            val backend = TypesafeVotingBackendImpl { bridge }
+
+            val notes =
+                backend.getWalletNotes(
+                    walletDbPath = "/tmp/wallet.db",
+                    snapshotHeight = BlockHeight.new(123_456L),
+                    networkId = 1,
+                    accountUuid = accountUuid
+                )
+
+            assertEquals("/tmp/wallet.db", bridge.walletDbPath)
+            assertEquals(123_456L, bridge.snapshotHeight)
+            assertEquals(1, bridge.networkId)
+            assertContentEquals(accountUuid.value, bridge.accountUuidBytes)
+            assertEquals(jniNotes.map { it.toVotingNoteInfo() }, notes)
+        }
 
     @Test
     fun delegation_methods_forward_arguments_and_map_results() =
@@ -359,6 +384,61 @@ class TypesafeVotingBackendImplTest {
             root = field(5),
             authPath = fieldElements(32)
         )
+
+    @Suppress("TooManyFunctions")
+    private class RecordingVotingBackendBridge(
+        private val walletNotes: Array<JniNoteInfo>
+    ) : VotingBackendBridge {
+        var walletDbPath: String? = null
+        var snapshotHeight: Long? = null
+        var networkId: Int? = null
+        var accountUuidBytes: ByteArray = ByteArray(0)
+
+        override suspend fun computeShareNullifier(
+            voteCommitment: ByteArray,
+            shareIndex: Int,
+            blind: ByteArray
+        ): ByteArray = unused()
+
+        override suspend fun openVotingDb(dbPath: String, walletId: String): VotingDbBackend =
+            unused()
+
+        override suspend fun computeBundleSetup(notes: List<JniNoteInfo>): JniBundleSetupResult =
+            unused()
+
+        override suspend fun warmProvingCaches() = unused()
+
+        override suspend fun extractOrchardFvkFromUfvk(
+            ufvk: String,
+            networkId: Int
+        ): ByteArray = unused()
+
+        override suspend fun extractNcRoot(treeStateBytes: ByteArray): ByteArray = unused()
+
+        override suspend fun verifyWitness(witness: JniWitnessData): Boolean = unused()
+
+        override suspend fun getWalletNotes(
+            walletDbPath: String,
+            snapshotHeight: Long,
+            networkId: Int,
+            accountUuidBytes: ByteArray
+        ): Array<JniNoteInfo> {
+            this.walletDbPath = walletDbPath
+            this.snapshotHeight = snapshotHeight
+            this.networkId = networkId
+            this.accountUuidBytes = accountUuidBytes
+            return walletNotes
+        }
+
+        override suspend fun extractPcztSighash(pcztBytes: ByteArray): ByteArray = unused()
+
+        override suspend fun extractSpendAuthSig(
+            signedPcztBytes: ByteArray,
+            actionIndex: Int
+        ): ByteArray = unused()
+
+        private fun unused(): Nothing = error("unused")
+    }
 
     private class RecordingVotingDbBackend(
         private val proofResult: JniDelegationProofResult,

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImplTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImplTest.kt
@@ -485,6 +485,16 @@ class TypesafeVotingBackendImplTest {
             return keystoneSubmissionResult
         }
 
+        override suspend fun storeTreeState(roundId: String, treeStateBytes: ByteArray) = unused()
+
+        override suspend fun generateNoteWitnesses(
+            roundId: String,
+            bundleIndex: Int,
+            walletDbPath: String,
+            networkId: Int,
+            notes: List<JniNoteInfo>
+        ): Array<JniWitnessData> = unused()
+
         private fun unused(): Nothing = error("unused")
     }
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
@@ -123,6 +123,7 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
@@ -695,6 +696,17 @@ class SdkSynchronizer private constructor(
                 Twig.error { message }
                 throw throwable
             }
+        }
+
+    internal suspend fun getWalletDbPathForVoting(): String =
+        withContext(Dispatchers.IO) {
+            val dataDbFile =
+                DatabaseCoordinator.getInstance(context).dataDbFile(
+                    network = synchronizerKey.zcashNetwork,
+                    alias = synchronizerKey.alias
+                )
+
+            dataDbFile.absolutePath
         }
 
     suspend fun isValidAddress(address: String): Boolean = !validateAddress(address).isNotValid

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackend.kt
@@ -1,7 +1,6 @@
 package cash.z.ecc.android.sdk.internal
 
 import cash.z.ecc.android.sdk.internal.model.voting.JniBundleSetupResult
-import cash.z.ecc.android.sdk.internal.model.voting.JniNoteInfo
 import cash.z.ecc.android.sdk.internal.model.voting.JniRoundState
 import cash.z.ecc.android.sdk.internal.model.voting.JniRoundSummary
 import cash.z.ecc.android.sdk.internal.model.voting.JniVoteRecord
@@ -20,7 +19,7 @@ internal interface TypesafeVotingBackend {
         blind: ByteArray
     ): ByteArray
 
-    suspend fun computeBundleSetup(notes: List<JniNoteInfo>): JniBundleSetupResult
+    suspend fun computeBundleSetup(notes: List<VotingNoteInfo>): JniBundleSetupResult
 
     suspend fun warmProvingCaches()
 
@@ -35,7 +34,7 @@ internal interface TypesafeVotingBackend {
         snapshotHeight: BlockHeight,
         networkId: Int,
         accountUuid: AccountUuid
-    ): List<JniNoteInfo>
+    ): List<VotingNoteInfo>
 
     suspend fun extractPcztSighash(pcztBytes: ByteArray): ByteArray
 
@@ -75,7 +74,7 @@ internal interface TypesafeVotingDb {
 
     suspend fun setupBundles(
         roundId: String,
-        notes: List<JniNoteInfo>
+        notes: List<VotingNoteInfo>
     ): JniBundleSetupResult
 
     suspend fun generateHotkey(
@@ -89,7 +88,7 @@ internal interface TypesafeVotingDb {
         ufvk: String,
         networkId: Int,
         accountIndex: Int,
-        notes: List<JniNoteInfo>,
+        notes: List<VotingNoteInfo>,
         walletSeed: ByteArray,
         seedFingerprint: ByteArray,
         roundName: String,
@@ -99,7 +98,7 @@ internal interface TypesafeVotingDb {
     suspend fun storeWitnesses(
         roundId: String,
         bundleIndex: Int,
-        notes: List<JniNoteInfo>,
+        notes: List<VotingNoteInfo>,
         witnesses: List<JniWitnessData>
     )
 
@@ -108,7 +107,7 @@ internal interface TypesafeVotingDb {
         bundleIndex: Int,
         pirServerUrl: String,
         networkId: Int,
-        notes: List<JniNoteInfo>
+        notes: List<VotingNoteInfo>
     ): DelegationPirPrecomputeResult
 
     suspend fun buildAndProveDelegation(
@@ -116,7 +115,7 @@ internal interface TypesafeVotingDb {
         bundleIndex: Int,
         pirServerUrl: String,
         networkId: Int,
-        notes: List<JniNoteInfo>,
+        notes: List<VotingNoteInfo>,
         walletSeed: ByteArray,
         accountIndex: Int,
         addressIndex: Int,
@@ -145,8 +144,60 @@ internal interface TypesafeVotingDb {
         bundleIndex: Int,
         walletDbPath: String,
         networkId: Int,
-        notes: List<JniNoteInfo>
+        notes: List<VotingNoteInfo>
     ): List<JniWitnessData>
+}
+
+internal data class VotingNoteInfo(
+    val commitment: ByteArray,
+    val nullifier: ByteArray,
+    val value: Long,
+    val position: Long,
+    val diversifier: ByteArray,
+    val rho: ByteArray,
+    val rseed: ByteArray,
+    val scope: VotingNoteScope,
+    val ufvk: String
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is VotingNoteInfo) return false
+        return commitment.contentEquals(other.commitment) &&
+            nullifier.contentEquals(other.nullifier) &&
+            value == other.value &&
+            position == other.position &&
+            diversifier.contentEquals(other.diversifier) &&
+            rho.contentEquals(other.rho) &&
+            rseed.contentEquals(other.rseed) &&
+            scope == other.scope &&
+            ufvk == other.ufvk
+    }
+
+    override fun hashCode(): Int {
+        var result = commitment.contentHashCode()
+        result = 31 * result + nullifier.contentHashCode()
+        result = 31 * result + value.hashCode()
+        result = 31 * result + position.hashCode()
+        result = 31 * result + diversifier.contentHashCode()
+        result = 31 * result + rho.contentHashCode()
+        result = 31 * result + rseed.contentHashCode()
+        result = 31 * result + scope.hashCode()
+        result = 31 * result + ufvk.hashCode()
+        return result
+    }
+}
+
+internal enum class VotingNoteScope(
+    val jniValue: Int
+) {
+    EXTERNAL(0),
+    INTERNAL(1);
+
+    companion object {
+        fun fromJniValue(value: Int) =
+            entries.firstOrNull { it.jniValue == value }
+                ?: error("Unknown voting note scope: $value")
+    }
 }
 
 internal data class GovernancePcztResult(

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackend.kt
@@ -7,6 +7,8 @@ import cash.z.ecc.android.sdk.internal.model.voting.JniRoundSummary
 import cash.z.ecc.android.sdk.internal.model.voting.JniVoteRecord
 import cash.z.ecc.android.sdk.internal.model.voting.JniVotingHotkey
 import cash.z.ecc.android.sdk.internal.model.voting.JniWitnessData
+import cash.z.ecc.android.sdk.model.AccountUuid
+import cash.z.ecc.android.sdk.model.BlockHeight
 
 @Suppress("TooManyFunctions", "LongParameterList")
 internal interface TypesafeVotingBackend {
@@ -30,9 +32,9 @@ internal interface TypesafeVotingBackend {
 
     suspend fun getWalletNotes(
         walletDbPath: String,
-        snapshotHeight: Long,
+        snapshotHeight: BlockHeight,
         networkId: Int,
-        accountUuidBytes: ByteArray
+        accountUuid: AccountUuid
     ): List<JniNoteInfo>
 
     suspend fun extractPcztSighash(pcztBytes: ByteArray): ByteArray

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackend.kt
@@ -22,6 +22,19 @@ internal interface TypesafeVotingBackend {
 
     suspend fun warmProvingCaches()
 
+    suspend fun extractOrchardFvkFromUfvk(ufvk: String, networkId: Int): ByteArray
+
+    suspend fun extractNcRoot(treeStateBytes: ByteArray): ByteArray
+
+    suspend fun verifyWitness(witness: JniWitnessData): Boolean
+
+    suspend fun getWalletNotes(
+        walletDbPath: String,
+        snapshotHeight: Long,
+        networkId: Int,
+        accountUuidBytes: ByteArray
+    ): List<JniNoteInfo>
+
     suspend fun extractPcztSighash(pcztBytes: ByteArray): ByteArray
 
     suspend fun extractSpendAuthSig(
@@ -122,6 +135,16 @@ internal interface TypesafeVotingDb {
         keystoneSig: ByteArray,
         keystoneSighash: ByteArray
     ): DelegationSubmissionResult
+
+    suspend fun storeTreeState(roundId: String, treeStateBytes: ByteArray)
+
+    suspend fun generateNoteWitnesses(
+        roundId: String,
+        bundleIndex: Int,
+        walletDbPath: String,
+        networkId: Int,
+        notes: List<JniNoteInfo>
+    ): List<JniWitnessData>
 }
 
 internal data class GovernancePcztResult(

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
@@ -17,6 +17,8 @@ import cash.z.ecc.android.sdk.internal.model.voting.JniRoundSummary
 import cash.z.ecc.android.sdk.internal.model.voting.JniVoteRecord
 import cash.z.ecc.android.sdk.internal.model.voting.JniVotingHotkey
 import cash.z.ecc.android.sdk.internal.model.voting.JniWitnessData
+import cash.z.ecc.android.sdk.model.AccountUuid
+import cash.z.ecc.android.sdk.model.BlockHeight
 
 @Suppress("TooManyFunctions", "LongParameterList")
 internal class TypesafeVotingBackendImpl : TypesafeVotingBackend {
@@ -50,19 +52,21 @@ internal class TypesafeVotingBackendImpl : TypesafeVotingBackend {
         rustBackend().extractNcRoot(treeStateBytes)
 
     override suspend fun verifyWitness(witness: JniWitnessData): Boolean =
-        when (val result = rustBackend().verifyWitness(witness)) {
-            0 -> false
-            1 -> true
-            else -> error("verifyWitness failed with result=$result")
-        }
+        rustBackend().verifyWitness(witness)
 
     override suspend fun getWalletNotes(
         walletDbPath: String,
-        snapshotHeight: Long,
+        snapshotHeight: BlockHeight,
         networkId: Int,
-        accountUuidBytes: ByteArray
+        accountUuid: AccountUuid
     ): List<JniNoteInfo> =
-        rustBackend().getWalletNotes(walletDbPath, snapshotHeight, networkId, accountUuidBytes).asList()
+        rustBackend()
+            .getWalletNotes(
+                walletDbPath,
+                snapshotHeight.value,
+                networkId,
+                accountUuid.value
+            ).asList()
 
     override suspend fun extractPcztSighash(pcztBytes: ByteArray): ByteArray =
         rustBackend().extractPcztSighash(pcztBytes)

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
@@ -43,6 +43,27 @@ internal class TypesafeVotingBackendImpl : TypesafeVotingBackend {
     override suspend fun warmProvingCaches() =
         rustBackend().warmProvingCaches()
 
+    override suspend fun extractOrchardFvkFromUfvk(ufvk: String, networkId: Int): ByteArray =
+        rustBackend().extractOrchardFvkFromUfvk(ufvk, networkId)
+
+    override suspend fun extractNcRoot(treeStateBytes: ByteArray): ByteArray =
+        rustBackend().extractNcRoot(treeStateBytes)
+
+    override suspend fun verifyWitness(witness: JniWitnessData): Boolean =
+        when (val result = rustBackend().verifyWitness(witness)) {
+            0 -> false
+            1 -> true
+            else -> error("verifyWitness failed with result=$result")
+        }
+
+    override suspend fun getWalletNotes(
+        walletDbPath: String,
+        snapshotHeight: Long,
+        networkId: Int,
+        accountUuidBytes: ByteArray
+    ): List<JniNoteInfo> =
+        rustBackend().getWalletNotes(walletDbPath, snapshotHeight, networkId, accountUuidBytes).asList()
+
     override suspend fun extractPcztSighash(pcztBytes: ByteArray): ByteArray =
         rustBackend().extractPcztSighash(pcztBytes)
 
@@ -147,6 +168,16 @@ internal interface VotingDbBackend {
         keystoneSig: ByteArray,
         keystoneSighash: ByteArray
     ): JniDelegationSubmissionResult
+
+    suspend fun storeTreeState(roundId: String, treeStateBytes: ByteArray)
+
+    suspend fun generateNoteWitnesses(
+        roundId: String,
+        bundleIndex: Int,
+        walletDbPath: String,
+        networkId: Int,
+        notes: List<JniNoteInfo>
+    ): Array<JniWitnessData>
 }
 
 @Suppress("TooManyFunctions", "LongParameterList")
@@ -297,6 +328,24 @@ private class RustVotingDbBackend(
             bundleIndex,
             keystoneSig,
             keystoneSighash
+        )
+
+    override suspend fun storeTreeState(roundId: String, treeStateBytes: ByteArray) =
+        votingDb.storeTreeState(roundId, treeStateBytes)
+
+    override suspend fun generateNoteWitnesses(
+        roundId: String,
+        bundleIndex: Int,
+        walletDbPath: String,
+        networkId: Int,
+        notes: List<JniNoteInfo>
+    ): Array<JniWitnessData> =
+        votingDb.generateNoteWitnesses(
+            roundId,
+            bundleIndex,
+            walletDbPath,
+            networkId,
+            notes
         )
 }
 
@@ -456,6 +505,27 @@ internal class TypesafeVotingDbImpl(
                 keystoneSig,
                 keystoneSighash
             ).toDelegationSubmissionResult()
+
+    override suspend fun storeTreeState(roundId: String, treeStateBytes: ByteArray) =
+        votingDb.storeTreeState(roundId, treeStateBytes)
+
+    override suspend fun generateNoteWitnesses(
+        roundId: String,
+        bundleIndex: Int,
+        walletDbPath: String,
+        networkId: Int,
+        notes: List<JniNoteInfo>
+    ): List<JniWitnessData> {
+        val witnesses =
+            votingDb.generateNoteWitnesses(
+                roundId,
+                bundleIndex,
+                walletDbPath,
+                networkId,
+                notes
+            )
+        return witnesses.asList()
+    }
 }
 
 internal fun JniGovernancePczt.toGovernancePcztResult(): GovernancePcztResult {

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
@@ -21,10 +21,14 @@ import cash.z.ecc.android.sdk.model.AccountUuid
 import cash.z.ecc.android.sdk.model.BlockHeight
 
 @Suppress("TooManyFunctions", "LongParameterList")
-internal class TypesafeVotingBackendImpl : TypesafeVotingBackend {
+internal class TypesafeVotingBackendImpl(
+    private val rustBackendFactory: suspend () -> VotingBackendBridge = {
+        RustVotingBackendBridge(VotingRustBackend.new())
+    }
+) : TypesafeVotingBackend {
     private val rustBackendLazy =
-        SuspendingLazy<Unit, VotingRustBackend> {
-            VotingRustBackend.new()
+        SuspendingLazy<Unit, VotingBackendBridge> {
+            rustBackendFactory()
         }
 
     override suspend fun computeShareNullifier(
@@ -36,7 +40,7 @@ internal class TypesafeVotingBackendImpl : TypesafeVotingBackend {
 
     override suspend fun openVotingDb(dbPath: String, walletId: String): TypesafeVotingDb =
         TypesafeVotingDbImpl(
-            RustVotingDbBackend(rustBackend().openVotingDb(dbPath, walletId))
+            rustBackend().openVotingDb(dbPath, walletId)
         )
 
     override suspend fun computeBundleSetup(notes: List<VotingNoteInfo>): JniBundleSetupResult =
@@ -78,6 +82,87 @@ internal class TypesafeVotingBackendImpl : TypesafeVotingBackend {
         rustBackend().extractSpendAuthSig(signedPcztBytes, actionIndex)
 
     private suspend fun rustBackend() = rustBackendLazy.getInstance(Unit)
+}
+
+@Suppress("TooManyFunctions")
+internal interface VotingBackendBridge {
+    suspend fun computeShareNullifier(
+        voteCommitment: ByteArray,
+        shareIndex: Int,
+        blind: ByteArray
+    ): ByteArray
+
+    suspend fun openVotingDb(dbPath: String, walletId: String): VotingDbBackend
+
+    suspend fun computeBundleSetup(notes: List<JniNoteInfo>): JniBundleSetupResult
+
+    suspend fun warmProvingCaches()
+
+    suspend fun extractOrchardFvkFromUfvk(ufvk: String, networkId: Int): ByteArray
+
+    suspend fun extractNcRoot(treeStateBytes: ByteArray): ByteArray
+
+    suspend fun verifyWitness(witness: JniWitnessData): Boolean
+
+    suspend fun getWalletNotes(
+        walletDbPath: String,
+        snapshotHeight: Long,
+        networkId: Int,
+        accountUuidBytes: ByteArray
+    ): Array<JniNoteInfo>
+
+    suspend fun extractPcztSighash(pcztBytes: ByteArray): ByteArray
+
+    suspend fun extractSpendAuthSig(
+        signedPcztBytes: ByteArray,
+        actionIndex: Int
+    ): ByteArray
+}
+
+private class RustVotingBackendBridge(
+    private val rustBackend: VotingRustBackend
+) : VotingBackendBridge {
+    override suspend fun computeShareNullifier(
+        voteCommitment: ByteArray,
+        shareIndex: Int,
+        blind: ByteArray
+    ): ByteArray =
+        rustBackend.computeShareNullifier(voteCommitment, shareIndex, blind)
+
+    override suspend fun openVotingDb(dbPath: String, walletId: String): VotingDbBackend =
+        RustVotingDbBackend(rustBackend.openVotingDb(dbPath, walletId))
+
+    override suspend fun computeBundleSetup(notes: List<JniNoteInfo>): JniBundleSetupResult =
+        rustBackend.computeBundleSetup(notes)
+
+    override suspend fun warmProvingCaches() =
+        rustBackend.warmProvingCaches()
+
+    override suspend fun extractOrchardFvkFromUfvk(ufvk: String, networkId: Int): ByteArray =
+        rustBackend.extractOrchardFvkFromUfvk(ufvk, networkId)
+
+    override suspend fun extractNcRoot(treeStateBytes: ByteArray): ByteArray =
+        rustBackend.extractNcRoot(treeStateBytes)
+
+    override suspend fun verifyWitness(witness: JniWitnessData): Boolean =
+        rustBackend.verifyWitness(witness)
+
+    override suspend fun getWalletNotes(
+        walletDbPath: String,
+        snapshotHeight: Long,
+        networkId: Int,
+        accountUuidBytes: ByteArray
+    ): Array<JniNoteInfo> =
+        rustBackend.getWalletNotes(walletDbPath, snapshotHeight, networkId, accountUuidBytes)
+
+    override suspend fun extractPcztSighash(pcztBytes: ByteArray): ByteArray =
+        rustBackend.extractPcztSighash(pcztBytes)
+
+    override suspend fun extractSpendAuthSig(
+        signedPcztBytes: ByteArray,
+        actionIndex: Int
+    ): ByteArray =
+        rustBackend.extractSpendAuthSig(signedPcztBytes, actionIndex)
 }
 
 @Suppress("TooManyFunctions", "LongParameterList")

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
@@ -39,8 +39,8 @@ internal class TypesafeVotingBackendImpl : TypesafeVotingBackend {
             RustVotingDbBackend(rustBackend().openVotingDb(dbPath, walletId))
         )
 
-    override suspend fun computeBundleSetup(notes: List<JniNoteInfo>): JniBundleSetupResult =
-        rustBackend().computeBundleSetup(notes)
+    override suspend fun computeBundleSetup(notes: List<VotingNoteInfo>): JniBundleSetupResult =
+        rustBackend().computeBundleSetup(notes.toJniNoteInfos())
 
     override suspend fun warmProvingCaches() =
         rustBackend().warmProvingCaches()
@@ -59,14 +59,14 @@ internal class TypesafeVotingBackendImpl : TypesafeVotingBackend {
         snapshotHeight: BlockHeight,
         networkId: Int,
         accountUuid: AccountUuid
-    ): List<JniNoteInfo> =
+    ): List<VotingNoteInfo> =
         rustBackend()
             .getWalletNotes(
                 walletDbPath,
                 snapshotHeight.value,
                 networkId,
                 accountUuid.value
-            ).asList()
+            ).map { it.toVotingNoteInfo() }
 
     override suspend fun extractPcztSighash(pcztBytes: ByteArray): ByteArray =
         rustBackend().extractPcztSighash(pcztBytes)
@@ -397,9 +397,9 @@ internal class TypesafeVotingDbImpl(
 
     override suspend fun setupBundles(
         roundId: String,
-        notes: List<JniNoteInfo>
+        notes: List<VotingNoteInfo>
     ): JniBundleSetupResult =
-        votingDb.setupBundles(roundId, notes)
+        votingDb.setupBundles(roundId, notes.toJniNoteInfos())
 
     override suspend fun generateHotkey(
         roundId: String,
@@ -413,7 +413,7 @@ internal class TypesafeVotingDbImpl(
         ufvk: String,
         networkId: Int,
         accountIndex: Int,
-        notes: List<JniNoteInfo>,
+        notes: List<VotingNoteInfo>,
         walletSeed: ByteArray,
         seedFingerprint: ByteArray,
         roundName: String,
@@ -426,7 +426,7 @@ internal class TypesafeVotingDbImpl(
                 ufvk,
                 networkId,
                 accountIndex,
-                notes,
+                notes.toJniNoteInfos(),
                 walletSeed,
                 seedFingerprint,
                 roundName,
@@ -436,16 +436,16 @@ internal class TypesafeVotingDbImpl(
     override suspend fun storeWitnesses(
         roundId: String,
         bundleIndex: Int,
-        notes: List<JniNoteInfo>,
+        notes: List<VotingNoteInfo>,
         witnesses: List<JniWitnessData>
-    ) = votingDb.storeWitnesses(roundId, bundleIndex, notes, witnesses)
+    ) = votingDb.storeWitnesses(roundId, bundleIndex, notes.toJniNoteInfos(), witnesses)
 
     override suspend fun precomputeDelegationPir(
         roundId: String,
         bundleIndex: Int,
         pirServerUrl: String,
         networkId: Int,
-        notes: List<JniNoteInfo>
+        notes: List<VotingNoteInfo>
     ): DelegationPirPrecomputeResult =
         votingDb
             .precomputeDelegationPir(
@@ -453,7 +453,7 @@ internal class TypesafeVotingDbImpl(
                 bundleIndex,
                 pirServerUrl,
                 networkId,
-                notes
+                notes.toJniNoteInfos()
             ).toDelegationPirPrecomputeResult()
 
     override suspend fun buildAndProveDelegation(
@@ -461,7 +461,7 @@ internal class TypesafeVotingDbImpl(
         bundleIndex: Int,
         pirServerUrl: String,
         networkId: Int,
-        notes: List<JniNoteInfo>,
+        notes: List<VotingNoteInfo>,
         walletSeed: ByteArray,
         accountIndex: Int,
         addressIndex: Int,
@@ -473,7 +473,7 @@ internal class TypesafeVotingDbImpl(
                 bundleIndex,
                 pirServerUrl,
                 networkId,
-                notes,
+                notes.toJniNoteInfos(),
                 walletSeed,
                 accountIndex,
                 addressIndex,
@@ -518,7 +518,7 @@ internal class TypesafeVotingDbImpl(
         bundleIndex: Int,
         walletDbPath: String,
         networkId: Int,
-        notes: List<JniNoteInfo>
+        notes: List<VotingNoteInfo>
     ): List<JniWitnessData> {
         val witnesses =
             votingDb.generateNoteWitnesses(
@@ -526,7 +526,7 @@ internal class TypesafeVotingDbImpl(
                 bundleIndex,
                 walletDbPath,
                 networkId,
-                notes
+                notes.toJniNoteInfos()
             )
         return witnesses.asList()
     }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/VotingNoteInfoMapper.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/VotingNoteInfoMapper.kt
@@ -1,0 +1,31 @@
+package cash.z.ecc.android.sdk.internal
+
+import cash.z.ecc.android.sdk.internal.model.voting.JniNoteInfo
+
+internal fun JniNoteInfo.toVotingNoteInfo() =
+    VotingNoteInfo(
+        commitment = commitment,
+        nullifier = nullifier,
+        value = value,
+        position = position,
+        diversifier = diversifier,
+        rho = rho,
+        rseed = rseed,
+        scope = VotingNoteScope.fromJniValue(scope),
+        ufvk = ufvk
+    )
+
+internal fun VotingNoteInfo.toJniNoteInfo() =
+    JniNoteInfo(
+        commitment = commitment,
+        nullifier = nullifier,
+        value = value,
+        position = position,
+        diversifier = diversifier,
+        rho = rho,
+        rseed = rseed,
+        scope = scope.jniValue,
+        ufvk = ufvk
+    )
+
+internal fun List<VotingNoteInfo>.toJniNoteInfos() = map { it.toJniNoteInfo() }


### PR DESCRIPTION
Part of zodl-inc/zodl-android#2193.
Slice of zcash/zcash-android-wallet-sdk#1924 (umbrella draft PR being split into reviewable pieces).
Stacked on zcash/zcash-android-wallet-sdk#1950 (PR 5 — delegation proof + submission).
Resolves MOB-1109

## Why

Sixth slice of the Android shielded-voting integration. PR 5 (#1950) finishes
the delegation half (PIR precompute, proof + progress callback, submission).
This PR introduces the snapshot input-prep path that vote construction will
consume in PR 7: extracting wallet notes at a historical snapshot height,
storing the matching tree state in the voting DB, and generating per-bundle
note witnesses against that snapshot.

No public `Synchronizer` voting API is added. Wallet DB access from the voting
backend goes through a new internal `SdkSynchronizer.getWalletDbPathForVoting()`
rather than a public `getWalletDbPath()` accessor (one of the open decisions in
the split plan).

## Not included

- Vote tree sync / VAN witnesses / vote commitment / cast-vote payloads (PR 7).
- Recovery records and share tracking (PR 8).
- Any new submission or proof-generation behavior.

## Review focus

Primary review track: core-dev. Secondary: mobile-app-dev.

- `getWalletDbPathForVoting()` as `internal suspend` on `SdkSynchronizer` —
  whether this is the right shape, or whether voting note extraction should go
  through a narrower SDK API instead.
- Read-only wallet DB access from the voting backend, including account UUID,
  UFVK, and network binding for `getWalletNotes`.
- Historical note selection / snapshot anchor correctness in
  `voting/notes.rs`.
- TreeState frontier parsing and root consistency in `extractNcRoot`.
- Witness generation against a stored snapshot, including bundle-specific note
  filtering and stale cached witness replacement behavior.
- JNI byte-boundary validation via the shared helpers in `voting/helpers.rs`
  (Orchard FVK bytes, TreeState bytes, account UUID, witness payload sizes).
- Typed FFI models (`JniNoteInfo`, `JniWitnessData`) and how the typesafe layer
  enforces size/count invariants before handing data back to the SDK.

## Validation

- `cargo check --manifest-path backend-lib/Cargo.toml --locked`
- `cargo fmt --manifest-path backend-lib/Cargo.toml --check`
- `./gradlew :backend-lib:compileReleaseKotlin :sdk-lib:compileReleaseKotlin`
- `./gradlew ktlint detektAll`
- `./gradlew checkProperties`
- `git diff --check`

# Author

- [ ] **Self-review** your own code in GitHub web interface
- [x] Add **automated tests** as appropriate
- [ ] Update the **manual tests** as appropriate
- [ ] Check the **code coverage** report for the automated tests
- [ ] Update **documentation** as appropriate
- [ ] **Run the demo app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer

# Reviewer

- [ ] Check the code with the Code Review Guidelines checklist
- [ ] Perform an **ad hoc review**
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation** as appropriate
- [ ] **Run the demo app** and try the changes
