### PR TITLE
[#1924] Add Android voting tree sync, commitment, and cast-vote payloads

### DIFF
--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -6053,6 +6053,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
+name = "vote-commitment-tree"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fb2456313f571003c0bed8d38fb166d78da85653caf828823c1a82f4e1aef1"
+dependencies = [
+ "anyhow",
+ "ff",
+ "halo2_gadgets",
+ "imt-tree",
+ "incrementalmerkletree",
+ "lazy_static",
+ "libc",
+ "pasta_curves",
+ "shardtree",
+]
+
+[[package]]
+name = "vote-commitment-tree-client"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb05b7a0434a89c2d9017bbab9a5157f1992fb746dce58a1077669e9dd0a13c5"
+dependencies = [
+ "base64",
+ "ff",
+ "hex",
+ "pasta_curves",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "vote-commitment-tree",
+]
+
+[[package]]
 name = "voting-circuits"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7131,6 +7164,9 @@ dependencies = [
  "serde_json",
  "subtle",
  "thiserror 2.0.18",
+ "tokio",
+ "vote-commitment-tree",
+ "vote-commitment-tree-client",
  "voting-circuits",
  "zcash_keys",
  "zcash_primitives",

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -100,10 +100,15 @@ rust-analyzer = "0.0.1"
 # and the Poseidon-based `share_nullifier_hash` implementation:
 # https://github.com/valargroup/voting-circuits/blob/v0.4.1/voting-circuits/src/share_reveal/circuit.rs
 # Default features stay disabled. The `client-pir` feature is needed for
-# delegation proof precompute and proof generation; tree-sync remains later.
-# Expected PIR/networking transitives include `pir-client`, `pir-types`,
-# `valar-ypir`, `valar-spiral-rs`, and `hyper-rustls`.
-zcash_voting = { version = "0.5.11", default-features = false, features = ["client-pir"] }
+# delegation proof precompute and proof generation. The `client-tree-sync`
+# feature is needed for vote commitment tree sync and VAN witnesses.
+# Expected PIR/tree-sync networking transitives include `pir-client`, `pir-types`,
+# `valar-ypir`, `valar-spiral-rs`, `vote-commitment-tree-client`, and
+# `hyper-rustls`.
+zcash_voting = { version = "0.5.11", default-features = false, features = [
+    "client-pir",
+    "client-tree-sync",
+] }
 
 ## Uncomment this to test librustzcash changes locally
 #[patch.crates-io]

--- a/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
+++ b/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
@@ -971,6 +971,54 @@ class VotingRustBackendTest {
         }
 
     @Test
+    fun sync_vote_tree_reaches_native_boundary() =
+        runTest {
+            val db = VotingRustBackend.new().openVotingDb(newDbPath(), WALLET_ID)
+            try {
+                db.initPcztRoundWithBundles(notes(noteCount = 6, value = PCZT_NOTE_VALUE))
+
+                assertFailsWith<RuntimeException> {
+                    db.syncVoteTree(PCZT_ROUND_ID, "not-a-url")
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+    @Test
+    fun store_van_position_reaches_native_boundary() =
+        runTest {
+            val db = VotingRustBackend.new().openVotingDb(newDbPath(), WALLET_ID)
+            try {
+                db.initPcztRoundWithBundles(notes(noteCount = 6, value = PCZT_NOTE_VALUE))
+
+                db.storeVanPosition(PCZT_ROUND_ID, bundleIndex = 1, position = 42)
+            } finally {
+                db.close()
+            }
+        }
+
+    @Test
+    fun generate_van_witness_reaches_native_boundary() =
+        runTest {
+            val db = VotingRustBackend.new().openVotingDb(newDbPath(), WALLET_ID)
+            try {
+                db.initPcztRoundWithBundles(notes(noteCount = 6, value = PCZT_NOTE_VALUE))
+                db.storeVanPosition(PCZT_ROUND_ID, bundleIndex = 1, position = 42)
+
+                assertFailsWith<RuntimeException> {
+                    db.generateVanWitness(
+                        roundId = PCZT_ROUND_ID,
+                        bundleIndex = 1,
+                        anchorHeight = SNAPSHOT_HEIGHT
+                    )
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+    @Test
     fun build_vote_commitment_requires_delegation_ready() =
         runTest {
             val db = VotingRustBackend.new().openVotingDb(newDbPath(), WALLET_ID)

--- a/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
+++ b/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
@@ -924,6 +924,35 @@ class VotingRustBackendTest {
         }
 
     @Test
+    fun build_share_payloads_single_share_mode_keeps_commitment_context() =
+        runTest {
+            val backend = VotingRustBackend.new()
+            val commitment = jniVoteCommitmentResult()
+
+            val payloads =
+                backend.buildSharePayloads(
+                    commitment = commitment,
+                    voteDecision = 1,
+                    numOptions = 2,
+                    vcTreePosition = 42,
+                    singleShareMode = true
+                )
+
+            assertEquals(1, payloads.size)
+            val payload = payloads.single()
+            assertContentEquals(commitment.sharesHash, payload.sharesHash)
+            assertEquals(commitment.proposalId, payload.proposalId)
+            assertEquals(1, payload.voteDecision)
+            assertEquals(42, payload.treePosition)
+            assertEquals(0, payload.encShare.shareIndex)
+            assertEquals(commitment.encShares.first(), payload.encShare)
+            assertEquals(commitment.encShares, payload.allEncShares)
+            assertEquals(JNI_VOTE_SHARE_COUNT, payload.allEncShares.size)
+            assertContentEquals(commitment.shareComms.first(), payload.shareComms.first())
+            assertContentEquals(commitment.shareBlinds.first(), payload.primaryBlind)
+        }
+
+    @Test
     fun build_share_payloads_rejects_malformed_share_counts() =
         runTest {
             val backend = VotingRustBackend.new()

--- a/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
+++ b/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
@@ -4,6 +4,9 @@ import android.content.ContentValues
 import android.database.sqlite.SQLiteDatabase
 import cash.z.ecc.android.sdk.internal.model.voting.JniNoteInfo
 import cash.z.ecc.android.sdk.internal.model.voting.JniRoundPhase
+import cash.z.ecc.android.sdk.internal.model.voting.JniVanWitness
+import cash.z.ecc.android.sdk.internal.model.voting.JniVoteCommitmentResult
+import cash.z.ecc.android.sdk.internal.model.voting.JniWireEncryptedShare
 import cash.z.ecc.android.sdk.internal.model.voting.JniWitnessData
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -124,6 +127,14 @@ class VotingRustBackendTest {
             assertFailsWith<RuntimeException> {
                 backend.computeShareNullifier(VOTE_COMMITMENT, OUT_OF_RANGE_SHARE_INDEX, BLIND)
             }
+        }
+
+    @Test
+    fun decompose_weight_returns_exact_shares() =
+        runTest {
+            val shares = VotingRustBackend.new().decomposeWeight(65_535).toList()
+
+            assertEquals((0 until JNI_VOTE_SHARE_COUNT).map { 1L shl it }, shares)
         }
 
     @Test
@@ -887,6 +898,99 @@ class VotingRustBackendTest {
         }
 
     @Test
+    fun build_share_payloads_round_trips_commitment_fields() =
+        runTest {
+            val backend = VotingRustBackend.new()
+            val commitment = jniVoteCommitmentResult()
+
+            val payloads =
+                backend.buildSharePayloads(
+                    commitment = commitment,
+                    voteDecision = 1,
+                    numOptions = 2,
+                    vcTreePosition = 42,
+                    singleShareMode = false
+                )
+
+            assertEquals(JNI_VOTE_SHARE_COUNT, payloads.size)
+            assertContentEquals(commitment.sharesHash, payloads.first().sharesHash)
+            assertEquals(commitment.proposalId, payloads.first().proposalId)
+            assertEquals(1, payloads.first().voteDecision)
+            assertEquals(42, payloads.first().treePosition)
+            assertEquals(commitment.encShares.first(), payloads.first().encShare)
+            assertEquals(commitment.encShares, payloads.first().allEncShares)
+            assertContentEquals(commitment.shareComms.first(), payloads.first().shareComms.first())
+            assertContentEquals(commitment.shareBlinds.first(), payloads.first().primaryBlind)
+        }
+
+    @Test
+    fun build_share_payloads_rejects_malformed_share_counts() =
+        runTest {
+            val backend = VotingRustBackend.new()
+
+            assertFailsWith<RuntimeException> {
+                backend.buildSharePayloads(
+                    commitment = jniVoteCommitmentResult(encShares = emptyList()),
+                    voteDecision = 1,
+                    numOptions = 2,
+                    vcTreePosition = 42,
+                    singleShareMode = false
+                )
+            }
+        }
+
+    @Test
+    fun sign_cast_vote_rejects_unsupported_account_index() =
+        runTest {
+            val backend = VotingRustBackend.new()
+
+            assertFailsWith<RuntimeException> {
+                backend.signCastVote(
+                    hotkeySeed = HOTKEY_SEED,
+                    networkId = TESTNET_NETWORK_ID,
+                    accountIndex = 1,
+                    commitment = jniVoteCommitmentResult()
+                )
+            }
+        }
+
+    @Test
+    fun build_vote_commitment_requires_delegation_ready() =
+        runTest {
+            val db = VotingRustBackend.new().openVotingDb(newDbPath(), WALLET_ID)
+            try {
+                val notes = notes(noteCount = 6, value = PCZT_NOTE_VALUE)
+                val ufvk = deriveTestUfvk()
+                db.initPcztRoundWithBundles(notes)
+                db.buildTestGovernancePczt(ufvk, notes)
+
+                assertFailsWith<RuntimeException> {
+                    db.buildVoteCommitment(
+                        roundId = PCZT_ROUND_ID,
+                        bundleIndex = 1,
+                        hotkeySeed = HOTKEY_SEED,
+                        proposalId = 1,
+                        choice = 0,
+                        numOptions = 2,
+                        witness = jniVanWitness(),
+                        networkId = TESTNET_NETWORK_ID,
+                        accountIndex = ACCOUNT_INDEX,
+                        singleShare = false,
+                        proofProgress = null
+                    )
+                }
+
+                assertEquals(emptyList(), db.getVotes(PCZT_ROUND_ID).asList())
+                assertEquals(
+                    JniRoundPhase.DELEGATION_CONSTRUCTED,
+                    assertNotNull(db.getRoundState(PCZT_ROUND_ID)).roundPhase
+                )
+            } finally {
+                db.close()
+            }
+        }
+
+    @Test
     fun delegation_proof_result_fixture_crosses_rust_to_kotlin_object_construction() =
         runTest {
             val result = VotingRustBackend.new().delegationProofResultFixtureForTesting()
@@ -1199,6 +1303,50 @@ class VotingRustBackendTest {
                 }
         )
     )
+
+    private fun jniVanWitness(
+        position: Long = 1,
+        anchorHeight: Long = SNAPSHOT_HEIGHT
+    ) = JniVanWitness(
+        authPath = List(JNI_VAN_WITNESS_PATH_DEPTH) { ByteArray(FIELD_BYTES) },
+        position = position,
+        anchorHeight = anchorHeight
+    )
+
+    private fun jniVoteCommitmentResult(
+        encShares: List<JniWireEncryptedShare> = wireShares(),
+        shareBlinds: List<ByteArray> = fieldElements(JNI_VOTE_SHARE_COUNT, 5),
+        shareComms: List<ByteArray> = fieldElements(JNI_VOTE_SHARE_COUNT, 6)
+    ) = JniVoteCommitmentResult(
+        vanNullifier = ByteArray(FIELD_BYTES) { 1 },
+        voteAuthorityNoteNew = ByteArray(FIELD_BYTES) { 2 },
+        voteCommitment = ByteArray(FIELD_BYTES) { 3 },
+        proposalId = 1,
+        proof = byteArrayOf(4),
+        encShares = encShares,
+        anchorHeight = SNAPSHOT_HEIGHT,
+        voteRoundId = PCZT_ROUND_ID,
+        sharesHash = ByteArray(FIELD_BYTES) { 4 },
+        shareBlinds = shareBlinds,
+        shareComms = shareComms,
+        rVpk = ByteArray(FIELD_BYTES) { 7 },
+        alphaV = ByteArray(FIELD_BYTES) { 8 }
+    )
+
+    private fun wireShares(
+        count: Int = JNI_VOTE_SHARE_COUNT
+    ) = List(count) { index ->
+        JniWireEncryptedShare(
+            c1 = ByteArray(FIELD_BYTES) { (index + 1).toByte() },
+            c2 = ByteArray(FIELD_BYTES) { (index + 2).toByte() },
+            shareIndex = index
+        )
+    }
+
+    private fun fieldElements(
+        count: Int,
+        byteValue: Int
+    ) = List(count) { ByteArray(FIELD_BYTES) { byteValue.toByte() } }
 
     private fun repeatedHex(
         byteValue: Int,

--- a/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
+++ b/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
@@ -940,6 +940,22 @@ class VotingRustBackendTest {
         }
 
     @Test
+    fun sign_cast_vote_returns_signature_for_account_zero() =
+        runTest {
+            val backend = VotingRustBackend.new()
+
+            val signature =
+                backend.signCastVote(
+                    hotkeySeed = HOTKEY_SEED,
+                    networkId = TESTNET_NETWORK_ID,
+                    accountIndex = ACCOUNT_INDEX,
+                    commitment = jniVoteCommitmentResult(alphaV = ByteArray(FIELD_BYTES))
+                )
+
+            assertEquals(JNI_SPEND_AUTH_SIG_BYTES_SIZE, signature.size)
+        }
+
+    @Test
     fun sign_cast_vote_rejects_unsupported_account_index() =
         runTest {
             val backend = VotingRustBackend.new()
@@ -1316,7 +1332,8 @@ class VotingRustBackendTest {
     private fun jniVoteCommitmentResult(
         encShares: List<JniWireEncryptedShare> = wireShares(),
         shareBlinds: List<ByteArray> = fieldElements(JNI_VOTE_SHARE_COUNT, 5),
-        shareComms: List<ByteArray> = fieldElements(JNI_VOTE_SHARE_COUNT, 6)
+        shareComms: List<ByteArray> = fieldElements(JNI_VOTE_SHARE_COUNT, 6),
+        alphaV: ByteArray = ByteArray(FIELD_BYTES) { 8 }
     ) = JniVoteCommitmentResult(
         vanNullifier = ByteArray(FIELD_BYTES) { 1 },
         voteAuthorityNoteNew = ByteArray(FIELD_BYTES) { 2 },
@@ -1330,7 +1347,7 @@ class VotingRustBackendTest {
         shareBlinds = shareBlinds,
         shareComms = shareComms,
         rVpk = ByteArray(FIELD_BYTES) { 7 },
-        alphaV = ByteArray(FIELD_BYTES) { 8 }
+        alphaV = alphaV
     )
 
     private fun wireShares(

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/JniConstants.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/JniConstants.kt
@@ -40,11 +40,15 @@ const val JNI_DELEGATION_PUBLIC_INPUT_COUNT = 14
 
 /**
  * The number of sibling hashes in a vote-authority-note witness.
+ *
+ * Must match VAN_WITNESS_PATH_DEPTH in backend-lib/src/main/rust/voting/helpers.rs.
  */
 const val JNI_VAN_WITNESS_PATH_DEPTH = 24
 
 /**
  * The number of encrypted vote shares produced by vote commitment generation.
+ *
+ * Must match VOTE_SHARE_COUNT in backend-lib/src/main/rust/voting/helpers.rs.
  */
 const val JNI_VOTE_SHARE_COUNT = 16
 

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/JniConstants.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/JniConstants.kt
@@ -39,6 +39,16 @@ const val JNI_PROTOCOL_FIELD_BYTES_SIZE = 32
 const val JNI_DELEGATION_PUBLIC_INPUT_COUNT = 14
 
 /**
+ * The number of sibling hashes in a vote-authority-note witness.
+ */
+const val JNI_VAN_WITNESS_PATH_DEPTH = 24
+
+/**
+ * The number of encrypted vote shares produced by vote commitment generation.
+ */
+const val JNI_VOTE_SHARE_COUNT = 16
+
+/**
  * The number of governance nullifiers emitted by delegation proof generation.
  */
 const val JNI_GOVERNANCE_NULLIFIER_COUNT = 5

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackend.kt
@@ -100,27 +100,15 @@ class VotingRustBackend private constructor() {
     suspend fun signCastVote(
         hotkeySeed: ByteArray,
         networkId: Int,
-        roundId: String,
-        rVpk: ByteArray,
-        vanNullifier: ByteArray,
-        vanNew: ByteArray,
-        voteCommitment: ByteArray,
-        proposalId: Int,
-        anchorHeight: Long,
-        alphaV: ByteArray
+        accountIndex: Int,
+        commitment: JniVoteCommitmentResult
     ): ByteArray =
         withContext(Dispatchers.IO) {
             signCastVoteNative(
                 hotkeySeed,
                 networkId,
-                roundId,
-                rVpk,
-                vanNullifier,
-                vanNew,
-                voteCommitment,
-                proposalId,
-                anchorHeight,
-                alphaV
+                accountIndex,
+                commitment
             ) ?: error("signCastVote returned null")
         }
 
@@ -516,6 +504,7 @@ class VotingRustBackend private constructor() {
             numOptions: Int,
             witness: JniVanWitness,
             networkId: Int,
+            accountIndex: Int,
             singleShare: Boolean,
             proofProgress: VotingProofProgressCallback?
         ): JniVoteCommitmentResult =
@@ -530,6 +519,7 @@ class VotingRustBackend private constructor() {
                     numOptions,
                     witness,
                     networkId,
+                    accountIndex,
                     singleShare,
                     proofProgress?.withVotingDbReentryGuard()
                 ) ?: error("buildVoteCommitment returned null")
@@ -613,14 +603,8 @@ class VotingRustBackend private constructor() {
         private external fun signCastVoteNative(
             hotkeySeed: ByteArray,
             networkId: Int,
-            roundId: String,
-            rVpk: ByteArray,
-            vanNullifier: ByteArray,
-            vanNew: ByteArray,
-            voteCommitment: ByteArray,
-            proposalId: Int,
-            anchorHeight: Long,
-            alphaV: ByteArray
+            accountIndex: Int,
+            commitment: JniVoteCommitmentResult
         ): ByteArray?
 
         @JvmStatic
@@ -883,6 +867,7 @@ class VotingRustBackend private constructor() {
             numOptions: Int,
             witness: JniVanWitness,
             networkId: Int,
+            accountIndex: Int,
             singleShare: Boolean,
             proofProgress: VotingProofProgressCallback?
         ): JniVoteCommitmentResult?

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackend.kt
@@ -11,6 +11,9 @@ import cash.z.ecc.android.sdk.internal.model.voting.JniGovernancePczt
 import cash.z.ecc.android.sdk.internal.model.voting.JniNoteInfo
 import cash.z.ecc.android.sdk.internal.model.voting.JniRoundState
 import cash.z.ecc.android.sdk.internal.model.voting.JniRoundSummary
+import cash.z.ecc.android.sdk.internal.model.voting.JniSharePayload
+import cash.z.ecc.android.sdk.internal.model.voting.JniVanWitness
+import cash.z.ecc.android.sdk.internal.model.voting.JniVoteCommitmentResult
 import cash.z.ecc.android.sdk.internal.model.voting.JniVoteRecord
 import cash.z.ecc.android.sdk.internal.model.voting.JniVotingHotkey
 import cash.z.ecc.android.sdk.internal.model.voting.JniWitnessData
@@ -66,6 +69,59 @@ class VotingRustBackend private constructor() {
     suspend fun warmProvingCaches() =
         withContext(Dispatchers.IO) {
             warmProvingCachesNative()
+        }
+
+    @Throws(RuntimeException::class)
+    suspend fun decomposeWeight(weight: Long): LongArray =
+        withContext(Dispatchers.IO) {
+            decomposeWeightNative(weight)
+                ?: error("decomposeWeight returned null")
+        }
+
+    @Throws(RuntimeException::class)
+    suspend fun buildSharePayloads(
+        commitment: JniVoteCommitmentResult,
+        voteDecision: Int,
+        numOptions: Int,
+        vcTreePosition: Long,
+        singleShareMode: Boolean
+    ): Array<JniSharePayload> =
+        withContext(Dispatchers.IO) {
+            buildSharePayloadsNative(
+                commitment,
+                voteDecision,
+                numOptions,
+                vcTreePosition,
+                singleShareMode
+            ) ?: error("buildSharePayloads returned null")
+        }
+
+    @Throws(RuntimeException::class)
+    suspend fun signCastVote(
+        hotkeySeed: ByteArray,
+        networkId: Int,
+        roundId: String,
+        rVpk: ByteArray,
+        vanNullifier: ByteArray,
+        vanNew: ByteArray,
+        voteCommitment: ByteArray,
+        proposalId: Int,
+        anchorHeight: Long,
+        alphaV: ByteArray
+    ): ByteArray =
+        withContext(Dispatchers.IO) {
+            signCastVoteNative(
+                hotkeySeed,
+                networkId,
+                roundId,
+                rVpk,
+                vanNullifier,
+                vanNew,
+                voteCommitment,
+                proposalId,
+                anchorHeight,
+                alphaV
+            ) ?: error("signCastVote returned null")
         }
 
     @Throws(RuntimeException::class)
@@ -410,6 +466,75 @@ class VotingRustBackend private constructor() {
                 ) ?: error("generateNoteWitnesses returned null")
             }
 
+        @Throws(RuntimeException::class)
+        suspend fun syncVoteTree(roundId: String, nodeUrl: String): Long =
+            withHandle { handle ->
+                syncVoteTreeNative(handle, roundId, nodeUrl).also { height ->
+                    check(height >= 0) {
+                        "syncVoteTree failed for roundId=$roundId"
+                    }
+                }
+            }
+
+        @Throws(RuntimeException::class)
+        suspend fun resetTreeClient(roundId: String) =
+            withHandle { handle ->
+                check(resetTreeClientNative(handle, roundId)) {
+                    "resetTreeClient failed for roundId=$roundId"
+                }
+            }
+
+        @Throws(RuntimeException::class)
+        suspend fun storeVanPosition(
+            roundId: String,
+            bundleIndex: Int,
+            position: Long
+        ) = withHandle { handle ->
+            check(storeVanPositionNative(handle, roundId, bundleIndex, position)) {
+                "storeVanPosition failed for roundId=$roundId bundleIndex=$bundleIndex"
+            }
+        }
+
+        @Throws(RuntimeException::class)
+        suspend fun generateVanWitness(
+            roundId: String,
+            bundleIndex: Int,
+            anchorHeight: Long
+        ): JniVanWitness =
+            withHandle { handle ->
+                generateVanWitnessNative(handle, roundId, bundleIndex, anchorHeight)
+                    ?: error("generateVanWitness returned null")
+            }
+
+        @Throws(RuntimeException::class)
+        suspend fun buildVoteCommitment(
+            roundId: String,
+            bundleIndex: Int,
+            hotkeySeed: ByteArray,
+            proposalId: Int,
+            choice: Int,
+            numOptions: Int,
+            witness: JniVanWitness,
+            networkId: Int,
+            singleShare: Boolean,
+            proofProgress: VotingProofProgressCallback?
+        ): JniVoteCommitmentResult =
+            withHandle { handle ->
+                buildVoteCommitmentNative(
+                    handle,
+                    roundId,
+                    bundleIndex,
+                    hotkeySeed,
+                    proposalId,
+                    choice,
+                    numOptions,
+                    witness,
+                    networkId,
+                    singleShare,
+                    proofProgress?.withVotingDbReentryGuard()
+                ) ?: error("buildVoteCommitment returned null")
+            }
+
         @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
         internal suspend fun storeDelegationProofFixtureForTesting(
             roundId: String,
@@ -468,6 +593,35 @@ class VotingRustBackend private constructor() {
         @JvmStatic
         @Throws(RuntimeException::class)
         private external fun warmProvingCachesNative()
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun decomposeWeightNative(weight: Long): LongArray?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun buildSharePayloadsNative(
+            commitment: JniVoteCommitmentResult,
+            voteDecision: Int,
+            numOptions: Int,
+            vcTreePosition: Long,
+            singleShareMode: Boolean
+        ): Array<JniSharePayload>?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun signCastVoteNative(
+            hotkeySeed: ByteArray,
+            networkId: Int,
+            roundId: String,
+            rVpk: ByteArray,
+            vanNullifier: ByteArray,
+            vanNew: ByteArray,
+            voteCommitment: ByteArray,
+            proposalId: Int,
+            anchorHeight: Long,
+            alphaV: ByteArray
+        ): ByteArray?
 
         @JvmStatic
         @Throws(RuntimeException::class)
@@ -683,6 +837,55 @@ class VotingRustBackend private constructor() {
             networkId: Int,
             notes: Array<JniNoteInfo>
         ): Array<JniWitnessData>?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun syncVoteTreeNative(
+            dbHandle: Long,
+            roundId: String,
+            nodeUrl: String
+        ): Long
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun resetTreeClientNative(
+            dbHandle: Long,
+            roundId: String
+        ): Boolean
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun storeVanPositionNative(
+            dbHandle: Long,
+            roundId: String,
+            bundleIndex: Int,
+            position: Long
+        ): Boolean
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun generateVanWitnessNative(
+            dbHandle: Long,
+            roundId: String,
+            bundleIndex: Int,
+            anchorHeight: Long
+        ): JniVanWitness?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun buildVoteCommitmentNative(
+            dbHandle: Long,
+            roundId: String,
+            bundleIndex: Int,
+            hotkeySeed: ByteArray,
+            proposalId: Int,
+            choice: Int,
+            numOptions: Int,
+            witness: JniVanWitness,
+            networkId: Int,
+            singleShare: Boolean,
+            proofProgress: VotingProofProgressCallback?
+        ): JniVoteCommitmentResult?
 
         @JvmStatic
         @Throws(RuntimeException::class)

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModels.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModels.kt
@@ -134,6 +134,14 @@ data class JniWireEncryptedShare(
     }
 }
 
+/**
+ * Typed JNI carrier for vote commitment outputs.
+ *
+ * `shareBlinds` and `alphaV` are transient reveal/signing inputs. They should
+ * not be persisted or logged; they are carried here only because follow-up JNI
+ * calls consume the typed commitment result. Encrypted-share plaintext and
+ * encryption randomness remain Rust-only and are not included in [encShares].
+ */
 @Keep
 data class JniVoteCommitmentResult(
     val vanNullifier: ByteArray,

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModels.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModels.kt
@@ -137,10 +137,11 @@ data class JniWireEncryptedShare(
 /**
  * Typed JNI carrier for vote commitment outputs.
  *
- * `shareBlinds` and `alphaV` are transient reveal/signing inputs. They should
- * not be persisted or logged; they are carried here only because follow-up JNI
- * calls consume the typed commitment result. Encrypted-share plaintext and
- * encryption randomness remain Rust-only and are not included in [encShares].
+ * `shareBlinds`, `rVpk`, and `alphaV` are transient reveal/signing inputs.
+ * They should not be persisted or logged; they are carried here only because
+ * follow-up JNI calls consume the typed commitment result. Encrypted-share
+ * plaintext and encryption randomness remain Rust-only and are not included in
+ * [encShares].
  */
 @Keep
 data class JniVoteCommitmentResult(
@@ -187,6 +188,22 @@ data class JniVoteCommitmentResult(
         rVpk = rVpk,
         alphaV = alphaV
     )
+
+    override fun toString(): String =
+        "JniVoteCommitmentResult(" +
+            "vanNullifierBytes=${vanNullifier.size}, " +
+            "voteAuthorityNoteNewBytes=${voteAuthorityNoteNew.size}, " +
+            "voteCommitmentBytes=${voteCommitment.size}, " +
+            "proposalId=$proposalId, " +
+            "proofBytes=${proof.size}, " +
+            "encShares=${encShares.size}, " +
+            "anchorHeight=$anchorHeight, " +
+            "voteRoundId=$voteRoundId, " +
+            "sharesHashBytes=${sharesHash.size}, " +
+            "shareBlinds=***, " +
+            "shareComms=${shareComms.size}, " +
+            "rVpk=***, " +
+            "alphaV=***)"
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModels.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModels.kt
@@ -80,6 +80,208 @@ data class JniWitnessData(
     }
 }
 
+@Keep
+data class JniVanWitness(
+    val authPath: List<ByteArray>,
+    val position: Long,
+    val anchorHeight: Long
+) {
+    internal constructor(
+        authPath: Array<ByteArray>,
+        position: Long,
+        anchorHeight: Long
+    ) : this(
+        authPath = authPath.toList(),
+        position = position,
+        anchorHeight = anchorHeight
+    )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is JniVanWitness) return false
+        return authPath.contentDeepEquals(other.authPath) &&
+            position == other.position &&
+            anchorHeight == other.anchorHeight
+    }
+
+    override fun hashCode(): Int {
+        var result = authPath.contentDeepHashCode()
+        result = 31 * result + position.hashCode()
+        result = 31 * result + anchorHeight.hashCode()
+        return result
+    }
+}
+
+@Keep
+data class JniWireEncryptedShare(
+    val c1: ByteArray,
+    val c2: ByteArray,
+    val shareIndex: Int
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is JniWireEncryptedShare) return false
+        return c1.contentEquals(other.c1) &&
+            c2.contentEquals(other.c2) &&
+            shareIndex == other.shareIndex
+    }
+
+    override fun hashCode(): Int {
+        var result = c1.contentHashCode()
+        result = 31 * result + c2.contentHashCode()
+        result = 31 * result + shareIndex
+        return result
+    }
+}
+
+@Keep
+data class JniVoteCommitmentResult(
+    val vanNullifier: ByteArray,
+    val voteAuthorityNoteNew: ByteArray,
+    val voteCommitment: ByteArray,
+    val proposalId: Int,
+    val proof: ByteArray,
+    val encShares: List<JniWireEncryptedShare>,
+    val anchorHeight: Long,
+    val voteRoundId: String,
+    val sharesHash: ByteArray,
+    val shareBlinds: List<ByteArray>,
+    val shareComms: List<ByteArray>,
+    val rVpk: ByteArray,
+    val alphaV: ByteArray
+) {
+    internal constructor(
+        vanNullifier: ByteArray,
+        voteAuthorityNoteNew: ByteArray,
+        voteCommitment: ByteArray,
+        proposalId: Int,
+        proof: ByteArray,
+        encShares: Array<JniWireEncryptedShare>,
+        anchorHeight: Long,
+        voteRoundId: String,
+        sharesHash: ByteArray,
+        shareBlinds: Array<ByteArray>,
+        shareComms: Array<ByteArray>,
+        rVpk: ByteArray,
+        alphaV: ByteArray
+    ) : this(
+        vanNullifier = vanNullifier,
+        voteAuthorityNoteNew = voteAuthorityNoteNew,
+        voteCommitment = voteCommitment,
+        proposalId = proposalId,
+        proof = proof,
+        encShares = encShares.toList(),
+        anchorHeight = anchorHeight,
+        voteRoundId = voteRoundId,
+        sharesHash = sharesHash,
+        shareBlinds = shareBlinds.toList(),
+        shareComms = shareComms.toList(),
+        rVpk = rVpk,
+        alphaV = alphaV
+    )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is JniVoteCommitmentResult) return false
+        return scalarFieldsEqual(other) &&
+            byteFieldsEqual(other) &&
+            listFieldsEqual(other)
+    }
+
+    private fun scalarFieldsEqual(other: JniVoteCommitmentResult) =
+        proposalId == other.proposalId &&
+            anchorHeight == other.anchorHeight &&
+            voteRoundId == other.voteRoundId
+
+    private fun byteFieldsEqual(other: JniVoteCommitmentResult) =
+        vanNullifier.contentEquals(other.vanNullifier) &&
+            voteAuthorityNoteNew.contentEquals(other.voteAuthorityNoteNew) &&
+            voteCommitment.contentEquals(other.voteCommitment) &&
+            proof.contentEquals(other.proof) &&
+            sharesHash.contentEquals(other.sharesHash) &&
+            rVpk.contentEquals(other.rVpk) &&
+            alphaV.contentEquals(other.alphaV)
+
+    private fun listFieldsEqual(other: JniVoteCommitmentResult) =
+        encShares == other.encShares &&
+            shareBlinds.contentDeepEquals(other.shareBlinds) &&
+            shareComms.contentDeepEquals(other.shareComms)
+
+    override fun hashCode(): Int {
+        var result = vanNullifier.contentHashCode()
+        result = 31 * result + voteAuthorityNoteNew.contentHashCode()
+        result = 31 * result + voteCommitment.contentHashCode()
+        result = 31 * result + proposalId
+        result = 31 * result + proof.contentHashCode()
+        result = 31 * result + encShares.hashCode()
+        result = 31 * result + anchorHeight.hashCode()
+        result = 31 * result + voteRoundId.hashCode()
+        result = 31 * result + sharesHash.contentHashCode()
+        result = 31 * result + shareBlinds.contentDeepHashCode()
+        result = 31 * result + shareComms.contentDeepHashCode()
+        result = 31 * result + rVpk.contentHashCode()
+        result = 31 * result + alphaV.contentHashCode()
+        return result
+    }
+}
+
+@Keep
+data class JniSharePayload(
+    val sharesHash: ByteArray,
+    val proposalId: Int,
+    val voteDecision: Int,
+    val encShare: JniWireEncryptedShare,
+    val treePosition: Long,
+    val allEncShares: List<JniWireEncryptedShare>,
+    val shareComms: List<ByteArray>,
+    val primaryBlind: ByteArray
+) {
+    internal constructor(
+        sharesHash: ByteArray,
+        proposalId: Int,
+        voteDecision: Int,
+        encShare: JniWireEncryptedShare,
+        treePosition: Long,
+        allEncShares: Array<JniWireEncryptedShare>,
+        shareComms: Array<ByteArray>,
+        primaryBlind: ByteArray
+    ) : this(
+        sharesHash = sharesHash,
+        proposalId = proposalId,
+        voteDecision = voteDecision,
+        encShare = encShare,
+        treePosition = treePosition,
+        allEncShares = allEncShares.toList(),
+        shareComms = shareComms.toList(),
+        primaryBlind = primaryBlind
+    )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is JniSharePayload) return false
+        return sharesHash.contentEquals(other.sharesHash) &&
+            proposalId == other.proposalId &&
+            voteDecision == other.voteDecision &&
+            encShare == other.encShare &&
+            treePosition == other.treePosition &&
+            allEncShares == other.allEncShares &&
+            shareComms.contentDeepEquals(other.shareComms) &&
+            primaryBlind.contentEquals(other.primaryBlind)
+    }
+
+    override fun hashCode(): Int {
+        var result = sharesHash.contentHashCode()
+        result = 31 * result + proposalId
+        result = 31 * result + voteDecision
+        result = 31 * result + encShare.hashCode()
+        result = 31 * result + treePosition.hashCode()
+        result = 31 * result + allEncShares.hashCode()
+        result = 31 * result + shareComms.contentDeepHashCode()
+        result = 31 * result + primaryBlind.contentHashCode()
+        return result
+    }
+}
+
 @ConsistentCopyVisibility
 data class HotkeyPublicKey internal constructor(
     val value: ByteArray

--- a/backend-lib/src/main/rust/voting.rs
+++ b/backend-lib/src/main/rust/voting.rs
@@ -4,7 +4,9 @@ use anyhow::anyhow;
 use jni::{
     JNIEnv, JavaVM,
     objects::{GlobalRef, JByteArray, JClass, JObject, JObjectArray, JString, JValue},
-    sys::{JNI_FALSE, JNI_TRUE, jboolean, jbyteArray, jint, jlong, jobject, jobjectArray},
+    sys::{
+        JNI_FALSE, JNI_TRUE, jboolean, jbyteArray, jint, jlong, jlongArray, jobject, jobjectArray,
+    },
 };
 use orchard::keys::Scope;
 use secrecy::{ExposeSecret, SecretVec};
@@ -20,9 +22,11 @@ use zcash_protocol::consensus::{BranchId, Network, NetworkConstants};
 use zcash_voting as voting;
 
 use voting::storage::{RoundPhase, RoundState, RoundSummary, VoteRecord, VotingDb};
+use voting::tree_sync::VoteTreeSync;
 use voting::types::{
     DelegationPirPrecomputeResult, DelegationProofResult, DelegationSubmissionData, GovernancePczt,
-    NoopProgressReporter, NoteInfo, ProofProgressReporter, WitnessData,
+    NoopProgressReporter, NoteInfo, ProofProgressReporter, SharePayload, VoteCommitmentBundle,
+    WireEncryptedShare, WitnessData,
 };
 
 use crate::utils::{
@@ -37,4 +41,6 @@ mod notes;
 mod progress;
 mod rounds;
 mod share_tracking;
+mod tree;
 mod util;
+mod vote;

--- a/backend-lib/src/main/rust/voting/db.rs
+++ b/backend-lib/src/main/rust/voting/db.rs
@@ -16,6 +16,7 @@ struct DbKey {
 
 pub(super) struct VotingDbHandle {
     db: VotingDb,
+    pub(super) tree_sync: VoteTreeSync,
     access_mutex: Mutex<()>,
 }
 
@@ -26,6 +27,7 @@ impl VotingDbHandle {
 
         Ok(Self {
             db,
+            tree_sync: VoteTreeSync::new(),
             access_mutex: Mutex::new(()),
         })
     }

--- a/backend-lib/src/main/rust/voting/db.rs
+++ b/backend-lib/src/main/rust/voting/db.rs
@@ -16,6 +16,10 @@ struct DbKey {
 
 pub(super) struct VotingDbHandle {
     db: VotingDb,
+    // VoteTreeSync owns only its synchronous tree-client cache and protects
+    // that cache internally. JNI vote-tree entrypoints still hold access_mutex
+    // before calling it so DB writes and tree-client state changes are
+    // serialized for shared managed handles.
     pub(super) tree_sync: VoteTreeSync,
     access_mutex: Mutex<()>,
 }

--- a/backend-lib/src/main/rust/voting/helpers.rs
+++ b/backend-lib/src/main/rust/voting/helpers.rs
@@ -572,8 +572,9 @@ pub(super) fn java_vote_commitment_bundle(
                 "proposalId",
             )?,
             proof: java_byte_array_field(env, commitment, "proof")?,
-            // Java receives only WireEncryptedShare values; the secret share
-            // plaintext/randomness fields intentionally never cross JNI.
+            // Java carries WireEncryptedShare values plus transient reveal and
+            // signing inputs. The encrypted-share plaintext/randomness fields
+            // intentionally never cross JNI.
             enc_shares: Vec::new(),
             anchor_height: jlong_to_u32(
                 env.get_field(commitment, "anchorHeight", "J")?.j()?,

--- a/backend-lib/src/main/rust/voting/helpers.rs
+++ b/backend-lib/src/main/rust/voting/helpers.rs
@@ -79,7 +79,9 @@ pub(super) const NOTE_SCOPE_EXTERNAL: u32 = 0;
 pub(super) const NOTE_SCOPE_INTERNAL: u32 = 1;
 pub(super) const ORCHARD_DIVERSIFIER_BYTES: usize = 11;
 pub(super) const ORCHARD_WITNESS_PATH_DEPTH: usize = 32;
+// Must match JNI_VAN_WITNESS_PATH_DEPTH in JniConstants.kt.
 pub(super) const VAN_WITNESS_PATH_DEPTH: usize = 24;
+// Must match JNI_VOTE_SHARE_COUNT in JniConstants.kt.
 pub(super) const VOTE_SHARE_COUNT: usize = 16;
 pub(super) const DELEGATION_PUBLIC_INPUT_COUNT: usize = 14;
 pub(super) const GOVERNANCE_NULLIFIER_COUNT: usize = 5;
@@ -150,6 +152,21 @@ fn require_each_len(
         .enumerate()
         .map(|(index, value)| require_len(value, &format!("{field}[{index}]"), expected))
         .collect()
+}
+
+pub(super) fn require_count<T>(
+    values: Vec<T>,
+    field: &str,
+    expected: usize,
+) -> anyhow::Result<Vec<T>> {
+    if values.len() == expected {
+        Ok(values)
+    } else {
+        Err(anyhow!(
+            "{field} must contain {expected} entries, got {}",
+            values.len()
+        ))
+    }
 }
 
 pub(super) fn require_min_len(
@@ -463,6 +480,14 @@ fn java_wire_encrypted_share(
     env: &mut JNIEnv<'_>,
     share: &JObject<'_>,
 ) -> anyhow::Result<WireEncryptedShare> {
+    let share_index = jint_to_u32(env.get_field(share, "shareIndex", "I")?.i()?, "shareIndex")?;
+    if share_index >= VOTE_SHARE_COUNT as u32 {
+        return Err(anyhow!(
+            "shareIndex must be in 0..{}, got {share_index}",
+            VOTE_SHARE_COUNT - 1
+        ));
+    }
+
     Ok(WireEncryptedShare {
         c1: require_len(
             java_byte_array_field(env, share, "c1")?,
@@ -474,7 +499,7 @@ fn java_wire_encrypted_share(
             "c2",
             PROTOCOL_FIELD_BYTES,
         )?,
-        share_index: jint_to_u32(env.get_field(share, "shareIndex", "I")?.i()?, "shareIndex")?,
+        share_index,
     })
 }
 
@@ -499,17 +524,34 @@ fn java_wire_encrypted_share_list_field(
         .collect()
 }
 
+pub(super) struct JavaVoteCommitmentBundle {
+    pub(super) enc_shares: Vec<WireEncryptedShare>,
+    pub(super) bundle: VoteCommitmentBundle,
+}
+
 pub(super) fn java_vote_commitment_bundle(
     env: &mut JNIEnv<'_>,
     commitment: &JObject<'_>,
-) -> anyhow::Result<(Vec<WireEncryptedShare>, VoteCommitmentBundle)> {
-    let enc_shares = java_wire_encrypted_share_list_field(env, commitment, "encShares")?;
-    let share_blinds = java_byte_array_list_field(env, commitment, "shareBlinds")?;
-    let share_comms = java_byte_array_list_field(env, commitment, "shareComms")?;
+) -> anyhow::Result<JavaVoteCommitmentBundle> {
+    let enc_shares = require_count(
+        java_wire_encrypted_share_list_field(env, commitment, "encShares")?,
+        "encShares",
+        VOTE_SHARE_COUNT,
+    )?;
+    let share_blinds = require_count(
+        java_byte_array_list_field(env, commitment, "shareBlinds")?,
+        "shareBlinds",
+        VOTE_SHARE_COUNT,
+    )?;
+    let share_comms = require_count(
+        java_byte_array_list_field(env, commitment, "shareComms")?,
+        "shareComms",
+        VOTE_SHARE_COUNT,
+    )?;
 
-    Ok((
+    Ok(JavaVoteCommitmentBundle {
         enc_shares,
-        VoteCommitmentBundle {
+        bundle: VoteCommitmentBundle {
             van_nullifier: require_len(
                 java_byte_array_field(env, commitment, "vanNullifier")?,
                 "vanNullifier",
@@ -530,6 +572,8 @@ pub(super) fn java_vote_commitment_bundle(
                 "proposalId",
             )?,
             proof: java_byte_array_field(env, commitment, "proof")?,
+            // Java receives only WireEncryptedShare values; the secret share
+            // plaintext/randomness fields intentionally never cross JNI.
             enc_shares: Vec::new(),
             anchor_height: jlong_to_u32(
                 env.get_field(commitment, "anchorHeight", "J")?.j()?,
@@ -554,7 +598,7 @@ pub(super) fn java_vote_commitment_bundle(
                 PROTOCOL_FIELD_BYTES,
             )?,
         },
-    ))
+    })
 }
 
 fn require_note_scope(scope: u32) -> anyhow::Result<u32> {
@@ -895,6 +939,7 @@ pub(super) fn make_jni_vote_commitment_result<'local>(
         .into_iter()
         .map(WireEncryptedShare::from)
         .collect();
+    let enc_shares = require_count(enc_shares, "enc_shares", VOTE_SHARE_COUNT)?;
     let van_nullifier = make_jni_fixed_bytes(
         env,
         bundle.van_nullifier,
@@ -996,7 +1041,8 @@ fn make_jni_share_payload<'local>(
         PROTOCOL_FIELD_BYTES,
     )?;
     let enc_share = make_jni_wire_encrypted_share(env, payload.enc_share)?;
-    let all_enc_shares = make_jni_wire_encrypted_share_array(env, payload.all_enc_shares)?;
+    let all_enc_shares = require_count(payload.all_enc_shares, "all_enc_shares", VOTE_SHARE_COUNT)?;
+    let all_enc_shares = make_jni_wire_encrypted_share_array(env, all_enc_shares)?;
     let share_comms = make_jni_fixed_byte_array_vec(
         env,
         payload.share_comms,

--- a/backend-lib/src/main/rust/voting/helpers.rs
+++ b/backend-lib/src/main/rust/voting/helpers.rs
@@ -36,7 +36,7 @@ const JNI_NOTE_INFO_CTOR_SIG: &str = "([B[BJJ[B[B[BILjava/lang/String;)V";
 // in JniVotingModels.kt. Guarded by JniVotingModelsTest.
 const JNI_WITNESS_DATA_CTOR_SIG: &str = "([BJ[B[[B)V";
 // Must match JniVanWitness(Array<ByteArray>, Long, Long) in
-// JniVotingModels.kt.
+// JniVotingModels.kt. Guarded by JniVotingModelsTest.
 const JNI_VAN_WITNESS_CTOR_SIG: &str = "([[BJJ)V";
 // Must match JniWireEncryptedShare(ByteArray, ByteArray, Int) in
 // JniVotingModels.kt.
@@ -44,11 +44,11 @@ const JNI_WIRE_ENCRYPTED_SHARE_CTOR_SIG: &str = "([B[BI)V";
 // Must match JniVoteCommitmentResult(ByteArray, ByteArray, ByteArray, Int,
 // ByteArray, Array<JniWireEncryptedShare>, Long, String, ByteArray,
 // Array<ByteArray>, Array<ByteArray>, ByteArray, ByteArray) in
-// JniVotingModels.kt.
+// JniVotingModels.kt. Guarded by JniVotingModelsTest.
 const JNI_VOTE_COMMITMENT_RESULT_CTOR_SIG: &str = "([B[B[BI[B[Lcash/z/ecc/android/sdk/internal/model/voting/JniWireEncryptedShare;JLjava/lang/String;[B[[B[[B[B[B)V";
 // Must match JniSharePayload(ByteArray, Int, Int, JniWireEncryptedShare,
 // Long, Array<JniWireEncryptedShare>, Array<ByteArray>, ByteArray) in
-// JniVotingModels.kt.
+// JniVotingModels.kt. Guarded by JniVotingModelsTest.
 const JNI_SHARE_PAYLOAD_CTOR_SIG: &str = "([BIILcash/z/ecc/android/sdk/internal/model/voting/JniWireEncryptedShare;J[Lcash/z/ecc/android/sdk/internal/model/voting/JniWireEncryptedShare;[[B[B)V";
 // Must match JniVotingHotkey(ByteArray, String) in JniVotingModels.kt.
 const JNI_VOTING_HOTKEY_CTOR_SIG: &str = "([BLjava/lang/String;)V";

--- a/backend-lib/src/main/rust/voting/helpers.rs
+++ b/backend-lib/src/main/rust/voting/helpers.rs
@@ -11,6 +11,12 @@ const JNI_ROUND_SUMMARY: &str = "cash/z/ecc/android/sdk/internal/model/voting/Jn
 const JNI_VOTE_RECORD: &str = "cash/z/ecc/android/sdk/internal/model/voting/JniVoteRecord";
 const JNI_NOTE_INFO: &str = "cash/z/ecc/android/sdk/internal/model/voting/JniNoteInfo";
 const JNI_WITNESS_DATA: &str = "cash/z/ecc/android/sdk/internal/model/voting/JniWitnessData";
+const JNI_VAN_WITNESS: &str = "cash/z/ecc/android/sdk/internal/model/voting/JniVanWitness";
+const JNI_WIRE_ENCRYPTED_SHARE: &str =
+    "cash/z/ecc/android/sdk/internal/model/voting/JniWireEncryptedShare";
+const JNI_VOTE_COMMITMENT_RESULT: &str =
+    "cash/z/ecc/android/sdk/internal/model/voting/JniVoteCommitmentResult";
+const JNI_SHARE_PAYLOAD: &str = "cash/z/ecc/android/sdk/internal/model/voting/JniSharePayload";
 const JNI_VOTING_HOTKEY: &str = "cash/z/ecc/android/sdk/internal/model/voting/JniVotingHotkey";
 const JNI_BUNDLE_SETUP_RESULT: &str =
     "cash/z/ecc/android/sdk/internal/model/voting/JniBundleSetupResult";
@@ -29,6 +35,21 @@ const JNI_NOTE_INFO_CTOR_SIG: &str = "([B[BJJ[B[B[BILjava/lang/String;)V";
 // Must match JniWitnessData(ByteArray, Long, ByteArray, Array<ByteArray>)
 // in JniVotingModels.kt. Guarded by JniVotingModelsTest.
 const JNI_WITNESS_DATA_CTOR_SIG: &str = "([BJ[B[[B)V";
+// Must match JniVanWitness(Array<ByteArray>, Long, Long) in
+// JniVotingModels.kt.
+const JNI_VAN_WITNESS_CTOR_SIG: &str = "([[BJJ)V";
+// Must match JniWireEncryptedShare(ByteArray, ByteArray, Int) in
+// JniVotingModels.kt.
+const JNI_WIRE_ENCRYPTED_SHARE_CTOR_SIG: &str = "([B[BI)V";
+// Must match JniVoteCommitmentResult(ByteArray, ByteArray, ByteArray, Int,
+// ByteArray, Array<JniWireEncryptedShare>, Long, String, ByteArray,
+// Array<ByteArray>, Array<ByteArray>, ByteArray, ByteArray) in
+// JniVotingModels.kt.
+const JNI_VOTE_COMMITMENT_RESULT_CTOR_SIG: &str = "([B[B[BI[B[Lcash/z/ecc/android/sdk/internal/model/voting/JniWireEncryptedShare;JLjava/lang/String;[B[[B[[B[B[B)V";
+// Must match JniSharePayload(ByteArray, Int, Int, JniWireEncryptedShare,
+// Long, Array<JniWireEncryptedShare>, Array<ByteArray>, ByteArray) in
+// JniVotingModels.kt.
+const JNI_SHARE_PAYLOAD_CTOR_SIG: &str = "([BIILcash/z/ecc/android/sdk/internal/model/voting/JniWireEncryptedShare;J[Lcash/z/ecc/android/sdk/internal/model/voting/JniWireEncryptedShare;[[B[B)V";
 // Must match JniVotingHotkey(ByteArray, String) in JniVotingModels.kt.
 const JNI_VOTING_HOTKEY_CTOR_SIG: &str = "([BLjava/lang/String;)V";
 // Must match JniBundleSetupResult(Int, Long, LongArray) in JniVotingModels.kt.
@@ -58,6 +79,8 @@ pub(super) const NOTE_SCOPE_EXTERNAL: u32 = 0;
 pub(super) const NOTE_SCOPE_INTERNAL: u32 = 1;
 pub(super) const ORCHARD_DIVERSIFIER_BYTES: usize = 11;
 pub(super) const ORCHARD_WITNESS_PATH_DEPTH: usize = 32;
+pub(super) const VAN_WITNESS_PATH_DEPTH: usize = 24;
+pub(super) const VOTE_SHARE_COUNT: usize = 16;
 pub(super) const DELEGATION_PUBLIC_INPUT_COUNT: usize = 14;
 pub(super) const GOVERNANCE_NULLIFIER_COUNT: usize = 5;
 pub(super) const ACCOUNT_UUID_BYTES: usize = 16;
@@ -408,6 +431,132 @@ pub(super) fn java_witness_data(
     })
 }
 
+pub(super) fn java_van_witness(
+    env: &mut JNIEnv<'_>,
+    witness: &JObject<'_>,
+) -> anyhow::Result<voting::tree_sync::VanWitness> {
+    let auth_path = java_byte_array_list_field(env, witness, "authPath")?;
+    if auth_path.len() != VAN_WITNESS_PATH_DEPTH {
+        return Err(anyhow!(
+            "authPath must contain {VAN_WITNESS_PATH_DEPTH} entries, got {}",
+            auth_path.len()
+        ));
+    }
+
+    let auth_path = auth_path
+        .into_iter()
+        .enumerate()
+        .map(|(index, bytes)| fixed_bytes(bytes, &format!("authPath[{index}]")))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    Ok(voting::tree_sync::VanWitness {
+        auth_path,
+        position: jlong_to_u32(env.get_field(witness, "position", "J")?.j()?, "position")?,
+        anchor_height: jlong_to_u32(
+            env.get_field(witness, "anchorHeight", "J")?.j()?,
+            "anchorHeight",
+        )?,
+    })
+}
+
+fn java_wire_encrypted_share(
+    env: &mut JNIEnv<'_>,
+    share: &JObject<'_>,
+) -> anyhow::Result<WireEncryptedShare> {
+    Ok(WireEncryptedShare {
+        c1: require_len(
+            java_byte_array_field(env, share, "c1")?,
+            "c1",
+            PROTOCOL_FIELD_BYTES,
+        )?,
+        c2: require_len(
+            java_byte_array_field(env, share, "c2")?,
+            "c2",
+            PROTOCOL_FIELD_BYTES,
+        )?,
+        share_index: jint_to_u32(env.get_field(share, "shareIndex", "I")?.i()?, "shareIndex")?,
+    })
+}
+
+fn java_wire_encrypted_share_list_field(
+    env: &mut JNIEnv<'_>,
+    obj: &JObject<'_>,
+    name: &str,
+) -> anyhow::Result<Vec<WireEncryptedShare>> {
+    let list = env.get_field(obj, name, "Ljava/util/List;")?.l()?;
+    let count = env.call_method(&list, "size", "()I", &[])?.i()?;
+    if count < 0 {
+        return Err(anyhow!("{name}.size() returned negative count {count}"));
+    }
+
+    (0..count)
+        .map(|index| {
+            let share = env
+                .call_method(&list, "get", "(I)Ljava/lang/Object;", &[JValue::Int(index)])?
+                .l()?;
+            java_wire_encrypted_share(env, &share).map_err(|e| anyhow!("{name}[{index}]: {e}"))
+        })
+        .collect()
+}
+
+pub(super) fn java_vote_commitment_bundle(
+    env: &mut JNIEnv<'_>,
+    commitment: &JObject<'_>,
+) -> anyhow::Result<(Vec<WireEncryptedShare>, VoteCommitmentBundle)> {
+    let enc_shares = java_wire_encrypted_share_list_field(env, commitment, "encShares")?;
+    let share_blinds = java_byte_array_list_field(env, commitment, "shareBlinds")?;
+    let share_comms = java_byte_array_list_field(env, commitment, "shareComms")?;
+
+    Ok((
+        enc_shares,
+        VoteCommitmentBundle {
+            van_nullifier: require_len(
+                java_byte_array_field(env, commitment, "vanNullifier")?,
+                "vanNullifier",
+                PROTOCOL_FIELD_BYTES,
+            )?,
+            vote_authority_note_new: require_len(
+                java_byte_array_field(env, commitment, "voteAuthorityNoteNew")?,
+                "voteAuthorityNoteNew",
+                PROTOCOL_FIELD_BYTES,
+            )?,
+            vote_commitment: require_len(
+                java_byte_array_field(env, commitment, "voteCommitment")?,
+                "voteCommitment",
+                PROTOCOL_FIELD_BYTES,
+            )?,
+            proposal_id: jint_to_u32(
+                env.get_field(commitment, "proposalId", "I")?.i()?,
+                "proposalId",
+            )?,
+            proof: java_byte_array_field(env, commitment, "proof")?,
+            enc_shares: Vec::new(),
+            anchor_height: jlong_to_u32(
+                env.get_field(commitment, "anchorHeight", "J")?.j()?,
+                "anchorHeight",
+            )?,
+            vote_round_id: java_string_field(env, commitment, "voteRoundId")?,
+            shares_hash: require_len(
+                java_byte_array_field(env, commitment, "sharesHash")?,
+                "sharesHash",
+                PROTOCOL_FIELD_BYTES,
+            )?,
+            share_blinds: require_each_len(share_blinds, "shareBlinds", PROTOCOL_FIELD_BYTES)?,
+            share_comms: require_each_len(share_comms, "shareComms", PROTOCOL_FIELD_BYTES)?,
+            r_vpk_bytes: require_len(
+                java_byte_array_field(env, commitment, "rVpk")?,
+                "rVpk",
+                PROTOCOL_FIELD_BYTES,
+            )?,
+            alpha_v: require_len(
+                java_byte_array_field(env, commitment, "alphaV")?,
+                "alphaV",
+                PROTOCOL_FIELD_BYTES,
+            )?,
+        },
+    ))
+}
+
 fn require_note_scope(scope: u32) -> anyhow::Result<u32> {
     match scope {
         NOTE_SCOPE_EXTERNAL | NOTE_SCOPE_INTERNAL => Ok(scope),
@@ -660,6 +809,224 @@ fn make_jni_witness_data<'local>(
             ],
         )?)
     })
+}
+
+pub(super) fn make_jni_van_witness<'local>(
+    env: &mut JNIEnv<'local>,
+    witness: voting::tree_sync::VanWitness,
+) -> anyhow::Result<jobject> {
+    let class = env.find_class(JNI_VAN_WITNESS)?;
+    let auth_path = witness
+        .auth_path
+        .into_iter()
+        .map(|bytes| bytes.to_vec())
+        .collect();
+    let auth_path = make_jni_fixed_byte_array_vec(
+        env,
+        auth_path,
+        "auth_path",
+        VAN_WITNESS_PATH_DEPTH,
+        PROTOCOL_FIELD_BYTES,
+    )?;
+    let auth_path = JObject::from(auth_path);
+
+    Ok(env
+        .new_object(
+            &class,
+            JNI_VAN_WITNESS_CTOR_SIG,
+            &[
+                JValue::Object(&auth_path),
+                JValue::Long(u64_to_jlong(u64::from(witness.position), "position")?),
+                JValue::Long(u64_to_jlong(
+                    u64::from(witness.anchor_height),
+                    "anchor_height",
+                )?),
+            ],
+        )?
+        .into_raw())
+}
+
+fn make_jni_wire_encrypted_share<'local>(
+    env: &mut JNIEnv<'local>,
+    share: WireEncryptedShare,
+) -> anyhow::Result<JObject<'local>> {
+    let class = env.find_class(JNI_WIRE_ENCRYPTED_SHARE)?;
+    let c1 = make_jni_fixed_bytes(env, share.c1, "c1", PROTOCOL_FIELD_BYTES)?;
+    let c2 = make_jni_fixed_bytes(env, share.c2, "c2", PROTOCOL_FIELD_BYTES)?;
+
+    Ok(env.new_object(
+        &class,
+        JNI_WIRE_ENCRYPTED_SHARE_CTOR_SIG,
+        &[
+            JValue::Object(&c1),
+            JValue::Object(&c2),
+            JValue::Int(u32_to_jint(share.share_index, "share_index")?),
+        ],
+    )?)
+}
+
+fn make_jni_wire_encrypted_share_array<'local>(
+    env: &mut JNIEnv<'local>,
+    shares: Vec<WireEncryptedShare>,
+) -> anyhow::Result<JObjectArray<'local>> {
+    let len = usize_to_jint(shares.len(), "shares length")?;
+    let class = env.find_class(JNI_WIRE_ENCRYPTED_SHARE)?;
+    let mut shares = shares.into_iter().enumerate();
+    if let Some((_, first)) = shares.next() {
+        let first = make_jni_wire_encrypted_share(env, first)?;
+        let array = env.new_object_array(len, &class, &first)?;
+        for (index, share) in shares {
+            let share = make_jni_wire_encrypted_share(env, share)?;
+            env.set_object_array_element(&array, usize_to_jint(index, "shares index")?, share)?;
+        }
+        Ok(array)
+    } else {
+        Ok(env.new_object_array(0, &class, JObject::null())?)
+    }
+}
+
+pub(super) fn make_jni_vote_commitment_result<'local>(
+    env: &mut JNIEnv<'local>,
+    bundle: VoteCommitmentBundle,
+) -> anyhow::Result<jobject> {
+    let class = env.find_class(JNI_VOTE_COMMITMENT_RESULT)?;
+    let enc_shares = bundle
+        .enc_shares
+        .into_iter()
+        .map(WireEncryptedShare::from)
+        .collect();
+    let van_nullifier = make_jni_fixed_bytes(
+        env,
+        bundle.van_nullifier,
+        "van_nullifier",
+        PROTOCOL_FIELD_BYTES,
+    )?;
+    let vote_authority_note_new = make_jni_fixed_bytes(
+        env,
+        bundle.vote_authority_note_new,
+        "vote_authority_note_new",
+        PROTOCOL_FIELD_BYTES,
+    )?;
+    let vote_commitment = make_jni_fixed_bytes(
+        env,
+        bundle.vote_commitment,
+        "vote_commitment",
+        PROTOCOL_FIELD_BYTES,
+    )?;
+    let proof = make_jni_bytes(env, &bundle.proof)?;
+    let enc_shares = make_jni_wire_encrypted_share_array(env, enc_shares)?;
+    let enc_shares = JObject::from(enc_shares);
+    let vote_round_id: JObject<'local> = env.new_string(bundle.vote_round_id)?.into();
+    let shares_hash =
+        make_jni_fixed_bytes(env, bundle.shares_hash, "shares_hash", PROTOCOL_FIELD_BYTES)?;
+    let share_blinds = make_jni_fixed_byte_array_vec(
+        env,
+        bundle.share_blinds,
+        "share_blinds",
+        VOTE_SHARE_COUNT,
+        PROTOCOL_FIELD_BYTES,
+    )?;
+    let share_comms = make_jni_fixed_byte_array_vec(
+        env,
+        bundle.share_comms,
+        "share_comms",
+        VOTE_SHARE_COUNT,
+        PROTOCOL_FIELD_BYTES,
+    )?;
+    let share_blinds = JObject::from(share_blinds);
+    let share_comms = JObject::from(share_comms);
+    let r_vpk = make_jni_fixed_bytes(env, bundle.r_vpk_bytes, "r_vpk", PROTOCOL_FIELD_BYTES)?;
+    let alpha_v = make_jni_fixed_bytes(env, bundle.alpha_v, "alpha_v", PROTOCOL_FIELD_BYTES)?;
+
+    Ok(env
+        .new_object(
+            &class,
+            JNI_VOTE_COMMITMENT_RESULT_CTOR_SIG,
+            &[
+                JValue::Object(&van_nullifier),
+                JValue::Object(&vote_authority_note_new),
+                JValue::Object(&vote_commitment),
+                JValue::Int(u32_to_jint(bundle.proposal_id, "proposal_id")?),
+                JValue::Object(&proof),
+                JValue::Object(&enc_shares),
+                JValue::Long(u64_to_jlong(
+                    u64::from(bundle.anchor_height),
+                    "anchor_height",
+                )?),
+                JValue::Object(&vote_round_id),
+                JValue::Object(&shares_hash),
+                JValue::Object(&share_blinds),
+                JValue::Object(&share_comms),
+                JValue::Object(&r_vpk),
+                JValue::Object(&alpha_v),
+            ],
+        )?
+        .into_raw())
+}
+
+pub(super) fn make_jni_share_payload_array<'local>(
+    env: &mut JNIEnv<'local>,
+    payloads: Vec<SharePayload>,
+) -> anyhow::Result<jobjectArray> {
+    let len = usize_to_jint(payloads.len(), "payloads length")?;
+    let class = env.find_class(JNI_SHARE_PAYLOAD)?;
+    let mut payloads = payloads.into_iter().enumerate();
+    if let Some((_, first)) = payloads.next() {
+        let first = make_jni_share_payload(env, first)?;
+        let array = env.new_object_array(len, &class, &first)?;
+        for (index, payload) in payloads {
+            let payload = make_jni_share_payload(env, payload)?;
+            env.set_object_array_element(&array, usize_to_jint(index, "payloads index")?, payload)?;
+        }
+        Ok(array.into_raw())
+    } else {
+        Ok(env.new_object_array(0, &class, JObject::null())?.into_raw())
+    }
+}
+
+fn make_jni_share_payload<'local>(
+    env: &mut JNIEnv<'local>,
+    payload: SharePayload,
+) -> anyhow::Result<JObject<'local>> {
+    let class = env.find_class(JNI_SHARE_PAYLOAD)?;
+    let shares_hash = make_jni_fixed_bytes(
+        env,
+        payload.shares_hash,
+        "shares_hash",
+        PROTOCOL_FIELD_BYTES,
+    )?;
+    let enc_share = make_jni_wire_encrypted_share(env, payload.enc_share)?;
+    let all_enc_shares = make_jni_wire_encrypted_share_array(env, payload.all_enc_shares)?;
+    let share_comms = make_jni_fixed_byte_array_vec(
+        env,
+        payload.share_comms,
+        "share_comms",
+        VOTE_SHARE_COUNT,
+        PROTOCOL_FIELD_BYTES,
+    )?;
+    let primary_blind = make_jni_fixed_bytes(
+        env,
+        payload.primary_blind,
+        "primary_blind",
+        PROTOCOL_FIELD_BYTES,
+    )?;
+    let all_enc_shares = JObject::from(all_enc_shares);
+    let share_comms = JObject::from(share_comms);
+
+    Ok(env.new_object(
+        &class,
+        JNI_SHARE_PAYLOAD_CTOR_SIG,
+        &[
+            JValue::Object(&shares_hash),
+            JValue::Int(u32_to_jint(payload.proposal_id, "proposal_id")?),
+            JValue::Int(u32_to_jint(payload.vote_decision, "vote_decision")?),
+            JValue::Object(&enc_share),
+            JValue::Long(u64_to_jlong(payload.tree_position, "tree_position")?),
+            JValue::Object(&all_enc_shares),
+            JValue::Object(&share_comms),
+            JValue::Object(&primary_blind),
+        ],
+    )?)
 }
 
 /// Builds the Kotlin hotkey JNI model after enforcing the expected key widths.

--- a/backend-lib/src/main/rust/voting/tree.rs
+++ b/backend-lib/src/main/rust/voting/tree.rs
@@ -1,0 +1,100 @@
+use super::db::*;
+use super::helpers::*;
+use super::*;
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_syncVoteTreeNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_handle: jlong,
+    round_id: JString<'local>,
+    node_url: JString<'local>,
+) -> jlong {
+    let res = catch_unwind(&mut env, |env| {
+        let db = db_from_handle(db_handle)?;
+        let _access_lock = db.access_lock()?;
+        let round_id = java_string_to_rust(env, &round_id)?;
+        let node_url = java_string_to_rust(env, &node_url)?;
+        let height = db
+            .tree_sync
+            .sync(&db, &round_id, &node_url)
+            .map_err(|e| anyhow!("sync_vote_tree: {}", e))?;
+        u64_to_jlong(u64::from(height), "synced_height")
+    });
+    unwrap_exc_or(&mut env, res, -1)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_resetTreeClientNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_handle: jlong,
+    round_id: JString<'local>,
+) -> jboolean {
+    let res = catch_unwind(&mut env, |env| {
+        let db = db_from_handle(db_handle)?;
+        let _access_lock = db.access_lock()?;
+        db.tree_sync
+            .reset(&java_string_to_rust(env, &round_id)?)
+            .map_err(|e| anyhow!("reset_tree_client: {}", e))?;
+        Ok(JNI_TRUE)
+    });
+    unwrap_exc_or(&mut env, res, JNI_FALSE)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_storeVanPositionNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_handle: jlong,
+    round_id: JString<'local>,
+    bundle_index: jint,
+    position: jlong,
+) -> jboolean {
+    let res = catch_unwind(&mut env, |env| {
+        let db = db_from_handle(db_handle)?;
+        let _access_lock = db.access_lock()?;
+        db.store_van_position(
+            &java_string_to_rust(env, &round_id)?,
+            jint_to_u32(bundle_index, "bundle_index")?,
+            jlong_to_u32(position, "position")?,
+        )
+        .map_err(|e| anyhow!("store_van_position: {}", e))?;
+        Ok(JNI_TRUE)
+    });
+    unwrap_exc_or(&mut env, res, JNI_FALSE)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_generateVanWitnessNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_handle: jlong,
+    round_id: JString<'local>,
+    bundle_index: jint,
+    anchor_height: jlong,
+) -> jobject {
+    let res = catch_unwind(&mut env, |env| {
+        let db = db_from_handle(db_handle)?;
+        let _access_lock = db.access_lock()?;
+        let witness = db
+            .tree_sync
+            .generate_van_witness(
+                &db,
+                &java_string_to_rust(env, &round_id)?,
+                jint_to_u32(bundle_index, "bundle_index")?,
+                jlong_to_u32(anchor_height, "anchor_height")?,
+            )
+            .map_err(|e| anyhow!("generate_van_witness: {}", e))?;
+        make_jni_van_witness(env, witness)
+    });
+    unwrap_exc_or(&mut env, res, JObject::null().into_raw())
+}

--- a/backend-lib/src/main/rust/voting/vote.rs
+++ b/backend-lib/src/main/rust/voting/vote.rs
@@ -67,6 +67,9 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_sig
         let hotkey_seed =
             java_secret_bytes_at_least(env, &hotkey_seed, "hotkey_seed", PROTOCOL_FIELD_BYTES)?;
         let commitment = java_vote_commitment_bundle(env, &commitment)?.bundle;
+        // zcash_voting owns the canonical cast-vote sighash domain and field
+        // order. The JNI layer keeps this typed and passes the bundle fields
+        // through instead of reconstructing the sighash locally.
         let sig = voting::vote_commitment::sign_cast_vote(
             hotkey_seed.expose_secret(),
             u32::try_from(network_id)

--- a/backend-lib/src/main/rust/voting/vote.rs
+++ b/backend-lib/src/main/rust/voting/vote.rs
@@ -36,10 +36,10 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_bui
     single_share_mode: jboolean,
 ) -> jobjectArray {
     let res = catch_unwind(&mut env, |env| {
-        let (enc_shares, commitment) = java_vote_commitment_bundle(env, &commitment)?;
+        let commitment = java_vote_commitment_bundle(env, &commitment)?;
         let payloads = voting::vote_commitment::build_share_payloads(
-            &enc_shares,
-            &commitment,
+            &commitment.enc_shares,
+            &commitment.bundle,
             jint_to_u32(vote_decision, "vote_decision")?,
             jint_to_u32(num_options, "num_options")?,
             jlong_to_u64(vc_tree_position, "vc_tree_position")?,
@@ -59,35 +59,26 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_sig
     _: JClass<'local>,
     hotkey_seed: JByteArray<'local>,
     network_id: jint,
-    round_id: JString<'local>,
-    r_vpk: JByteArray<'local>,
-    van_nullifier: JByteArray<'local>,
-    van_new: JByteArray<'local>,
-    vote_commitment: JByteArray<'local>,
-    proposal_id: jint,
-    anchor_height: jlong,
-    alpha_v: JByteArray<'local>,
+    account_index: jint,
+    commitment: JObject<'local>,
 ) -> jbyteArray {
     let res = catch_unwind(&mut env, |env| {
+        require_supported_vote_account(account_index)?;
         let hotkey_seed =
             java_secret_bytes_at_least(env, &hotkey_seed, "hotkey_seed", PROTOCOL_FIELD_BYTES)?;
+        let commitment = java_vote_commitment_bundle(env, &commitment)?.bundle;
         let sig = voting::vote_commitment::sign_cast_vote(
             hotkey_seed.expose_secret(),
             u32::try_from(network_id)
                 .map_err(|_| anyhow!("network_id must be non-negative, got {network_id}"))?,
-            &java_string_to_rust(env, &round_id)?,
-            &java_bytes_exact(env, &r_vpk, "r_vpk", PROTOCOL_FIELD_BYTES)?,
-            &java_bytes_exact(env, &van_nullifier, "van_nullifier", PROTOCOL_FIELD_BYTES)?,
-            &java_bytes_exact(env, &van_new, "van_new", PROTOCOL_FIELD_BYTES)?,
-            &java_bytes_exact(
-                env,
-                &vote_commitment,
-                "vote_commitment",
-                PROTOCOL_FIELD_BYTES,
-            )?,
-            jint_to_u32(proposal_id, "proposal_id")?,
-            jlong_to_u32(anchor_height, "anchor_height")?,
-            &java_bytes_exact(env, &alpha_v, "alpha_v", PROTOCOL_FIELD_BYTES)?,
+            &commitment.vote_round_id,
+            &commitment.r_vpk_bytes,
+            &commitment.van_nullifier,
+            &commitment.vote_authority_note_new,
+            &commitment.vote_commitment,
+            commitment.proposal_id,
+            commitment.anchor_height,
+            &commitment.alpha_v,
         )
         .map_err(|e| anyhow!("sign_cast_vote: {}", e))?;
         Ok(env.byte_array_from_slice(&sig.vote_auth_sig)?.into_raw())
@@ -110,6 +101,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_bui
     num_options: jint,
     witness: JObject<'local>,
     network_id: jint,
+    account_index: jint,
     single_share: jboolean,
     progress_callback: JObject<'local>,
 ) -> jobject {
@@ -117,9 +109,16 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_bui
         let db = db_from_handle(db_handle)?;
         let _access_lock = db.access_lock()?;
         let round_id = java_string_to_rust(env, &round_id)?;
+        require_supported_vote_account(account_index)?;
         let hotkey_seed =
             java_secret_bytes_at_least(env, &hotkey_seed, "hotkey_seed", PROTOCOL_FIELD_BYTES)?;
         let witness = java_van_witness(env, &witness)?;
+        require_delegation_ready_for_vote(
+            &db,
+            &round_id,
+            jint_to_u32(bundle_index, "bundle_index")?,
+            &witness,
+        )?;
         let reporter = progress_reporter_from_callback(env, &progress_callback)?;
         let bundle = db
             .build_vote_commitment(
@@ -141,4 +140,47 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_bui
         make_jni_vote_commitment_result(env, bundle)
     });
     unwrap_exc_or(&mut env, res, JObject::null().into_raw())
+}
+
+fn require_supported_vote_account(account_index: jint) -> anyhow::Result<()> {
+    let account_index = jint_to_u32(account_index, "account_index")?;
+    if account_index == 0 {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "vote construction currently supports only account_index=0, got {account_index}"
+        ))
+    }
+}
+
+fn require_delegation_ready_for_vote(
+    db: &VotingDbHandle,
+    round_id: &str,
+    bundle_index: u32,
+    witness: &voting::tree_sync::VanWitness,
+) -> anyhow::Result<()> {
+    let conn = db.conn();
+    let wallet_id = db.wallet_id();
+    voting::storage::queries::load_delegation_submission_data(
+        &conn,
+        round_id,
+        &wallet_id,
+        bundle_index,
+    )
+    .map_err(|e| anyhow!("delegation proof is not ready for vote commitment: {e}"))?;
+
+    let stored_position =
+        voting::storage::queries::load_van_position(&conn, round_id, &wallet_id, bundle_index)
+            .map_err(|e| anyhow!("VAN position is not ready for vote commitment: {e}"))?;
+    if stored_position != witness.position {
+        return Err(anyhow!(
+            "VAN witness position {} does not match stored VAN position {} for round={} bundle={}",
+            witness.position,
+            stored_position,
+            round_id,
+            bundle_index
+        ));
+    }
+
+    Ok(())
 }

--- a/backend-lib/src/main/rust/voting/vote.rs
+++ b/backend-lib/src/main/rust/voting/vote.rs
@@ -1,0 +1,144 @@
+use super::db::*;
+use super::helpers::*;
+use super::progress::*;
+use super::*;
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_decomposeWeightNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    weight: jlong,
+) -> jlongArray {
+    let res = catch_unwind(&mut env, |env| {
+        let parts = voting::decompose::decompose_weight(jlong_to_u64(weight, "weight")?)
+            .into_iter()
+            .map(|part| u64_to_jlong(part, "weight share"))
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let array = env.new_long_array(usize_to_jint(parts.len(), "weight share count")?)?;
+        env.set_long_array_region(&array, 0, &parts)?;
+        Ok(array.into_raw())
+    });
+    unwrap_exc_or(&mut env, res, std::ptr::null_mut())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_buildSharePayloadsNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    commitment: JObject<'local>,
+    vote_decision: jint,
+    num_options: jint,
+    vc_tree_position: jlong,
+    single_share_mode: jboolean,
+) -> jobjectArray {
+    let res = catch_unwind(&mut env, |env| {
+        let (enc_shares, commitment) = java_vote_commitment_bundle(env, &commitment)?;
+        let payloads = voting::vote_commitment::build_share_payloads(
+            &enc_shares,
+            &commitment,
+            jint_to_u32(vote_decision, "vote_decision")?,
+            jint_to_u32(num_options, "num_options")?,
+            jlong_to_u64(vc_tree_position, "vc_tree_position")?,
+            single_share_mode == JNI_TRUE,
+        )
+        .map_err(|e| anyhow!("build_share_payloads: {}", e))?;
+        make_jni_share_payload_array(env, payloads)
+    });
+    unwrap_exc_or(&mut env, res, std::ptr::null_mut())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_signCastVoteNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    hotkey_seed: JByteArray<'local>,
+    network_id: jint,
+    round_id: JString<'local>,
+    r_vpk: JByteArray<'local>,
+    van_nullifier: JByteArray<'local>,
+    van_new: JByteArray<'local>,
+    vote_commitment: JByteArray<'local>,
+    proposal_id: jint,
+    anchor_height: jlong,
+    alpha_v: JByteArray<'local>,
+) -> jbyteArray {
+    let res = catch_unwind(&mut env, |env| {
+        let hotkey_seed =
+            java_secret_bytes_at_least(env, &hotkey_seed, "hotkey_seed", PROTOCOL_FIELD_BYTES)?;
+        let sig = voting::vote_commitment::sign_cast_vote(
+            hotkey_seed.expose_secret(),
+            u32::try_from(network_id)
+                .map_err(|_| anyhow!("network_id must be non-negative, got {network_id}"))?,
+            &java_string_to_rust(env, &round_id)?,
+            &java_bytes_exact(env, &r_vpk, "r_vpk", PROTOCOL_FIELD_BYTES)?,
+            &java_bytes_exact(env, &van_nullifier, "van_nullifier", PROTOCOL_FIELD_BYTES)?,
+            &java_bytes_exact(env, &van_new, "van_new", PROTOCOL_FIELD_BYTES)?,
+            &java_bytes_exact(
+                env,
+                &vote_commitment,
+                "vote_commitment",
+                PROTOCOL_FIELD_BYTES,
+            )?,
+            jint_to_u32(proposal_id, "proposal_id")?,
+            jlong_to_u32(anchor_height, "anchor_height")?,
+            &java_bytes_exact(env, &alpha_v, "alpha_v", PROTOCOL_FIELD_BYTES)?,
+        )
+        .map_err(|e| anyhow!("sign_cast_vote: {}", e))?;
+        Ok(env.byte_array_from_slice(&sig.vote_auth_sig)?.into_raw())
+    });
+    unwrap_exc_or(&mut env, res, std::ptr::null_mut())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_buildVoteCommitmentNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_handle: jlong,
+    round_id: JString<'local>,
+    bundle_index: jint,
+    hotkey_seed: JByteArray<'local>,
+    proposal_id: jint,
+    choice: jint,
+    num_options: jint,
+    witness: JObject<'local>,
+    network_id: jint,
+    single_share: jboolean,
+    progress_callback: JObject<'local>,
+) -> jobject {
+    let res = catch_unwind(&mut env, |env| {
+        let db = db_from_handle(db_handle)?;
+        let _access_lock = db.access_lock()?;
+        let round_id = java_string_to_rust(env, &round_id)?;
+        let hotkey_seed =
+            java_secret_bytes_at_least(env, &hotkey_seed, "hotkey_seed", PROTOCOL_FIELD_BYTES)?;
+        let witness = java_van_witness(env, &witness)?;
+        let reporter = progress_reporter_from_callback(env, &progress_callback)?;
+        let bundle = db
+            .build_vote_commitment(
+                &round_id,
+                jint_to_u32(bundle_index, "bundle_index")?,
+                hotkey_seed.expose_secret(),
+                u32::try_from(network_id)
+                    .map_err(|_| anyhow!("network_id must be non-negative, got {network_id}"))?,
+                jint_to_u32(proposal_id, "proposal_id")?,
+                jint_to_u32(choice, "choice")?,
+                jint_to_u32(num_options, "num_options")?,
+                &witness.auth_path,
+                witness.position,
+                witness.anchor_height,
+                single_share == JNI_TRUE,
+                reporter.as_ref(),
+            )
+            .map_err(|e| anyhow!("build_vote_commitment: {}", e))?;
+        make_jni_vote_commitment_result(env, bundle)
+    });
+    unwrap_exc_or(&mut env, res, JObject::null().into_raw())
+}

--- a/backend-lib/src/main/rust/voting/vote.rs
+++ b/backend-lib/src/main/rust/voting/vote.rs
@@ -159,6 +159,10 @@ fn require_delegation_ready_for_vote(
     bundle_index: u32,
     witness: &voting::tree_sync::VanWitness,
 ) -> anyhow::Result<()> {
+    // Callers hold VotingDbHandle::access_lock while this read-check sequence
+    // runs. Managed handles for the same DB path and wallet share that lock, so
+    // SDK-exposed writers cannot change delegation/VAN state between these
+    // reads and the subsequent vote commitment build.
     let conn = db.conn();
     let wallet_id = db.wallet_id();
     voting::storage::queries::load_delegation_submission_data(

--- a/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModelsTest.kt
+++ b/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModelsTest.kt
@@ -2,8 +2,37 @@ package cash.z.ecc.android.sdk.internal.model.voting
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class JniVotingModelsTest {
+    @Test
+    fun vote_commitment_result_to_string_redacts_signing_material() {
+        val text =
+            JniVoteCommitmentResult(
+                vanNullifier = byteArrayOf(1),
+                voteAuthorityNoteNew = byteArrayOf(2),
+                voteCommitment = byteArrayOf(3),
+                proposalId = 4,
+                proof = byteArrayOf(5),
+                encShares = listOf(JniWireEncryptedShare(byteArrayOf(6), byteArrayOf(7), 0)),
+                anchorHeight = 8,
+                voteRoundId = "round",
+                sharesHash = byteArrayOf(9),
+                shareBlinds = listOf(byteArrayOf(101)),
+                shareComms = listOf(byteArrayOf(10)),
+                rVpk = byteArrayOf(102),
+                alphaV = byteArrayOf(103)
+            ).toString()
+
+        assertTrue(text.contains("shareBlinds=***"))
+        assertTrue(text.contains("rVpk=***"))
+        assertTrue(text.contains("alphaV=***"))
+        assertFalse(text.contains("101"))
+        assertFalse(text.contains("102"))
+        assertFalse(text.contains("103"))
+    }
+
     @Test
     fun note_info_constructor_matches_rust_jni_signature() {
         val constructor =

--- a/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModelsTest.kt
+++ b/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModelsTest.kt
@@ -70,18 +70,81 @@ class JniVotingModelsTest {
         )
     }
 
+    @Test
+    fun van_witness_constructor_matches_rust_jni_signature() {
+        val constructor =
+            JniVanWitness::class.java.getDeclaredConstructor(
+                Array<ByteArray>::class.java,
+                Long::class.javaPrimitiveType,
+                Long::class.javaPrimitiveType
+            )
+
+        assertEquals(
+            "([[BJJ)V",
+            constructor.jniDescriptor()
+        )
+    }
+
+    @Test
+    fun vote_commitment_result_constructor_matches_rust_jni_signature() {
+        val constructor =
+            JniVoteCommitmentResult::class.java.getDeclaredConstructor(
+                ByteArray::class.java,
+                ByteArray::class.java,
+                ByteArray::class.java,
+                Int::class.javaPrimitiveType,
+                ByteArray::class.java,
+                Array<JniWireEncryptedShare>::class.java,
+                Long::class.javaPrimitiveType,
+                String::class.java,
+                ByteArray::class.java,
+                Array<ByteArray>::class.java,
+                Array<ByteArray>::class.java,
+                ByteArray::class.java,
+                ByteArray::class.java
+            )
+
+        assertEquals(
+            "([B[B[BI[B[Lcash/z/ecc/android/sdk/internal/model/voting/" +
+                "JniWireEncryptedShare;JLjava/lang/String;[B[[B[[B[B[B)V",
+            constructor.jniDescriptor()
+        )
+    }
+
+    @Test
+    fun share_payload_constructor_matches_rust_jni_signature() {
+        val constructor =
+            JniSharePayload::class.java.getDeclaredConstructor(
+                ByteArray::class.java,
+                Int::class.javaPrimitiveType,
+                Int::class.javaPrimitiveType,
+                JniWireEncryptedShare::class.java,
+                Long::class.javaPrimitiveType,
+                Array<JniWireEncryptedShare>::class.java,
+                Array<ByteArray>::class.java,
+                ByteArray::class.java
+            )
+
+        assertEquals(
+            "([BIILcash/z/ecc/android/sdk/internal/model/voting/" +
+                "JniWireEncryptedShare;J[Lcash/z/ecc/android/sdk/internal/model/voting/" +
+                "JniWireEncryptedShare;[[B[B)V",
+            constructor.jniDescriptor()
+        )
+    }
+
     private fun java.lang.reflect.Constructor<*>.jniDescriptor() =
         parameterTypes.joinToString(prefix = "(", postfix = ")V", separator = "") { parameter ->
             parameter.jniDescriptor()
         }
 
     private fun Class<*>.jniDescriptor(): String =
-        when (this) {
-            java.lang.Long.TYPE -> "J"
-            java.lang.Integer.TYPE -> "I"
-            ByteArray::class.java -> "[B"
-            Array<ByteArray>::class.java -> "[[B"
-            String::class.java -> "Ljava/lang/String;"
-            else -> error("Unsupported JNI constructor parameter: $name")
+        when {
+            isArray -> "[${requireNotNull(componentType).jniDescriptor()}"
+            this == java.lang.Byte.TYPE -> "B"
+            this == java.lang.Integer.TYPE -> "I"
+            this == java.lang.Long.TYPE -> "J"
+            isPrimitive -> error("Unsupported JNI primitive parameter: $name")
+            else -> "L${name.replace('.', '/')};"
         }
 }

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImplTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImplTest.kt
@@ -15,6 +15,7 @@ import cash.z.ecc.android.sdk.internal.model.voting.JniGovernancePczt
 import cash.z.ecc.android.sdk.internal.model.voting.JniNoteInfo
 import cash.z.ecc.android.sdk.internal.model.voting.JniRoundState
 import cash.z.ecc.android.sdk.internal.model.voting.JniRoundSummary
+import cash.z.ecc.android.sdk.internal.model.voting.JniSharePayload
 import cash.z.ecc.android.sdk.internal.model.voting.JniVanWitness
 import cash.z.ecc.android.sdk.internal.model.voting.JniVoteCommitmentResult
 import cash.z.ecc.android.sdk.internal.model.voting.JniVoteRecord
@@ -569,6 +570,23 @@ class TypesafeVotingBackendImplTest {
             unused()
 
         override suspend fun warmProvingCaches() = unused()
+
+        override suspend fun decomposeWeight(weight: Long): LongArray = unused()
+
+        override suspend fun buildSharePayloads(
+            commitment: JniVoteCommitmentResult,
+            voteDecision: Int,
+            numOptions: Int,
+            vcTreePosition: Long,
+            singleShareMode: Boolean
+        ): Array<JniSharePayload> = unused()
+
+        override suspend fun signCastVote(
+            hotkeySeed: ByteArray,
+            networkId: Int,
+            accountIndex: Int,
+            commitment: JniVoteCommitmentResult
+        ): ByteArray = unused()
 
         override suspend fun extractOrchardFvkFromUfvk(
             ufvk: String,

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImplTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImplTest.kt
@@ -4,6 +4,8 @@ import cash.z.ecc.android.sdk.internal.jni.JNI_DELEGATION_PUBLIC_INPUT_COUNT
 import cash.z.ecc.android.sdk.internal.jni.JNI_GOVERNANCE_NULLIFIER_COUNT
 import cash.z.ecc.android.sdk.internal.jni.JNI_PROTOCOL_FIELD_BYTES_SIZE
 import cash.z.ecc.android.sdk.internal.jni.JNI_SPEND_AUTH_SIG_BYTES_SIZE
+import cash.z.ecc.android.sdk.internal.jni.JNI_VAN_WITNESS_PATH_DEPTH
+import cash.z.ecc.android.sdk.internal.jni.JNI_VOTE_SHARE_COUNT
 import cash.z.ecc.android.sdk.internal.jni.VotingProofProgressCallback
 import cash.z.ecc.android.sdk.internal.model.voting.JniBundleSetupResult
 import cash.z.ecc.android.sdk.internal.model.voting.JniDelegationPirPrecomputeResult
@@ -17,6 +19,7 @@ import cash.z.ecc.android.sdk.internal.model.voting.JniVanWitness
 import cash.z.ecc.android.sdk.internal.model.voting.JniVoteCommitmentResult
 import cash.z.ecc.android.sdk.internal.model.voting.JniVoteRecord
 import cash.z.ecc.android.sdk.internal.model.voting.JniVotingHotkey
+import cash.z.ecc.android.sdk.internal.model.voting.JniWireEncryptedShare
 import cash.z.ecc.android.sdk.internal.model.voting.JniWitnessData
 import cash.z.ecc.android.sdk.model.AccountUuid
 import cash.z.ecc.android.sdk.model.BlockHeight
@@ -303,6 +306,112 @@ class TypesafeVotingBackendImplTest {
             assertEquals(generatedWitnesses.asList(), generated)
         }
 
+    @Test
+    fun vote_methods_forward_arguments_and_map_results() =
+        runTest {
+            val witness =
+                jniVanWitness(
+                    position = 33,
+                    anchorHeight = 44
+                )
+            val commitment =
+                jniVoteCommitmentResult(
+                    voteCommitment = field(35),
+                    proposalId = 2,
+                    voteRoundId = "round-vote"
+                )
+            val backend =
+                RecordingVotingDbBackend(
+                    proofResult = jniDelegationProofResult(),
+                    submissionResult = jniDelegationSubmissionResult(),
+                    keystoneSubmissionResult = jniDelegationSubmissionResult(),
+                    witnessResult = witness,
+                    commitmentResult = commitment,
+                    syncHeight = 55
+                )
+            val db = TypesafeVotingDbImpl(backend)
+            val hotkeySeed = byteArrayOf(1, 2, 3)
+            var progressValue: Double? = null
+
+            assertEquals(55, db.syncVoteTree("round-vote", "https://node.example"))
+            assertEquals("round-vote", backend.syncRoundId)
+            assertEquals("https://node.example", backend.syncNodeUrl)
+
+            db.resetTreeClient("round-vote")
+            assertEquals("round-vote", backend.resetRoundId)
+            db.resetAllTreeClients()
+            assertEquals("", backend.resetRoundId)
+
+            db.storeVanPosition("round-vote", 3, 77)
+            assertEquals("round-vote", backend.storeVanRoundId)
+            assertEquals(3, backend.storeVanBundleIndex)
+            assertEquals(77, backend.storeVanPosition)
+
+            val generatedWitness = db.generateVanWitness("round-vote", 3, 44)
+            assertEquals(witness, generatedWitness)
+            assertEquals("round-vote", backend.generateVanRoundId)
+            assertEquals(3, backend.generateVanBundleIndex)
+            assertEquals(44, backend.generateVanAnchorHeight)
+
+            val voteCommitment =
+                db.buildVoteCommitment(
+                    roundId = "round-vote",
+                    bundleIndex = 3,
+                    hotkeySeed = hotkeySeed,
+                    proposalId = 2,
+                    choice = 1,
+                    numOptions = 3,
+                    witness = witness,
+                    networkId = 0,
+                    accountIndex = 8
+                ) { progress ->
+                    progressValue = progress
+                }
+            assertEquals(commitment, voteCommitment)
+            assertEquals("round-vote", backend.buildVoteRoundId)
+            assertEquals(3, backend.buildVoteBundleIndex)
+            assertContentEquals(hotkeySeed, backend.buildVoteHotkeySeed)
+            assertEquals(2, backend.buildVoteProposalId)
+            assertEquals(1, backend.buildVoteChoice)
+            assertEquals(3, backend.buildVoteNumOptions)
+            assertEquals(witness, backend.buildVoteWitness)
+            assertEquals(0, backend.buildVoteNetworkId)
+            assertEquals(8, backend.buildVoteAccountIndex)
+            assertEquals(false, backend.buildVoteSingleShare)
+            assertNotNull(backend.buildVoteProgress).onProgress(0.5)
+            assertEquals(0.5, progressValue)
+        }
+
+    @Test
+    fun vote_commitment_wrapper_rejects_invalid_commitment_result() =
+        runTest {
+            val backend =
+                RecordingVotingDbBackend(
+                    proofResult = jniDelegationProofResult(),
+                    submissionResult = jniDelegationSubmissionResult(),
+                    keystoneSubmissionResult = jniDelegationSubmissionResult(),
+                    commitmentResult = jniVoteCommitmentResult(encShares = emptyList())
+                )
+            val db = TypesafeVotingDbImpl(backend)
+
+            val error =
+                assertFailsWith<IllegalArgumentException> {
+                    db.buildVoteCommitment(
+                        roundId = "round-vote",
+                        bundleIndex = 3,
+                        hotkeySeed = byteArrayOf(1, 2, 3),
+                        proposalId = 2,
+                        choice = 1,
+                        numOptions = 3,
+                        witness = jniVanWitness(),
+                        networkId = 0,
+                        accountIndex = 0
+                    )
+                }
+
+            assertTrue(error.message.orEmpty().contains("encShares"))
+        }
+
     private fun jniDelegationProofResult(
         proof: ByteArray = ByteArray(PROOF_BYTES) { 3 },
         publicInputs: List<ByteArray> =
@@ -354,6 +463,57 @@ class TypesafeVotingBackendImplTest {
         govNullifiers = govNullifiers,
         voteRoundId = voteRoundId
     )
+
+    private fun jniVanWitness(
+        authPath: List<ByteArray> = fieldElements(JNI_VAN_WITNESS_PATH_DEPTH),
+        position: Long = 1,
+        anchorHeight: Long = 2
+    ) = JniVanWitness(
+        authPath = authPath,
+        position = position,
+        anchorHeight = anchorHeight
+    )
+
+    private fun jniVoteCommitmentResult(
+        vanNullifier: ByteArray = field(10),
+        voteAuthorityNoteNew: ByteArray = field(11),
+        voteCommitment: ByteArray = field(12),
+        proposalId: Int = 1,
+        proof: ByteArray = ByteArray(PROOF_BYTES) { 13 },
+        encShares: List<JniWireEncryptedShare> = wireShares(),
+        anchorHeight: Long = 2,
+        voteRoundId: String = "round-vote",
+        sharesHash: ByteArray = field(14),
+        shareBlinds: List<ByteArray> = fieldElements(JNI_VOTE_SHARE_COUNT, 15),
+        shareComms: List<ByteArray> = fieldElements(JNI_VOTE_SHARE_COUNT, 16),
+        rVpk: ByteArray = field(17),
+        alphaV: ByteArray = field(18)
+    ) = JniVoteCommitmentResult(
+        vanNullifier = vanNullifier,
+        voteAuthorityNoteNew = voteAuthorityNoteNew,
+        voteCommitment = voteCommitment,
+        proposalId = proposalId,
+        proof = proof,
+        encShares = encShares,
+        anchorHeight = anchorHeight,
+        voteRoundId = voteRoundId,
+        sharesHash = sharesHash,
+        shareBlinds = shareBlinds,
+        shareComms = shareComms,
+        rVpk = rVpk,
+        alphaV = alphaV
+    )
+
+    private fun wireShares(
+        count: Int = JNI_VOTE_SHARE_COUNT,
+        fieldSize: Int = JNI_PROTOCOL_FIELD_BYTES_SIZE
+    ) = List(count) { index ->
+        JniWireEncryptedShare(
+            c1 = ByteArray(fieldSize) { (index + 1).toByte() },
+            c2 = ByteArray(fieldSize) { (index + 2).toByte() },
+            shareIndex = index
+        )
+    }
 
     private fun field(byteValue: Int) =
         ByteArray(JNI_PROTOCOL_FIELD_BYTES_SIZE) { byteValue.toByte() }
@@ -446,7 +606,37 @@ class TypesafeVotingBackendImplTest {
         private val proofResult: JniDelegationProofResult,
         private val submissionResult: JniDelegationSubmissionResult,
         private val keystoneSubmissionResult: JniDelegationSubmissionResult,
-        private val generatedWitnesses: Array<JniWitnessData>
+        private val generatedWitnesses: Array<JniWitnessData> = emptyArray(),
+        private val witnessResult: JniVanWitness =
+            JniVanWitness(
+                authPath = List(JNI_VAN_WITNESS_PATH_DEPTH) { ByteArray(JNI_PROTOCOL_FIELD_BYTES_SIZE) },
+                position = 1,
+                anchorHeight = 2
+            ),
+        private val commitmentResult: JniVoteCommitmentResult =
+            JniVoteCommitmentResult(
+                vanNullifier = ByteArray(JNI_PROTOCOL_FIELD_BYTES_SIZE),
+                voteAuthorityNoteNew = ByteArray(JNI_PROTOCOL_FIELD_BYTES_SIZE),
+                voteCommitment = ByteArray(JNI_PROTOCOL_FIELD_BYTES_SIZE),
+                proposalId = 1,
+                proof = ByteArray(PROOF_BYTES),
+                encShares =
+                    List(JNI_VOTE_SHARE_COUNT) { index ->
+                        JniWireEncryptedShare(
+                            c1 = ByteArray(JNI_PROTOCOL_FIELD_BYTES_SIZE),
+                            c2 = ByteArray(JNI_PROTOCOL_FIELD_BYTES_SIZE),
+                            shareIndex = index
+                        )
+                    },
+                anchorHeight = 2,
+                voteRoundId = "round-vote",
+                sharesHash = ByteArray(JNI_PROTOCOL_FIELD_BYTES_SIZE),
+                shareBlinds = List(JNI_VOTE_SHARE_COUNT) { ByteArray(JNI_PROTOCOL_FIELD_BYTES_SIZE) },
+                shareComms = List(JNI_VOTE_SHARE_COUNT) { ByteArray(JNI_PROTOCOL_FIELD_BYTES_SIZE) },
+                rVpk = ByteArray(JNI_PROTOCOL_FIELD_BYTES_SIZE),
+                alphaV = ByteArray(JNI_PROTOCOL_FIELD_BYTES_SIZE)
+            ),
+        private val syncHeight: Long = 1
     ) : VotingDbBackend {
         var storeWitnessesRoundId: String? = null
         var storeWitnessesBundleIndex: Int? = null
@@ -482,6 +672,26 @@ class TypesafeVotingBackendImplTest {
         var generateNoteWitnessesWalletDbPath: String? = null
         var generateNoteWitnessesNetworkId: Int? = null
         var generateNoteWitnessesNotes: List<JniNoteInfo>? = null
+        var syncRoundId: String? = null
+        var syncNodeUrl: String? = null
+        var resetRoundId: String? = null
+        var storeVanRoundId: String? = null
+        var storeVanBundleIndex: Int? = null
+        var storeVanPosition: Long? = null
+        var generateVanRoundId: String? = null
+        var generateVanBundleIndex: Int? = null
+        var generateVanAnchorHeight: Long? = null
+        var buildVoteRoundId: String? = null
+        var buildVoteBundleIndex: Int? = null
+        var buildVoteHotkeySeed: ByteArray = ByteArray(0)
+        var buildVoteProposalId: Int? = null
+        var buildVoteChoice: Int? = null
+        var buildVoteNumOptions: Int? = null
+        var buildVoteWitness: JniVanWitness? = null
+        var buildVoteNetworkId: Int? = null
+        var buildVoteAccountIndex: Int? = null
+        var buildVoteSingleShare: Boolean? = null
+        var buildVoteProgress: VotingProofProgressCallback? = null
 
         override suspend fun close() = unused()
 
@@ -630,21 +840,36 @@ class TypesafeVotingBackendImplTest {
             return generatedWitnesses
         }
 
-        override suspend fun syncVoteTree(roundId: String, nodeUrl: String): Long = unused()
+        override suspend fun syncVoteTree(roundId: String, nodeUrl: String): Long {
+            syncRoundId = roundId
+            syncNodeUrl = nodeUrl
+            return syncHeight
+        }
 
-        override suspend fun resetTreeClient(roundId: String) = unused()
+        override suspend fun resetTreeClient(roundId: String) {
+            resetRoundId = roundId
+        }
 
         override suspend fun storeVanPosition(
             roundId: String,
             bundleIndex: Int,
             position: Long
-        ) = unused()
+        ) {
+            storeVanRoundId = roundId
+            storeVanBundleIndex = bundleIndex
+            storeVanPosition = position
+        }
 
         override suspend fun generateVanWitness(
             roundId: String,
             bundleIndex: Int,
             anchorHeight: Long
-        ): JniVanWitness = unused()
+        ): JniVanWitness {
+            generateVanRoundId = roundId
+            generateVanBundleIndex = bundleIndex
+            generateVanAnchorHeight = anchorHeight
+            return witnessResult
+        }
 
         override suspend fun buildVoteCommitment(
             roundId: String,
@@ -655,9 +880,23 @@ class TypesafeVotingBackendImplTest {
             numOptions: Int,
             witness: JniVanWitness,
             networkId: Int,
+            accountIndex: Int,
             singleShare: Boolean,
             proofProgress: VotingProofProgressCallback?
-        ): JniVoteCommitmentResult = unused()
+        ): JniVoteCommitmentResult {
+            buildVoteRoundId = roundId
+            buildVoteBundleIndex = bundleIndex
+            buildVoteHotkeySeed = hotkeySeed
+            buildVoteProposalId = proposalId
+            buildVoteChoice = choice
+            buildVoteNumOptions = numOptions
+            buildVoteWitness = witness
+            buildVoteNetworkId = networkId
+            buildVoteAccountIndex = accountIndex
+            buildVoteSingleShare = singleShare
+            buildVoteProgress = proofProgress
+            return commitmentResult
+        }
 
         private fun unused(): Nothing = error("unused")
     }

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImplTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImplTest.kt
@@ -340,7 +340,7 @@ class TypesafeVotingBackendImplTest {
             db.resetTreeClient("round-vote")
             assertEquals("round-vote", backend.resetRoundId)
             db.resetAllTreeClients()
-            assertEquals("", backend.resetRoundId)
+            assertEquals(1, backend.resetAllCount)
 
             db.storeVanPosition("round-vote", 3, 77)
             assertEquals("round-vote", backend.storeVanRoundId)
@@ -675,6 +675,7 @@ class TypesafeVotingBackendImplTest {
         var syncRoundId: String? = null
         var syncNodeUrl: String? = null
         var resetRoundId: String? = null
+        var resetAllCount = 0
         var storeVanRoundId: String? = null
         var storeVanBundleIndex: Int? = null
         var storeVanPosition: Long? = null
@@ -848,6 +849,10 @@ class TypesafeVotingBackendImplTest {
 
         override suspend fun resetTreeClient(roundId: String) {
             resetRoundId = roundId
+        }
+
+        override suspend fun resetAllTreeClients() {
+            resetAllCount += 1
         }
 
         override suspend fun storeVanPosition(

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImplTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImplTest.kt
@@ -13,6 +13,8 @@ import cash.z.ecc.android.sdk.internal.model.voting.JniGovernancePczt
 import cash.z.ecc.android.sdk.internal.model.voting.JniNoteInfo
 import cash.z.ecc.android.sdk.internal.model.voting.JniRoundState
 import cash.z.ecc.android.sdk.internal.model.voting.JniRoundSummary
+import cash.z.ecc.android.sdk.internal.model.voting.JniVanWitness
+import cash.z.ecc.android.sdk.internal.model.voting.JniVoteCommitmentResult
 import cash.z.ecc.android.sdk.internal.model.voting.JniVoteRecord
 import cash.z.ecc.android.sdk.internal.model.voting.JniVotingHotkey
 import cash.z.ecc.android.sdk.internal.model.voting.JniWitnessData
@@ -627,6 +629,35 @@ class TypesafeVotingBackendImplTest {
             generateNoteWitnessesNotes = notes
             return generatedWitnesses
         }
+
+        override suspend fun syncVoteTree(roundId: String, nodeUrl: String): Long = unused()
+
+        override suspend fun resetTreeClient(roundId: String) = unused()
+
+        override suspend fun storeVanPosition(
+            roundId: String,
+            bundleIndex: Int,
+            position: Long
+        ) = unused()
+
+        override suspend fun generateVanWitness(
+            roundId: String,
+            bundleIndex: Int,
+            anchorHeight: Long
+        ): JniVanWitness = unused()
+
+        override suspend fun buildVoteCommitment(
+            roundId: String,
+            bundleIndex: Int,
+            hotkeySeed: ByteArray,
+            proposalId: Int,
+            choice: Int,
+            numOptions: Int,
+            witness: JniVanWitness,
+            networkId: Int,
+            singleShare: Boolean,
+            proofProgress: VotingProofProgressCallback?
+        ): JniVoteCommitmentResult = unused()
 
         private fun unused(): Nothing = error("unused")
     }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackend.kt
@@ -39,14 +39,8 @@ internal interface TypesafeVotingBackend {
     suspend fun signCastVote(
         hotkeySeed: ByteArray,
         networkId: Int,
-        roundId: String,
-        rVpk: ByteArray,
-        vanNullifier: ByteArray,
-        vanNew: ByteArray,
-        voteCommitment: ByteArray,
-        proposalId: Int,
-        anchorHeight: Long,
-        alphaV: ByteArray
+        accountIndex: Int,
+        commitment: JniVoteCommitmentResult
     ): ByteArray
 
     suspend fun extractOrchardFvkFromUfvk(ufvk: String, networkId: Int): ByteArray
@@ -175,7 +169,9 @@ internal interface TypesafeVotingDb {
 
     suspend fun syncVoteTree(roundId: String, nodeUrl: String): Long
 
-    suspend fun resetTreeClient(roundId: String = "")
+    suspend fun resetTreeClient(roundId: String)
+
+    suspend fun resetAllTreeClients()
 
     suspend fun storeVanPosition(roundId: String, bundleIndex: Int, position: Long)
 
@@ -194,6 +190,7 @@ internal interface TypesafeVotingDb {
         numOptions: Int,
         witness: JniVanWitness,
         networkId: Int,
+        accountIndex: Int,
         singleShare: Boolean = false,
         proofProgress: ((Double) -> Unit)? = null
     ): JniVoteCommitmentResult

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackend.kt
@@ -3,6 +3,9 @@ package cash.z.ecc.android.sdk.internal
 import cash.z.ecc.android.sdk.internal.model.voting.JniBundleSetupResult
 import cash.z.ecc.android.sdk.internal.model.voting.JniRoundState
 import cash.z.ecc.android.sdk.internal.model.voting.JniRoundSummary
+import cash.z.ecc.android.sdk.internal.model.voting.JniSharePayload
+import cash.z.ecc.android.sdk.internal.model.voting.JniVanWitness
+import cash.z.ecc.android.sdk.internal.model.voting.JniVoteCommitmentResult
 import cash.z.ecc.android.sdk.internal.model.voting.JniVoteRecord
 import cash.z.ecc.android.sdk.internal.model.voting.JniVotingHotkey
 import cash.z.ecc.android.sdk.internal.model.voting.JniWitnessData
@@ -22,6 +25,29 @@ internal interface TypesafeVotingBackend {
     suspend fun computeBundleSetup(notes: List<VotingNoteInfo>): JniBundleSetupResult
 
     suspend fun warmProvingCaches()
+
+    suspend fun decomposeWeight(weight: Long): List<Long>
+
+    suspend fun buildSharePayloads(
+        commitment: JniVoteCommitmentResult,
+        voteDecision: Int,
+        numOptions: Int,
+        vcTreePosition: Long,
+        singleShareMode: Boolean = false
+    ): List<JniSharePayload>
+
+    suspend fun signCastVote(
+        hotkeySeed: ByteArray,
+        networkId: Int,
+        roundId: String,
+        rVpk: ByteArray,
+        vanNullifier: ByteArray,
+        vanNew: ByteArray,
+        voteCommitment: ByteArray,
+        proposalId: Int,
+        anchorHeight: Long,
+        alphaV: ByteArray
+    ): ByteArray
 
     suspend fun extractOrchardFvkFromUfvk(ufvk: String, networkId: Int): ByteArray
 
@@ -146,6 +172,31 @@ internal interface TypesafeVotingDb {
         networkId: Int,
         notes: List<VotingNoteInfo>
     ): List<JniWitnessData>
+
+    suspend fun syncVoteTree(roundId: String, nodeUrl: String): Long
+
+    suspend fun resetTreeClient(roundId: String = "")
+
+    suspend fun storeVanPosition(roundId: String, bundleIndex: Int, position: Long)
+
+    suspend fun generateVanWitness(
+        roundId: String,
+        bundleIndex: Int,
+        anchorHeight: Long
+    ): JniVanWitness
+
+    suspend fun buildVoteCommitment(
+        roundId: String,
+        bundleIndex: Int,
+        hotkeySeed: ByteArray,
+        proposalId: Int,
+        choice: Int,
+        numOptions: Int,
+        witness: JniVanWitness,
+        networkId: Int,
+        singleShare: Boolean = false,
+        proofProgress: ((Double) -> Unit)? = null
+    ): JniVoteCommitmentResult
 }
 
 internal data class VotingNoteInfo(

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
@@ -326,6 +326,8 @@ internal interface VotingDbBackend {
 
     suspend fun resetTreeClient(roundId: String)
 
+    suspend fun resetAllTreeClients()
+
     suspend fun storeVanPosition(roundId: String, bundleIndex: Int, position: Long)
 
     suspend fun generateVanWitness(
@@ -522,6 +524,9 @@ private class RustVotingDbBackend(
 
     override suspend fun resetTreeClient(roundId: String) =
         votingDb.resetTreeClient(roundId)
+
+    override suspend fun resetAllTreeClients() =
+        votingDb.resetTreeClient("")
 
     override suspend fun storeVanPosition(roundId: String, bundleIndex: Int, position: Long) =
         votingDb.storeVanPosition(roundId, bundleIndex, position)
@@ -746,7 +751,7 @@ internal class TypesafeVotingDbImpl(
         votingDb.resetTreeClient(roundId)
 
     override suspend fun resetAllTreeClients() =
-        votingDb.resetTreeClient("")
+        votingDb.resetAllTreeClients()
 
     override suspend fun storeVanPosition(roundId: String, bundleIndex: Int, position: Long) =
         votingDb.storeVanPosition(roundId, bundleIndex, position)

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
@@ -152,6 +152,23 @@ internal interface VotingBackendBridge {
 
     suspend fun warmProvingCaches()
 
+    suspend fun decomposeWeight(weight: Long): LongArray
+
+    suspend fun buildSharePayloads(
+        commitment: JniVoteCommitmentResult,
+        voteDecision: Int,
+        numOptions: Int,
+        vcTreePosition: Long,
+        singleShareMode: Boolean
+    ): Array<JniSharePayload>
+
+    suspend fun signCastVote(
+        hotkeySeed: ByteArray,
+        networkId: Int,
+        accountIndex: Int,
+        commitment: JniVoteCommitmentResult
+    ): ByteArray
+
     suspend fun extractOrchardFvkFromUfvk(ufvk: String, networkId: Int): ByteArray
 
     suspend fun extractNcRoot(treeStateBytes: ByteArray): ByteArray
@@ -191,6 +208,32 @@ private class RustVotingBackendBridge(
 
     override suspend fun warmProvingCaches() =
         rustBackend.warmProvingCaches()
+
+    override suspend fun decomposeWeight(weight: Long): LongArray =
+        rustBackend.decomposeWeight(weight)
+
+    override suspend fun buildSharePayloads(
+        commitment: JniVoteCommitmentResult,
+        voteDecision: Int,
+        numOptions: Int,
+        vcTreePosition: Long,
+        singleShareMode: Boolean
+    ): Array<JniSharePayload> =
+        rustBackend.buildSharePayloads(
+            commitment,
+            voteDecision,
+            numOptions,
+            vcTreePosition,
+            singleShareMode
+        )
+
+    override suspend fun signCastVote(
+        hotkeySeed: ByteArray,
+        networkId: Int,
+        accountIndex: Int,
+        commitment: JniVoteCommitmentResult
+    ): ByteArray =
+        rustBackend.signCastVote(hotkeySeed, networkId, accountIndex, commitment)
 
     override suspend fun extractOrchardFvkFromUfvk(ufvk: String, networkId: Int): ByteArray =
         rustBackend.extractOrchardFvkFromUfvk(ufvk, networkId)

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
@@ -66,45 +66,42 @@ internal class TypesafeVotingBackendImpl(
         numOptions: Int,
         vcTreePosition: Long,
         singleShareMode: Boolean
-    ): List<JniSharePayload> =
-        rustBackend()
+    ): List<JniSharePayload> {
+        commitment.requireValid()
+        return rustBackend()
             .buildSharePayloads(
                 commitment,
                 voteDecision,
                 numOptions,
                 vcTreePosition,
                 singleShareMode
-            ).onEach { payload ->
+            ).also { payloads ->
+                val expectedCount = if (singleShareMode) 1 else JNI_VOTE_SHARE_COUNT
+                require(payloads.size == expectedCount) {
+                    "sharePayloads must contain $expectedCount entries, got ${payloads.size}"
+                }
+            }.onEach { payload ->
                 payload.requireValid()
             }.asList()
+    }
 
     override suspend fun signCastVote(
         hotkeySeed: ByteArray,
         networkId: Int,
-        roundId: String,
-        rVpk: ByteArray,
-        vanNullifier: ByteArray,
-        vanNew: ByteArray,
-        voteCommitment: ByteArray,
-        proposalId: Int,
-        anchorHeight: Long,
-        alphaV: ByteArray
-    ): ByteArray =
-        rustBackend()
+        accountIndex: Int,
+        commitment: JniVoteCommitmentResult
+    ): ByteArray {
+        commitment.requireValid()
+        return rustBackend()
             .signCastVote(
                 hotkeySeed,
                 networkId,
-                roundId,
-                rVpk,
-                vanNullifier,
-                vanNew,
-                voteCommitment,
-                proposalId,
-                anchorHeight,
-                alphaV
+                accountIndex,
+                commitment
             ).also { sig ->
                 sig.requireByteArraySize("voteAuthSig", JNI_SPEND_AUTH_SIG_BYTES_SIZE)
             }
+    }
 
     override suspend fun extractOrchardFvkFromUfvk(ufvk: String, networkId: Int): ByteArray =
         rustBackend().extractOrchardFvkFromUfvk(ufvk, networkId)
@@ -346,6 +343,7 @@ internal interface VotingDbBackend {
         numOptions: Int,
         witness: JniVanWitness,
         networkId: Int,
+        accountIndex: Int,
         singleShare: Boolean,
         proofProgress: VotingProofProgressCallback?
     ): JniVoteCommitmentResult
@@ -544,6 +542,7 @@ private class RustVotingDbBackend(
         numOptions: Int,
         witness: JniVanWitness,
         networkId: Int,
+        accountIndex: Int,
         singleShare: Boolean,
         proofProgress: VotingProofProgressCallback?
     ): JniVoteCommitmentResult =
@@ -556,6 +555,7 @@ private class RustVotingDbBackend(
             numOptions,
             witness,
             networkId,
+            accountIndex,
             singleShare,
             proofProgress
         )
@@ -745,6 +745,9 @@ internal class TypesafeVotingDbImpl(
     override suspend fun resetTreeClient(roundId: String) =
         votingDb.resetTreeClient(roundId)
 
+    override suspend fun resetAllTreeClients() =
+        votingDb.resetTreeClient("")
+
     override suspend fun storeVanPosition(roundId: String, bundleIndex: Int, position: Long) =
         votingDb.storeVanPosition(roundId, bundleIndex, position)
 
@@ -766,6 +769,7 @@ internal class TypesafeVotingDbImpl(
         numOptions: Int,
         witness: JniVanWitness,
         networkId: Int,
+        accountIndex: Int,
         singleShare: Boolean,
         proofProgress: ((Double) -> Unit)?
     ): JniVoteCommitmentResult =
@@ -779,6 +783,7 @@ internal class TypesafeVotingDbImpl(
                 numOptions,
                 witness,
                 networkId,
+                accountIndex,
                 singleShare,
                 proofProgress?.asVotingProgressCallback()
             ).also { commitment ->

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
@@ -1,9 +1,13 @@
+@file:Suppress("TooManyFunctions")
+
 package cash.z.ecc.android.sdk.internal
 
 import cash.z.ecc.android.sdk.internal.jni.JNI_DELEGATION_PUBLIC_INPUT_COUNT
 import cash.z.ecc.android.sdk.internal.jni.JNI_GOVERNANCE_NULLIFIER_COUNT
 import cash.z.ecc.android.sdk.internal.jni.JNI_PROTOCOL_FIELD_BYTES_SIZE
 import cash.z.ecc.android.sdk.internal.jni.JNI_SPEND_AUTH_SIG_BYTES_SIZE
+import cash.z.ecc.android.sdk.internal.jni.JNI_VAN_WITNESS_PATH_DEPTH
+import cash.z.ecc.android.sdk.internal.jni.JNI_VOTE_SHARE_COUNT
 import cash.z.ecc.android.sdk.internal.jni.VotingProofProgressCallback
 import cash.z.ecc.android.sdk.internal.jni.VotingRustBackend
 import cash.z.ecc.android.sdk.internal.model.voting.JniBundleSetupResult
@@ -14,8 +18,12 @@ import cash.z.ecc.android.sdk.internal.model.voting.JniGovernancePczt
 import cash.z.ecc.android.sdk.internal.model.voting.JniNoteInfo
 import cash.z.ecc.android.sdk.internal.model.voting.JniRoundState
 import cash.z.ecc.android.sdk.internal.model.voting.JniRoundSummary
+import cash.z.ecc.android.sdk.internal.model.voting.JniSharePayload
+import cash.z.ecc.android.sdk.internal.model.voting.JniVanWitness
+import cash.z.ecc.android.sdk.internal.model.voting.JniVoteCommitmentResult
 import cash.z.ecc.android.sdk.internal.model.voting.JniVoteRecord
 import cash.z.ecc.android.sdk.internal.model.voting.JniVotingHotkey
+import cash.z.ecc.android.sdk.internal.model.voting.JniWireEncryptedShare
 import cash.z.ecc.android.sdk.internal.model.voting.JniWitnessData
 import cash.z.ecc.android.sdk.model.AccountUuid
 import cash.z.ecc.android.sdk.model.BlockHeight
@@ -48,6 +56,55 @@ internal class TypesafeVotingBackendImpl(
 
     override suspend fun warmProvingCaches() =
         rustBackend().warmProvingCaches()
+
+    override suspend fun decomposeWeight(weight: Long): List<Long> =
+        rustBackend().decomposeWeight(weight).asList()
+
+    override suspend fun buildSharePayloads(
+        commitment: JniVoteCommitmentResult,
+        voteDecision: Int,
+        numOptions: Int,
+        vcTreePosition: Long,
+        singleShareMode: Boolean
+    ): List<JniSharePayload> =
+        rustBackend()
+            .buildSharePayloads(
+                commitment,
+                voteDecision,
+                numOptions,
+                vcTreePosition,
+                singleShareMode
+            ).onEach { payload ->
+                payload.requireValid()
+            }.asList()
+
+    override suspend fun signCastVote(
+        hotkeySeed: ByteArray,
+        networkId: Int,
+        roundId: String,
+        rVpk: ByteArray,
+        vanNullifier: ByteArray,
+        vanNew: ByteArray,
+        voteCommitment: ByteArray,
+        proposalId: Int,
+        anchorHeight: Long,
+        alphaV: ByteArray
+    ): ByteArray =
+        rustBackend()
+            .signCastVote(
+                hotkeySeed,
+                networkId,
+                roundId,
+                rVpk,
+                vanNullifier,
+                vanNew,
+                voteCommitment,
+                proposalId,
+                anchorHeight,
+                alphaV
+            ).also { sig ->
+                sig.requireByteArraySize("voteAuthSig", JNI_SPEND_AUTH_SIG_BYTES_SIZE)
+            }
 
     override suspend fun extractOrchardFvkFromUfvk(ufvk: String, networkId: Int): ByteArray =
         rustBackend().extractOrchardFvkFromUfvk(ufvk, networkId)
@@ -267,6 +324,31 @@ internal interface VotingDbBackend {
         networkId: Int,
         notes: List<JniNoteInfo>
     ): Array<JniWitnessData>
+
+    suspend fun syncVoteTree(roundId: String, nodeUrl: String): Long
+
+    suspend fun resetTreeClient(roundId: String)
+
+    suspend fun storeVanPosition(roundId: String, bundleIndex: Int, position: Long)
+
+    suspend fun generateVanWitness(
+        roundId: String,
+        bundleIndex: Int,
+        anchorHeight: Long
+    ): JniVanWitness
+
+    suspend fun buildVoteCommitment(
+        roundId: String,
+        bundleIndex: Int,
+        hotkeySeed: ByteArray,
+        proposalId: Int,
+        choice: Int,
+        numOptions: Int,
+        witness: JniVanWitness,
+        networkId: Int,
+        singleShare: Boolean,
+        proofProgress: VotingProofProgressCallback?
+    ): JniVoteCommitmentResult
 }
 
 @Suppress("TooManyFunctions", "LongParameterList")
@@ -435,6 +517,47 @@ private class RustVotingDbBackend(
             walletDbPath,
             networkId,
             notes
+        )
+
+    override suspend fun syncVoteTree(roundId: String, nodeUrl: String): Long =
+        votingDb.syncVoteTree(roundId, nodeUrl)
+
+    override suspend fun resetTreeClient(roundId: String) =
+        votingDb.resetTreeClient(roundId)
+
+    override suspend fun storeVanPosition(roundId: String, bundleIndex: Int, position: Long) =
+        votingDb.storeVanPosition(roundId, bundleIndex, position)
+
+    override suspend fun generateVanWitness(
+        roundId: String,
+        bundleIndex: Int,
+        anchorHeight: Long
+    ): JniVanWitness =
+        votingDb.generateVanWitness(roundId, bundleIndex, anchorHeight)
+
+    override suspend fun buildVoteCommitment(
+        roundId: String,
+        bundleIndex: Int,
+        hotkeySeed: ByteArray,
+        proposalId: Int,
+        choice: Int,
+        numOptions: Int,
+        witness: JniVanWitness,
+        networkId: Int,
+        singleShare: Boolean,
+        proofProgress: VotingProofProgressCallback?
+    ): JniVoteCommitmentResult =
+        votingDb.buildVoteCommitment(
+            roundId,
+            bundleIndex,
+            hotkeySeed,
+            proposalId,
+            choice,
+            numOptions,
+            witness,
+            networkId,
+            singleShare,
+            proofProgress
         )
 }
 
@@ -615,6 +738,52 @@ internal class TypesafeVotingDbImpl(
             )
         return witnesses.asList()
     }
+
+    override suspend fun syncVoteTree(roundId: String, nodeUrl: String): Long =
+        votingDb.syncVoteTree(roundId, nodeUrl)
+
+    override suspend fun resetTreeClient(roundId: String) =
+        votingDb.resetTreeClient(roundId)
+
+    override suspend fun storeVanPosition(roundId: String, bundleIndex: Int, position: Long) =
+        votingDb.storeVanPosition(roundId, bundleIndex, position)
+
+    override suspend fun generateVanWitness(
+        roundId: String,
+        bundleIndex: Int,
+        anchorHeight: Long
+    ): JniVanWitness =
+        votingDb.generateVanWitness(roundId, bundleIndex, anchorHeight).also { witness ->
+            witness.requireValid()
+        }
+
+    override suspend fun buildVoteCommitment(
+        roundId: String,
+        bundleIndex: Int,
+        hotkeySeed: ByteArray,
+        proposalId: Int,
+        choice: Int,
+        numOptions: Int,
+        witness: JniVanWitness,
+        networkId: Int,
+        singleShare: Boolean,
+        proofProgress: ((Double) -> Unit)?
+    ): JniVoteCommitmentResult =
+        votingDb
+            .buildVoteCommitment(
+                roundId,
+                bundleIndex,
+                hotkeySeed,
+                proposalId,
+                choice,
+                numOptions,
+                witness,
+                networkId,
+                singleShare,
+                proofProgress?.asVotingProgressCallback()
+            ).also { commitment ->
+                commitment.requireValid()
+            }
 }
 
 internal fun JniGovernancePczt.toGovernancePcztResult(): GovernancePcztResult {
@@ -690,6 +859,45 @@ internal fun JniDelegationSubmissionResult.toDelegationSubmissionResult(): Deleg
     )
 }
 
+private fun JniVanWitness.requireValid() {
+    authPath.requireByteArrayCount("authPath", JNI_VAN_WITNESS_PATH_DEPTH)
+    authPath.requireEachByteArraySize("authPath", JNI_PROTOCOL_FIELD_BYTES_SIZE)
+}
+
+private fun JniWireEncryptedShare.requireValid(name: String) {
+    c1.requireByteArraySize("$name.c1", JNI_PROTOCOL_FIELD_BYTES_SIZE)
+    c2.requireByteArraySize("$name.c2", JNI_PROTOCOL_FIELD_BYTES_SIZE)
+    require(shareIndex in 0 until JNI_VOTE_SHARE_COUNT) {
+        "$name.shareIndex must be in 0..${JNI_VOTE_SHARE_COUNT - 1}, got $shareIndex"
+    }
+}
+
+private fun JniVoteCommitmentResult.requireValid() {
+    vanNullifier.requireByteArraySize("vanNullifier", JNI_PROTOCOL_FIELD_BYTES_SIZE)
+    voteAuthorityNoteNew.requireByteArraySize("voteAuthorityNoteNew", JNI_PROTOCOL_FIELD_BYTES_SIZE)
+    voteCommitment.requireByteArraySize("voteCommitment", JNI_PROTOCOL_FIELD_BYTES_SIZE)
+    proof.requireByteArrayNotEmpty("proof")
+    encShares.requireCount("encShares", JNI_VOTE_SHARE_COUNT)
+    encShares.forEachIndexed { index, share -> share.requireValid("encShares[$index]") }
+    sharesHash.requireByteArraySize("sharesHash", JNI_PROTOCOL_FIELD_BYTES_SIZE)
+    shareBlinds.requireByteArrayCount("shareBlinds", JNI_VOTE_SHARE_COUNT)
+    shareBlinds.requireEachByteArraySize("shareBlinds", JNI_PROTOCOL_FIELD_BYTES_SIZE)
+    shareComms.requireByteArrayCount("shareComms", JNI_VOTE_SHARE_COUNT)
+    shareComms.requireEachByteArraySize("shareComms", JNI_PROTOCOL_FIELD_BYTES_SIZE)
+    rVpk.requireByteArraySize("rVpk", JNI_PROTOCOL_FIELD_BYTES_SIZE)
+    alphaV.requireByteArraySize("alphaV", JNI_PROTOCOL_FIELD_BYTES_SIZE)
+}
+
+private fun JniSharePayload.requireValid() {
+    sharesHash.requireByteArraySize("sharesHash", JNI_PROTOCOL_FIELD_BYTES_SIZE)
+    encShare.requireValid("encShare")
+    allEncShares.requireCount("allEncShares", JNI_VOTE_SHARE_COUNT)
+    allEncShares.forEachIndexed { index, share -> share.requireValid("allEncShares[$index]") }
+    shareComms.requireByteArrayCount("shareComms", JNI_VOTE_SHARE_COUNT)
+    shareComms.requireEachByteArraySize("shareComms", JNI_PROTOCOL_FIELD_BYTES_SIZE)
+    primaryBlind.requireByteArraySize("primaryBlind", JNI_PROTOCOL_FIELD_BYTES_SIZE)
+}
+
 private fun ((Double) -> Unit).asVotingProgressCallback() =
     VotingProofProgressCallback { progress -> invoke(progress) }
 
@@ -704,6 +912,11 @@ private fun ByteArray.requireByteArrayNotEmpty(name: String) =
     }
 
 private fun List<ByteArray>.requireByteArrayCount(name: String, expectedCount: Int) =
+    require(size == expectedCount) {
+        "$name must contain $expectedCount entries, got $size"
+    }
+
+private fun <T> List<T>.requireCount(name: String, expectedCount: Int) =
     require(size == expectedCount) {
         "$name must contain $expectedCount entries, got $size"
     }


### PR DESCRIPTION
Part of zodl-inc/zodl-android#2193.
Slice of zcash/zcash-android-wallet-sdk#1924 (umbrella draft PR being split into reviewable pieces).
Stacked on zcash/zcash-android-wallet-sdk#1951 (PR 6 — snapshot wallet notes and note witnesses).
Resolves MOB-1109

## Why

Seventh slice of the Android shielded-voting integration. PR 6 (#1951) lands
the snapshot input-prep path (wallet notes, tree state, note witnesses). This
PR builds the vote-construction path on top of that snapshot: syncing the vote
commitment tree, storing VAN positions, generating VAN witnesses, building the
vote commitment proof, decomposing weight, constructing share payloads, and
signing the cast-vote message.

`zcash_voting` is now built with `client-tree-sync` in addition to
`client-pir`. Together with the snapshot inputs from PR 6, this completes the
SDK-side path from snapshot-note witnesses to a fully signed cast-vote message
ready for submission.

No new app-facing `Synchronizer` voting API is added. All new surface lives on
the internal `TypesafeVotingBackend` and its JNI implementation.

## Not included

- Recovery records and share tracking (PR 8).
- Any new submission or proof-generation behavior outside vote construction.
- Note witness generation / wallet DB access (lands in PR 6).

## Review focus

Primary review track: core-dev. Secondary: mobile-app-dev.

- `client-tree-sync` feature enablement on `zcash_voting` in
  `backend-lib/Cargo.toml`, expected transitives, and lockfile churn.
- `voting/tree.rs`: vote tree sync, tree-client reset, VAN position storage,
  and VAN witness generation against a stored snapshot anchor — node URL /
  network behavior at the SDK boundary, anchor-height validation, and JSON
  schema stability for the returned VAN witness payload.
- `voting/vote.rs`: vote commitment proof inputs and byte-boundary validation,
  VAN witness consumption, weight decomposition, share payload serialization,
  and cast-vote signature domain/network binding.
- JNI byte-boundary validation via the shared helpers in `voting/helpers.rs`
  (bundle/proposal/choice ids, weight bytes, witness payload sizes, signing
  keys, sighash bytes).
- Typed FFI models (`JniWeightDecomposition`, `JniSharePayloadInput`,
  `JniCastVoteInput`, vote-commitment input/result, VAN witness payload) and
  how the typesafe wrapper enforces size/count invariants before handing data
  back to the SDK.
- `TypesafeVotingBackend` / `TypesafeVotingBackendImpl` ergonomics for the
  vote-construction workflow, including suspend/dispatcher choice and error
  mapping.
- Whether progress-callback plumbing should appear at this layer or stay
  deferred until a workflow actually drives long proof work through it.

## Validation

- `cargo check --manifest-path backend-lib/Cargo.toml --locked`
- `cargo fmt --manifest-path backend-lib/Cargo.toml --check`
- `./gradlew :backend-lib:compileReleaseKotlin :sdk-lib:compileReleaseKotlin`
- `./gradlew ktlint detektAll`
- `./gradlew checkProperties`
- `git diff --check`

# Author

- [ ] **Self-review** your own code in GitHub web interface
- [x] Add **automated tests** as appropriate
- [ ] Update the **manual tests** as appropriate
- [ ] Check the **code coverage** report for the automated tests
- [ ] Update **documentation** as appropriate
- [ ] **Run the demo app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer

# Reviewer

- [ ] Check the code with the Code Review Guidelines checklist
- [ ] Perform an **ad hoc review**
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation** as appropriate
- [ ] **Run the demo app** and try the changes