### PR TITLE
[#1924] Add Android voting recovery and share tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 - Added internal `VotingRustBackend` / `TypesafeVotingBackend` plumbing for future shielded voting backend work.
+- Added internal shielded voting recovery and share-tracking persistence for replaying,
+  retrying, and confirming delegation and vote submission workflows.
 - Pinned `orchard` to `=0.13.1` with `unstable-voting-circuits` to match `zcash_voting` / `voting-circuits` requirements.
 
 ## [2.5.0] - 2026-05-01

--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -1230,7 +1230,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1480,7 +1480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2389,7 +2389,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2679,7 +2679,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3791,7 +3791,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4320,7 +4320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4495,7 +4495,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6293,7 +6293,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6813,6 +6813,8 @@ dependencies = [
  "rust_decimal",
  "sapling-crypto",
  "secrecy",
+ "serde",
+ "serde_json",
  "tonic",
  "tor-rtcompat",
  "tracing",
@@ -7135,9 +7137,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7835b7e3d823bfc889279f9c7ab3d4033d3d707004dbf3a0fa158f6f1ef8b43"
+checksum = "066eefe9678138a8450c20ec222da402bb92bb3f46351958a9661a75733c0bc8"
 dependencies = [
  "anyhow",
  "blake2b_simd",

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -62,6 +62,8 @@ jni = { version = "0.21", default-features = false }
 uuid = "1"
 bitflags = "2"
 hex = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 # lightwalletd
 tonic = "0.14"
@@ -94,7 +96,7 @@ rust-analyzer = "0.0.1"
 # The Android JNI boundary for voting code is `src/main/rust/voting.rs`.
 # Its share-nullifier entry point forwards to
 # `zcash_voting::share_tracking::compute_share_nullifier`:
-# https://github.com/valargroup/zcash_voting/blob/zcash_voting-v0.5.9/zcash_voting/src/share_tracking.rs
+# https://github.com/valargroup/zcash_voting/blob/zcash_voting-v0.5.12/zcash_voting/src/share_tracking.rs
 #
 # The transitive `voting-circuits` dependency contains the share-reveal circuit
 # and the Poseidon-based `share_nullifier_hash` implementation:
@@ -105,7 +107,7 @@ rust-analyzer = "0.0.1"
 # Expected PIR/tree-sync networking transitives include `pir-client`, `pir-types`,
 # `valar-ypir`, `valar-spiral-rs`, `vote-commitment-tree-client`, and
 # `hyper-rustls`.
-zcash_voting = { version = "0.5.11", default-features = false, features = [
+zcash_voting = { version = "0.5.12", default-features = false, features = [
     "client-pir",
     "client-tree-sync",
 ] }

--- a/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
+++ b/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
@@ -1104,6 +1104,60 @@ class VotingRustBackendTest {
         }
 
     @Test
+    fun add_sent_servers_appends_and_deduplicates_native_jni() =
+        runTest {
+            val db = VotingRustBackend.new().openVotingDb(newDbPath(), WALLET_ID)
+            try {
+                db.initPcztRoundWithBundles(notes(noteCount = 6, value = PCZT_NOTE_VALUE))
+                db.storeVoteFixtureForTesting(
+                    roundId = PCZT_ROUND_ID,
+                    bundleIndex = 1,
+                    proposalId = 1,
+                    choice = 0
+                )
+                db.recordShareDelegation(
+                    roundId = PCZT_ROUND_ID,
+                    bundleIndex = 1,
+                    proposalId = 1,
+                    shareIndex = SHARE_INDEX,
+                    sentToUrls = listOf("https://helper-1.example"),
+                    nullifier = ByteArray(FIELD_BYTES) { 0x55 },
+                    submitAt = 123
+                )
+
+                db.addSentServers(
+                    roundId = PCZT_ROUND_ID,
+                    bundleIndex = 1,
+                    proposalId = 1,
+                    shareIndex = SHARE_INDEX,
+                    newUrls = listOf("https://helper-2.example")
+                )
+                assertEquals(
+                    listOf("https://helper-1.example", "https://helper-2.example"),
+                    db.getShareDelegations(PCZT_ROUND_ID).single().sentToUrls
+                )
+
+                db.addSentServers(
+                    roundId = PCZT_ROUND_ID,
+                    bundleIndex = 1,
+                    proposalId = 1,
+                    shareIndex = SHARE_INDEX,
+                    newUrls = listOf("https://helper-2.example", "https://helper-3.example")
+                )
+                assertEquals(
+                    listOf(
+                        "https://helper-1.example",
+                        "https://helper-2.example",
+                        "https://helper-3.example"
+                    ),
+                    db.getShareDelegations(PCZT_ROUND_ID).single().sentToUrls
+                )
+            } finally {
+                db.close()
+            }
+        }
+
+    @Test
     fun delegation_proof_result_fixture_crosses_rust_to_kotlin_object_construction() =
         runTest {
             val result =

--- a/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
+++ b/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
@@ -1583,12 +1583,14 @@ class VotingRustBackendTest {
         encShares: List<JniWireEncryptedShare> = wireShares(),
         shareBlinds: List<ByteArray> = fieldElements(JNI_VOTE_SHARE_COUNT, 5),
         shareComms: List<ByteArray> = fieldElements(JNI_VOTE_SHARE_COUNT, 6),
+        bundleIndex: Int = 1,
         alphaV: ByteArray = ByteArray(FIELD_BYTES) { 8 }
     ) = JniVoteCommitmentResult(
         vanNullifier = ByteArray(FIELD_BYTES) { 1 },
         voteAuthorityNoteNew = ByteArray(FIELD_BYTES) { 2 },
         voteCommitment = ByteArray(FIELD_BYTES) { 3 },
         proposalId = 1,
+        bundleIndex = bundleIndex,
         proof = byteArrayOf(4),
         encShares = encShares,
         anchorHeight = SNAPSHOT_HEIGHT,

--- a/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
+++ b/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
@@ -44,7 +44,6 @@ class VotingRustBackendTest {
         private const val SESSION_JSON = "{\"round\":\"one\"}"
         private const val TESTNET_NETWORK_ID = JNI_VOTING_NETWORK_ID_TESTNET
         private const val ACCOUNT_INDEX = 0
-        private const val ADDRESS_INDEX = 1
         private const val MAINNET_NETWORK_ID = JNI_VOTING_NETWORK_ID_MAINNET
         private const val SECOND_ROUND_ID = "round-2"
         private const val PCZT_ROUND_ID =
@@ -869,9 +868,7 @@ class VotingRustBackendTest {
                         pirServerUrl = "http://127.0.0.1:1",
                         networkId = TESTNET_NETWORK_ID,
                         notes = notes,
-                        walletSeed = SHORT_FIELD,
-                        accountIndex = ACCOUNT_INDEX,
-                        addressIndex = ADDRESS_INDEX,
+                        hotkeySeed = SHORT_FIELD,
                         proofProgress = null
                     )
                 }
@@ -1084,9 +1081,35 @@ class VotingRustBackendTest {
         }
 
     @Test
+    fun recovery_state_round_trips_through_native_jni() =
+        runTest {
+            val db = VotingRustBackend.new().openVotingDb(newDbPath(), WALLET_ID)
+            try {
+                db.initPcztRoundWithBundles(notes(noteCount = 6, value = PCZT_NOTE_VALUE))
+                db.storeVoteFixtureForTesting(
+                    roundId = PCZT_ROUND_ID,
+                    bundleIndex = 1,
+                    proposalId = 1,
+                    choice = 0
+                )
+
+                db.assertStoredTxHashesRoundTrip()
+                db.assertStoredCommitmentBundleRoundTrips()
+                db.assertShareDelegationRecoveryStateRoundTrips()
+                db.clearRecoveryState(PCZT_ROUND_ID)
+                db.assertRecoveryStateCleared()
+            } finally {
+                db.close()
+            }
+        }
+
+    @Test
     fun delegation_proof_result_fixture_crosses_rust_to_kotlin_object_construction() =
         runTest {
-            val result = VotingRustBackend.new().delegationProofResultFixtureForTesting()
+            val result =
+                VotingRustBackend
+                    .new()
+                    .delegationProofResultFixtureForTesting()
 
             assertEquals(96, result.proof.size)
             assertEquals(14, result.publicInputs.size)
@@ -1179,6 +1202,102 @@ class VotingRustBackendTest {
 
     private fun newDbPath() =
         createTempDirectory("voting-db-").resolve("voting.db").toFile().absolutePath
+
+    private suspend fun VotingRustBackend.VotingDb.assertStoredTxHashesRoundTrip() {
+        assertNull(getDelegationTxHash(PCZT_ROUND_ID, bundleIndex = 1))
+        assertNull(getVoteTxHash(PCZT_ROUND_ID, bundleIndex = 1, proposalId = 1))
+
+        storeDelegationTxHash(PCZT_ROUND_ID, bundleIndex = 1, txHash = "delegation-tx")
+        assertEquals("delegation-tx", getDelegationTxHash(PCZT_ROUND_ID, bundleIndex = 1))
+
+        storeVoteTxHash(PCZT_ROUND_ID, bundleIndex = 1, proposalId = 1, txHash = "vote-tx")
+        assertEquals("vote-tx", getVoteTxHash(PCZT_ROUND_ID, bundleIndex = 1, proposalId = 1))
+
+        markVoteSubmitted(PCZT_ROUND_ID, bundleIndex = 1, proposalId = 1)
+        assertTrue(
+            getVotes(PCZT_ROUND_ID)
+                .single { vote ->
+                    vote.bundleIndex == 1 && vote.proposalId == 1
+                }.submitted
+        )
+    }
+
+    private suspend fun VotingRustBackend.VotingDb.assertStoredCommitmentBundleRoundTrips() {
+        assertNull(getCommitmentBundle(PCZT_ROUND_ID, bundleIndex = 1, proposalId = 1))
+
+        val commitment = jniVoteCommitmentResult()
+        storeCommitmentBundle(
+            roundId = PCZT_ROUND_ID,
+            bundleIndex = 1,
+            proposalId = 1,
+            commitment = commitment,
+            vcTreePosition = 42
+        )
+        val recoveredCommitment =
+            assertNotNull(
+                getCommitmentBundle(
+                    PCZT_ROUND_ID,
+                    bundleIndex = 1,
+                    proposalId = 1
+                )
+            )
+        assertEquals(commitment, recoveredCommitment.commitment)
+        assertEquals(42, recoveredCommitment.vcTreePosition)
+    }
+
+    private suspend fun VotingRustBackend.VotingDb.assertShareDelegationRecoveryStateRoundTrips() {
+        val nullifier = ByteArray(FIELD_BYTES) { 0x55 }
+        recordShareDelegation(
+            roundId = PCZT_ROUND_ID,
+            bundleIndex = 1,
+            proposalId = 1,
+            shareIndex = SHARE_INDEX,
+            sentToUrls = listOf("https://helper-1.example"),
+            nullifier = nullifier,
+            submitAt = 123
+        )
+        assertRecordedShareDelegation(nullifier)
+
+        addSentServers(
+            roundId = PCZT_ROUND_ID,
+            bundleIndex = 1,
+            proposalId = 1,
+            shareIndex = SHARE_INDEX,
+            newUrls = listOf("https://helper-1.example", "https://helper-2.example")
+        )
+        assertEquals(
+            listOf("https://helper-1.example", "https://helper-2.example"),
+            getShareDelegations(PCZT_ROUND_ID).single().sentToUrls
+        )
+
+        markShareConfirmed(
+            PCZT_ROUND_ID,
+            bundleIndex = 1,
+            proposalId = 1,
+            shareIndex = SHARE_INDEX
+        )
+        assertTrue(getShareDelegations(PCZT_ROUND_ID).single().confirmed)
+        assertEquals(emptyList(), getUnconfirmedDelegations(PCZT_ROUND_ID).asList())
+    }
+
+    private suspend fun VotingRustBackend.VotingDb.assertRecordedShareDelegation(
+        nullifier: ByteArray
+    ) {
+        val recordedShare = getShareDelegations(PCZT_ROUND_ID).single()
+        assertEquals(SHARE_INDEX, recordedShare.shareIndex)
+        assertEquals(listOf("https://helper-1.example"), recordedShare.sentToUrls)
+        assertContentEquals(nullifier, recordedShare.nullifier)
+        assertFalse(recordedShare.confirmed)
+        assertEquals(123, recordedShare.submitAt)
+        assertEquals(1, getUnconfirmedDelegations(PCZT_ROUND_ID).size)
+    }
+
+    private suspend fun VotingRustBackend.VotingDb.assertRecoveryStateCleared() {
+        assertNull(getDelegationTxHash(PCZT_ROUND_ID, bundleIndex = 1))
+        assertNull(getVoteTxHash(PCZT_ROUND_ID, bundleIndex = 1, proposalId = 1))
+        assertNull(getCommitmentBundle(PCZT_ROUND_ID, bundleIndex = 1, proposalId = 1))
+        assertEquals(emptyList(), getShareDelegations(PCZT_ROUND_ID).asList())
+    }
 
     private suspend fun newWalletDbWithAccount(): WalletDbFixture {
         val walletDbFile =
@@ -1323,7 +1442,7 @@ class VotingRustBackendTest {
     private suspend fun VotingRustBackend.VotingDb.buildTestGovernancePczt(
         ufvk: String,
         notes: List<JniNoteInfo>,
-        walletSeed: ByteArray = HOTKEY_SEED,
+        hotkeySeed: ByteArray = HOTKEY_SEED,
         networkId: Int = TESTNET_NETWORK_ID,
         roundId: String = PCZT_ROUND_ID
     ) = buildGovernancePczt(
@@ -1333,10 +1452,10 @@ class VotingRustBackendTest {
         networkId = networkId,
         accountIndex = ACCOUNT_INDEX,
         notes = notes,
-        walletSeed = walletSeed,
+        walletSeed = HOTKEY_SEED,
+        hotkeySeed = hotkeySeed,
         seedFingerprint = SEED_FINGERPRINT,
-        roundName = ROUND_NAME,
-        addressIndex = ADDRESS_INDEX
+        roundName = ROUND_NAME
     )
 
     private fun notes(

--- a/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
+++ b/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
@@ -1263,7 +1263,7 @@ class VotingRustBackendTest {
             bundleIndex = 1,
             proposalId = 1,
             shareIndex = SHARE_INDEX,
-            newUrls = listOf("https://helper-1.example", "https://helper-2.example")
+            newUrls = listOf("https://helper-2.example")
         )
         assertEquals(
             listOf("https://helper-1.example", "https://helper-2.example"),

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackend.kt
@@ -4,6 +4,7 @@ import androidx.annotation.Keep
 import androidx.annotation.VisibleForTesting
 import cash.z.ecc.android.sdk.internal.SdkDispatchers
 import cash.z.ecc.android.sdk.internal.model.voting.JniBundleSetupResult
+import cash.z.ecc.android.sdk.internal.model.voting.JniCommitmentBundleRecord
 import cash.z.ecc.android.sdk.internal.model.voting.JniDelegationPirPrecomputeResult
 import cash.z.ecc.android.sdk.internal.model.voting.JniDelegationProofResult
 import cash.z.ecc.android.sdk.internal.model.voting.JniDelegationSubmissionResult
@@ -11,6 +12,7 @@ import cash.z.ecc.android.sdk.internal.model.voting.JniGovernancePczt
 import cash.z.ecc.android.sdk.internal.model.voting.JniNoteInfo
 import cash.z.ecc.android.sdk.internal.model.voting.JniRoundState
 import cash.z.ecc.android.sdk.internal.model.voting.JniRoundSummary
+import cash.z.ecc.android.sdk.internal.model.voting.JniShareDelegationRecord
 import cash.z.ecc.android.sdk.internal.model.voting.JniSharePayload
 import cash.z.ecc.android.sdk.internal.model.voting.JniVanWitness
 import cash.z.ecc.android.sdk.internal.model.voting.JniVoteCommitmentResult
@@ -309,9 +311,9 @@ class VotingRustBackend private constructor() {
             accountIndex: Int,
             notes: List<JniNoteInfo>,
             walletSeed: ByteArray,
+            hotkeySeed: ByteArray,
             seedFingerprint: ByteArray,
-            roundName: String,
-            addressIndex: Int
+            roundName: String
         ): JniGovernancePczt =
             withHandle { handle ->
                 buildGovernancePcztNative(
@@ -323,9 +325,9 @@ class VotingRustBackend private constructor() {
                     accountIndex,
                     notes.toTypedArray(),
                     walletSeed,
+                    hotkeySeed,
                     seedFingerprint,
-                    roundName,
-                    addressIndex
+                    roundName
                 ) ?: error("buildGovernancePczt returned null")
             }
 
@@ -371,9 +373,7 @@ class VotingRustBackend private constructor() {
             pirServerUrl: String,
             networkId: Int,
             notes: List<JniNoteInfo>,
-            walletSeed: ByteArray,
-            accountIndex: Int,
-            addressIndex: Int,
+            hotkeySeed: ByteArray,
             proofProgress: VotingProofProgressCallback?
         ): JniDelegationProofResult =
             withHandle { handle ->
@@ -384,9 +384,7 @@ class VotingRustBackend private constructor() {
                     pirServerUrl,
                     networkId,
                     notes.toTypedArray(),
-                    walletSeed,
-                    accountIndex,
-                    addressIndex,
+                    hotkeySeed,
                     proofProgress?.withVotingDbReentryGuard()
                 ) ?: error("buildAndProveDelegation returned null")
             }
@@ -525,6 +523,176 @@ class VotingRustBackend private constructor() {
                 ) ?: error("buildVoteCommitment returned null")
             }
 
+        @Throws(RuntimeException::class)
+        suspend fun storeDelegationTxHash(
+            roundId: String,
+            bundleIndex: Int,
+            txHash: String
+        ) = withHandle { handle ->
+            check(storeDelegationTxHashNative(handle, roundId, bundleIndex, txHash)) {
+                "storeDelegationTxHash failed for roundId=$roundId bundleIndex=$bundleIndex"
+            }
+        }
+
+        @Throws(RuntimeException::class)
+        suspend fun getDelegationTxHash(
+            roundId: String,
+            bundleIndex: Int
+        ): String? =
+            withHandle { handle ->
+                getDelegationTxHashNative(handle, roundId, bundleIndex)
+            }
+
+        @Throws(RuntimeException::class)
+        suspend fun storeVoteTxHash(
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int,
+            txHash: String
+        ) = withHandle { handle ->
+            check(storeVoteTxHashNative(handle, roundId, bundleIndex, proposalId, txHash)) {
+                "storeVoteTxHash failed for roundId=$roundId bundleIndex=$bundleIndex proposalId=$proposalId"
+            }
+        }
+
+        @Throws(RuntimeException::class)
+        suspend fun markVoteSubmitted(
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int
+        ) = withHandle { handle ->
+            check(markVoteSubmittedNative(handle, roundId, bundleIndex, proposalId)) {
+                "markVoteSubmitted failed for roundId=$roundId bundleIndex=$bundleIndex proposalId=$proposalId"
+            }
+        }
+
+        @Throws(RuntimeException::class)
+        suspend fun getVoteTxHash(
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int
+        ): String? =
+            withHandle { handle ->
+                getVoteTxHashNative(handle, roundId, bundleIndex, proposalId)
+            }
+
+        @Throws(RuntimeException::class)
+        suspend fun storeCommitmentBundle(
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int,
+            commitment: JniVoteCommitmentResult,
+            vcTreePosition: Long
+        ) = withHandle { handle ->
+            check(
+                storeCommitmentBundleNative(
+                    handle,
+                    roundId,
+                    bundleIndex,
+                    proposalId,
+                    commitment,
+                    vcTreePosition
+                )
+            ) {
+                "storeCommitmentBundle failed for roundId=$roundId bundleIndex=$bundleIndex proposalId=$proposalId"
+            }
+        }
+
+        @Throws(RuntimeException::class)
+        suspend fun getCommitmentBundle(
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int
+        ): JniCommitmentBundleRecord? =
+            withHandle { handle ->
+                getCommitmentBundleNative(handle, roundId, bundleIndex, proposalId)
+            }
+
+        @Throws(RuntimeException::class)
+        suspend fun clearRecoveryState(roundId: String) =
+            withHandle { handle ->
+                check(clearRecoveryStateNative(handle, roundId)) {
+                    "clearRecoveryState failed for roundId=$roundId"
+                }
+            }
+
+        @Throws(RuntimeException::class)
+        suspend fun recordShareDelegation(
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int,
+            shareIndex: Int,
+            sentToUrls: List<String>,
+            nullifier: ByteArray,
+            submitAt: Long
+        ) = withHandle { handle ->
+            check(
+                recordShareDelegationNative(
+                    handle,
+                    roundId,
+                    bundleIndex,
+                    proposalId,
+                    shareIndex,
+                    sentToUrls.toTypedArray(),
+                    nullifier,
+                    submitAt
+                )
+            ) {
+                "recordShareDelegation failed for roundId=$roundId " +
+                    "bundleIndex=$bundleIndex proposalId=$proposalId shareIndex=$shareIndex"
+            }
+        }
+
+        @Throws(RuntimeException::class)
+        suspend fun getShareDelegations(roundId: String): Array<JniShareDelegationRecord> =
+            withHandle { handle ->
+                getShareDelegationsNative(handle, roundId)
+                    ?: error("getShareDelegations returned null")
+            }
+
+        @Throws(RuntimeException::class)
+        suspend fun getUnconfirmedDelegations(roundId: String): Array<JniShareDelegationRecord> =
+            withHandle { handle ->
+                getUnconfirmedDelegationsNative(handle, roundId)
+                    ?: error("getUnconfirmedDelegations returned null")
+            }
+
+        @Throws(RuntimeException::class)
+        suspend fun markShareConfirmed(
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int,
+            shareIndex: Int
+        ) = withHandle { handle ->
+            check(markShareConfirmedNative(handle, roundId, bundleIndex, proposalId, shareIndex)) {
+                "markShareConfirmed failed for roundId=$roundId " +
+                    "bundleIndex=$bundleIndex proposalId=$proposalId shareIndex=$shareIndex"
+            }
+        }
+
+        @Throws(RuntimeException::class)
+        suspend fun addSentServers(
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int,
+            shareIndex: Int,
+            newUrls: List<String>
+        ) = withHandle { handle ->
+            check(
+                addSentServersNative(
+                    handle,
+                    roundId,
+                    bundleIndex,
+                    proposalId,
+                    shareIndex,
+                    newUrls.toTypedArray()
+                )
+            ) {
+                "addSentServers failed for roundId=$roundId " +
+                    "bundleIndex=$bundleIndex proposalId=$proposalId shareIndex=$shareIndex"
+            }
+        }
+
         @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
         internal suspend fun storeDelegationProofFixtureForTesting(
             roundId: String,
@@ -532,6 +700,16 @@ class VotingRustBackend private constructor() {
             proof: ByteArray
         ) = withHandle { handle ->
             storeDelegationProofFixtureNative(handle, roundId, bundleIndex, proof)
+        }
+
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        internal suspend fun storeVoteFixtureForTesting(
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int,
+            choice: Int
+        ) = withHandle { handle ->
+            storeVoteFixtureNative(handle, roundId, bundleIndex, proposalId, choice)
         }
 
         private suspend fun <T> withHandle(block: (Long) -> T): T {
@@ -710,9 +888,9 @@ class VotingRustBackend private constructor() {
             accountIndex: Int,
             notes: Array<JniNoteInfo>,
             walletSeed: ByteArray,
+            hotkeySeed: ByteArray,
             seedFingerprint: ByteArray,
-            roundName: String,
-            addressIndex: Int
+            roundName: String
         ): JniGovernancePczt?
 
         @JvmStatic
@@ -776,9 +954,7 @@ class VotingRustBackend private constructor() {
             pirServerUrl: String,
             networkId: Int,
             notes: Array<JniNoteInfo>,
-            walletSeed: ByteArray,
-            accountIndex: Int,
-            addressIndex: Int,
+            hotkeySeed: ByteArray,
             proofProgress: VotingProofProgressCallback?
         ): JniDelegationProofResult?
 
@@ -874,11 +1050,138 @@ class VotingRustBackend private constructor() {
 
         @JvmStatic
         @Throws(RuntimeException::class)
+        private external fun storeDelegationTxHashNative(
+            dbHandle: Long,
+            roundId: String,
+            bundleIndex: Int,
+            txHash: String
+        ): Boolean
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun getDelegationTxHashNative(
+            dbHandle: Long,
+            roundId: String,
+            bundleIndex: Int
+        ): String?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun storeVoteTxHashNative(
+            dbHandle: Long,
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int,
+            txHash: String
+        ): Boolean
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun markVoteSubmittedNative(
+            dbHandle: Long,
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int
+        ): Boolean
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun getVoteTxHashNative(
+            dbHandle: Long,
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int
+        ): String?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun storeCommitmentBundleNative(
+            dbHandle: Long,
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int,
+            commitment: JniVoteCommitmentResult,
+            vcTreePosition: Long
+        ): Boolean
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun getCommitmentBundleNative(
+            dbHandle: Long,
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int
+        ): JniCommitmentBundleRecord?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun clearRecoveryStateNative(dbHandle: Long, roundId: String): Boolean
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun recordShareDelegationNative(
+            dbHandle: Long,
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int,
+            shareIndex: Int,
+            sentToUrls: Array<String>,
+            nullifier: ByteArray,
+            submitAt: Long
+        ): Boolean
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun getShareDelegationsNative(
+            dbHandle: Long,
+            roundId: String
+        ): Array<JniShareDelegationRecord>?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun getUnconfirmedDelegationsNative(
+            dbHandle: Long,
+            roundId: String
+        ): Array<JniShareDelegationRecord>?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun markShareConfirmedNative(
+            dbHandle: Long,
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int,
+            shareIndex: Int
+        ): Boolean
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun addSentServersNative(
+            dbHandle: Long,
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int,
+            shareIndex: Int,
+            newUrls: Array<String>
+        ): Boolean
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
         private external fun storeDelegationProofFixtureNative(
             dbHandle: Long,
             roundId: String,
             bundleIndex: Int,
             proof: ByteArray
+        )
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun storeVoteFixtureNative(
+            dbHandle: Long,
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int,
+            choice: Int
         )
     }
 }

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackend.kt
@@ -670,6 +670,9 @@ class VotingRustBackend private constructor() {
             }
         }
 
+        /**
+         * Appends [newUrls] to the stored sent-server list for this share, ignoring duplicates.
+         */
         @Throws(RuntimeException::class)
         suspend fun addSentServers(
             roundId: String,

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModels.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModels.kt
@@ -137,9 +137,10 @@ data class JniWireEncryptedShare(
 /**
  * Typed JNI carrier for vote commitment outputs.
  *
- * `shareBlinds`, `rVpk`, and `alphaV` are transient reveal/signing inputs.
- * They should not be persisted or logged; they are carried here only because
- * follow-up JNI calls consume the typed commitment result. Encrypted-share
+ * `shareBlinds`, `rVpk`, and `alphaV` are sensitive reveal/signing inputs.
+ * They must not be logged or exposed outside the voting recovery path. They are
+ * carried here because follow-up JNI calls consume the typed commitment result,
+ * and recovery persistence needs them to resume after restart. Encrypted-share
  * plaintext and encryption randomness remain Rust-only and are not included in
  * [encShares].
  */
@@ -189,21 +190,7 @@ data class JniVoteCommitmentResult(
         alphaV = alphaV
     )
 
-    override fun toString(): String =
-        "JniVoteCommitmentResult(" +
-            "vanNullifierBytes=${vanNullifier.size}, " +
-            "voteAuthorityNoteNewBytes=${voteAuthorityNoteNew.size}, " +
-            "voteCommitmentBytes=${voteCommitment.size}, " +
-            "proposalId=$proposalId, " +
-            "proofBytes=${proof.size}, " +
-            "encShares=${encShares.size}, " +
-            "anchorHeight=$anchorHeight, " +
-            "voteRoundId=$voteRoundId, " +
-            "sharesHashBytes=${sharesHash.size}, " +
-            "shareBlinds=***, " +
-            "shareComms=${shareComms.size}, " +
-            "rVpk=***, " +
-            "alphaV=***)"
+    override fun toString(): String = "JniVoteCommitmentResult(redacted)"
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -249,6 +236,12 @@ data class JniVoteCommitmentResult(
         return result
     }
 }
+
+@Keep
+data class JniCommitmentBundleRecord(
+    val commitment: JniVoteCommitmentResult,
+    val vcTreePosition: Long
+)
 
 @Keep
 data class JniSharePayload(
@@ -303,6 +296,68 @@ data class JniSharePayload(
         result = 31 * result + allEncShares.hashCode()
         result = 31 * result + shareComms.contentDeepHashCode()
         result = 31 * result + primaryBlind.contentHashCode()
+        return result
+    }
+}
+
+@Keep
+data class JniShareDelegationRecord(
+    val roundId: String,
+    val bundleIndex: Int,
+    val proposalId: Int,
+    val shareIndex: Int,
+    val sentToUrls: List<String>,
+    val nullifier: ByteArray,
+    val confirmed: Boolean,
+    val submitAt: Long,
+    val createdAt: Long
+) {
+    internal constructor(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int,
+        shareIndex: Int,
+        sentToUrls: Array<String>,
+        nullifier: ByteArray,
+        confirmed: Boolean,
+        submitAt: Long,
+        createdAt: Long
+    ) : this(
+        roundId = roundId,
+        bundleIndex = bundleIndex,
+        proposalId = proposalId,
+        shareIndex = shareIndex,
+        sentToUrls = sentToUrls.toList(),
+        nullifier = nullifier,
+        confirmed = confirmed,
+        submitAt = submitAt,
+        createdAt = createdAt
+    )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is JniShareDelegationRecord) return false
+        return roundId == other.roundId &&
+            bundleIndex == other.bundleIndex &&
+            proposalId == other.proposalId &&
+            shareIndex == other.shareIndex &&
+            sentToUrls == other.sentToUrls &&
+            nullifier.contentEquals(other.nullifier) &&
+            confirmed == other.confirmed &&
+            submitAt == other.submitAt &&
+            createdAt == other.createdAt
+    }
+
+    override fun hashCode(): Int {
+        var result = roundId.hashCode()
+        result = 31 * result + bundleIndex
+        result = 31 * result + proposalId
+        result = 31 * result + shareIndex
+        result = 31 * result + sentToUrls.hashCode()
+        result = 31 * result + nullifier.contentHashCode()
+        result = 31 * result + confirmed.hashCode()
+        result = 31 * result + submitAt.hashCode()
+        result = 31 * result + createdAt.hashCode()
         return result
     }
 }

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModels.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModels.kt
@@ -150,6 +150,7 @@ data class JniVoteCommitmentResult(
     val voteAuthorityNoteNew: ByteArray,
     val voteCommitment: ByteArray,
     val proposalId: Int,
+    val bundleIndex: Int,
     val proof: ByteArray,
     val encShares: List<JniWireEncryptedShare>,
     val anchorHeight: Long,
@@ -165,6 +166,7 @@ data class JniVoteCommitmentResult(
         voteAuthorityNoteNew: ByteArray,
         voteCommitment: ByteArray,
         proposalId: Int,
+        bundleIndex: Int,
         proof: ByteArray,
         encShares: Array<JniWireEncryptedShare>,
         anchorHeight: Long,
@@ -179,6 +181,7 @@ data class JniVoteCommitmentResult(
         voteAuthorityNoteNew = voteAuthorityNoteNew,
         voteCommitment = voteCommitment,
         proposalId = proposalId,
+        bundleIndex = bundleIndex,
         proof = proof,
         encShares = encShares.toList(),
         anchorHeight = anchorHeight,
@@ -202,6 +205,7 @@ data class JniVoteCommitmentResult(
 
     private fun scalarFieldsEqual(other: JniVoteCommitmentResult) =
         proposalId == other.proposalId &&
+            bundleIndex == other.bundleIndex &&
             anchorHeight == other.anchorHeight &&
             voteRoundId == other.voteRoundId
 
@@ -224,6 +228,7 @@ data class JniVoteCommitmentResult(
         result = 31 * result + voteAuthorityNoteNew.contentHashCode()
         result = 31 * result + voteCommitment.contentHashCode()
         result = 31 * result + proposalId
+        result = 31 * result + bundleIndex
         result = 31 * result + proof.contentHashCode()
         result = 31 * result + encShares.hashCode()
         result = 31 * result + anchorHeight.hashCode()

--- a/backend-lib/src/main/rust/voting.rs
+++ b/backend-lib/src/main/rust/voting.rs
@@ -6,6 +6,7 @@ use jni::{
     objects::{GlobalRef, JByteArray, JClass, JObject, JObjectArray, JString, JValue},
     sys::{
         JNI_FALSE, JNI_TRUE, jboolean, jbyteArray, jint, jlong, jlongArray, jobject, jobjectArray,
+        jstring,
     },
 };
 use orchard::keys::Scope;
@@ -39,6 +40,7 @@ mod delegation;
 mod helpers;
 mod notes;
 mod progress;
+mod recovery;
 mod rounds;
 mod share_tracking;
 mod tree;

--- a/backend-lib/src/main/rust/voting/delegation.rs
+++ b/backend-lib/src/main/rust/voting/delegation.rs
@@ -19,9 +19,9 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_bui
     account_index: jint,
     notes: JObjectArray<'local>,
     wallet_seed: JByteArray<'local>,
+    hotkey_seed: JByteArray<'local>,
     seed_fingerprint: JByteArray<'local>,
     round_name: JString<'local>,
-    address_index: jint,
 ) -> jobject {
     let res = catch_unwind(&mut env, |env| {
         let db = db_from_handle(db_handle)?;
@@ -29,12 +29,13 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_bui
         let network = network_from_id(network_id)?;
         let bundle_index = jint_to_u32(bundle_index, "bundle_index")?;
         let account_index = jint_to_u32(account_index, "account_index")?;
-        let address_index = jint_to_u32(address_index, "address_index")?;
         let ufvk_str = java_string_to_rust(env, &ufvk)?;
         let fvk_bytes = orchard_fvk_bytes(&ufvk_str, network)?;
 
         let seed_bytes =
             java_secret_bytes_at_least(env, &wallet_seed, "walletSeed", PROTOCOL_FIELD_BYTES)?;
+        let hotkey_seed =
+            java_secret_bytes_at_least(env, &hotkey_seed, "hotkeySeed", PROTOCOL_FIELD_BYTES)?;
         let derived_fvk_bytes =
             orchard_fvk_bytes_from_wallet_seed(seed_bytes.expose_secret(), network, account_index)?;
         if derived_fvk_bytes != fvk_bytes {
@@ -42,12 +43,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_bui
                 "ufvk does not match walletSeed for network_id={network_id} account_index={account_index}"
             ));
         }
-        let hotkey_raw_address = hotkey_orchard_raw_address_from_wallet_seed(
-            seed_bytes.expose_secret(),
-            network,
-            account_index,
-            address_index,
-        )?;
+        let hotkey_raw_address =
+            hotkey_orchard_raw_address(hotkey_seed.expose_secret(), network, 0)?;
         let seed_fingerprint = java_bytes32(env, &seed_fingerprint, "seedFingerprint")?;
 
         let notes = java_note_info_array(env, &notes, "notes")?;
@@ -68,7 +65,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_bui
                 &seed_fingerprint,
                 account_index,
                 &round_name,
-                address_index,
+                HOTKEY_ADDRESS_INDEX,
             )
             .map_err(|e| anyhow!("build_governance_pczt: {}", e))?;
         update_round_phase_forward(&db, &round_id, RoundPhase::DelegationConstructed)?;
@@ -224,9 +221,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_bui
     pir_server_url: JString<'local>,
     network_id: jint,
     notes: JObjectArray<'local>,
-    wallet_seed: JByteArray<'local>,
-    account_index: jint,
-    address_index: jint,
+    hotkey_seed: JByteArray<'local>,
     progress_callback: JObject<'local>,
 ) -> jobject {
     let res = catch_unwind(&mut env, |env| {
@@ -235,23 +230,15 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_bui
         let network = network_from_id(network_id)?;
         let network_id = jint_to_u32(network_id, "network_id")?;
         let bundle_index = jint_to_u32(bundle_index, "bundle_index")?;
-        let account_index = jint_to_u32(account_index, "account_index")?;
-        let address_index = jint_to_u32(address_index, "address_index")?;
-        let seed_bytes =
-            java_secret_bytes_at_least(env, &wallet_seed, "walletSeed", PROTOCOL_FIELD_BYTES)?;
-        let hotkey_raw_address = hotkey_orchard_raw_address_from_wallet_seed(
-            seed_bytes.expose_secret(),
-            network,
-            account_index,
-            address_index,
-        )?;
-        drop(seed_bytes);
-
         let notes = java_note_info_array(env, &notes, "notes")?;
         let bundle_notes = bundled_notes_for_index(&notes, bundle_index)?;
         let round_id = java_string_to_rust(env, &round_id)?;
         require_round_phase_not_after(&db, &round_id, RoundPhase::DelegationProved)?;
         require_bundle_notes_match(&db, &round_id, bundle_index, &bundle_notes)?;
+        let hotkey_seed =
+            java_secret_bytes_at_least(env, &hotkey_seed, "hotkeySeed", PROTOCOL_FIELD_BYTES)?;
+        let hotkey_raw_address =
+            hotkey_orchard_raw_address(hotkey_seed.expose_secret(), network, 0)?;
         let pir_url = java_string_to_rust(env, &pir_server_url)?;
         let pir_client = connect_pir_client(&pir_url)?;
         let reporter = progress_reporter_from_callback(env, &progress_callback)?;

--- a/backend-lib/src/main/rust/voting/helpers.rs
+++ b/backend-lib/src/main/rust/voting/helpers.rs
@@ -1,4 +1,5 @@
 use super::*;
+use secrecy::Zeroize;
 use serde::{Deserialize, Serialize};
 
 // Must match JNI_ROUND_PHASE_* constants in JniVotingModels.kt.
@@ -197,6 +198,22 @@ pub(super) fn require_len(bytes: Vec<u8>, field: &str, expected: usize) -> anyho
         Err(anyhow!(
             "{field} must be exactly {expected} bytes, got {}",
             bytes.len()
+        ))
+    }
+}
+
+fn require_len_and_zeroize(
+    bytes: &mut Vec<u8>,
+    field: &str,
+    expected: usize,
+) -> anyhow::Result<()> {
+    let len = bytes.len();
+    bytes.zeroize();
+    if len == expected {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "{field} must be exactly {expected} bytes, got {len}"
         ))
     }
 }
@@ -1415,30 +1432,58 @@ fn make_jni_string_array<'local>(
 }
 
 /// Builds the Kotlin hotkey JNI model after enforcing the expected key widths.
-/// The secret key is intentionally not surfaced across JNI.
+/// The secret key is intentionally not surfaced across JNI and is zeroized
+/// before constructing the public-only Java object.
 pub(super) fn make_jni_voting_hotkey<'local>(
     env: &mut JNIEnv<'local>,
     hotkey: voting::types::VotingHotkey,
 ) -> anyhow::Result<jobject> {
-    let class = env.find_class(JNI_VOTING_HOTKEY)?;
-    require_len(
-        hotkey.secret_key,
+    let voting::types::VotingHotkey {
+        mut secret_key,
+        public_key,
+        address,
+    } = hotkey;
+    require_len_and_zeroize(
+        &mut secret_key,
         "hotkey_secret_key",
         HOTKEY_SECRET_KEY_BYTES,
     )?;
-    let public_key = require_len(
-        hotkey.public_key,
-        "hotkey_public_key",
-        HOTKEY_PUBLIC_KEY_BYTES,
-    )?;
+
+    let public_key = require_len(public_key, "hotkey_public_key", HOTKEY_PUBLIC_KEY_BYTES)?;
+    let class = env.find_class(JNI_VOTING_HOTKEY)?;
     let pk_obj: JObject<'local> = env.byte_array_from_slice(&public_key)?.into();
-    let addr_obj: JObject<'local> = env.new_string(&hotkey.address)?.into();
+    let addr_obj: JObject<'local> = env.new_string(&address)?.into();
     let obj = env.new_object(
         &class,
         JNI_VOTING_HOTKEY_CTOR_SIG,
         &[JValue::Object(&pk_obj), JValue::Object(&addr_obj)],
     )?;
     Ok(obj.into_raw())
+}
+
+#[cfg(test)]
+mod hotkey_secret_tests {
+    use super::*;
+
+    #[test]
+    fn require_len_and_zeroize_clears_secret_on_success() {
+        let mut secret = vec![0xAB; HOTKEY_SECRET_KEY_BYTES];
+
+        require_len_and_zeroize(&mut secret, "secret", HOTKEY_SECRET_KEY_BYTES).unwrap();
+
+        assert!(secret.iter().all(|byte| *byte == 0));
+    }
+
+    #[test]
+    fn require_len_and_zeroize_clears_secret_on_error() {
+        let mut secret = vec![0xAB; HOTKEY_SECRET_KEY_BYTES - 1];
+
+        let error = require_len_and_zeroize(&mut secret, "secret", HOTKEY_SECRET_KEY_BYTES)
+            .expect_err("wrong length should fail");
+
+        assert!(error.to_string().contains("secret must be exactly"));
+        assert!(secret.iter().all(|byte| *byte == 0));
+    }
 }
 
 /// Builds the Kotlin bundle setup JNI model with width-checked Java primitives.

--- a/backend-lib/src/main/rust/voting/helpers.rs
+++ b/backend-lib/src/main/rust/voting/helpers.rs
@@ -1,4 +1,5 @@
 use super::*;
+use serde::{Deserialize, Serialize};
 
 // Must match JNI_ROUND_PHASE_* constants in JniVotingModels.kt.
 const PHASE_INITIALIZED: u32 = 0;
@@ -17,6 +18,10 @@ const JNI_WIRE_ENCRYPTED_SHARE: &str =
 const JNI_VOTE_COMMITMENT_RESULT: &str =
     "cash/z/ecc/android/sdk/internal/model/voting/JniVoteCommitmentResult";
 const JNI_SHARE_PAYLOAD: &str = "cash/z/ecc/android/sdk/internal/model/voting/JniSharePayload";
+const JNI_COMMITMENT_BUNDLE_RECORD: &str =
+    "cash/z/ecc/android/sdk/internal/model/voting/JniCommitmentBundleRecord";
+const JNI_SHARE_DELEGATION_RECORD: &str =
+    "cash/z/ecc/android/sdk/internal/model/voting/JniShareDelegationRecord";
 const JNI_VOTING_HOTKEY: &str = "cash/z/ecc/android/sdk/internal/model/voting/JniVotingHotkey";
 const JNI_BUNDLE_SETUP_RESULT: &str =
     "cash/z/ecc/android/sdk/internal/model/voting/JniBundleSetupResult";
@@ -46,10 +51,19 @@ const JNI_WIRE_ENCRYPTED_SHARE_CTOR_SIG: &str = "([B[BI)V";
 // Array<ByteArray>, Array<ByteArray>, ByteArray, ByteArray) in
 // JniVotingModels.kt. Guarded by JniVotingModelsTest.
 const JNI_VOTE_COMMITMENT_RESULT_CTOR_SIG: &str = "([B[B[BI[B[Lcash/z/ecc/android/sdk/internal/model/voting/JniWireEncryptedShare;JLjava/lang/String;[B[[B[[B[B[B)V";
+// Must match JniCommitmentBundleRecord(JniVoteCommitmentResult, Long) in
+// JniVotingModels.kt. Guarded by JniVotingModelsTest.
+const JNI_COMMITMENT_BUNDLE_RECORD_CTOR_SIG: &str =
+    "(Lcash/z/ecc/android/sdk/internal/model/voting/JniVoteCommitmentResult;J)V";
 // Must match JniSharePayload(ByteArray, Int, Int, JniWireEncryptedShare,
 // Long, Array<JniWireEncryptedShare>, Array<ByteArray>, ByteArray) in
 // JniVotingModels.kt. Guarded by JniVotingModelsTest.
 const JNI_SHARE_PAYLOAD_CTOR_SIG: &str = "([BIILcash/z/ecc/android/sdk/internal/model/voting/JniWireEncryptedShare;J[Lcash/z/ecc/android/sdk/internal/model/voting/JniWireEncryptedShare;[[B[B)V";
+// Must match JniShareDelegationRecord(String, Int, Int, Int, Array<String>,
+// ByteArray, Boolean, Long, Long) in JniVotingModels.kt. Guarded by
+// JniVotingModelsTest.
+const JNI_SHARE_DELEGATION_RECORD_CTOR_SIG: &str =
+    "(Ljava/lang/String;III[Ljava/lang/String;[BZJJ)V";
 // Must match JniVotingHotkey(ByteArray, String) in JniVotingModels.kt.
 const JNI_VOTING_HOTKEY_CTOR_SIG: &str = "([BLjava/lang/String;)V";
 // Must match JniBundleSetupResult(Int, Long, LongArray) in JniVotingModels.kt.
@@ -73,7 +87,10 @@ pub(super) const PROTOCOL_FIELD_BYTES: usize = 32;
 pub(super) const VOTE_COMMITMENT_BYTES: usize = PROTOCOL_FIELD_BYTES;
 pub(super) const BLIND_BYTES: usize = PROTOCOL_FIELD_BYTES;
 pub(super) const SHARE_NULLIFIER_BYTES: usize = PROTOCOL_FIELD_BYTES;
+pub(super) const HOTKEY_SECRET_KEY_BYTES: usize = PROTOCOL_FIELD_BYTES;
 pub(super) const HOTKEY_PUBLIC_KEY_BYTES: usize = PROTOCOL_FIELD_BYTES;
+// Hotkeys use one stable Orchard address for voting identity and recovery.
+pub(super) const HOTKEY_ADDRESS_INDEX: u32 = 0;
 pub(super) const SPEND_AUTH_SIG_BYTES: usize = 64;
 pub(super) const NOTE_SCOPE_EXTERNAL: u32 = 0;
 pub(super) const NOTE_SCOPE_INTERNAL: u32 = 1;
@@ -101,6 +118,48 @@ struct JniVoteRecordPayload {
     bundle_index: jint,
     choice: jint,
     submitted: bool,
+}
+
+struct JniVoteCommitmentResultPayload {
+    van_nullifier: Vec<u8>,
+    vote_authority_note_new: Vec<u8>,
+    vote_commitment: Vec<u8>,
+    proposal_id: u32,
+    proof: Vec<u8>,
+    enc_shares: Vec<WireEncryptedShare>,
+    anchor_height: u32,
+    vote_round_id: String,
+    shares_hash: Vec<u8>,
+    share_blinds: Vec<Vec<u8>>,
+    share_comms: Vec<Vec<u8>>,
+    r_vpk_bytes: Vec<u8>,
+    alpha_v: Vec<u8>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct StoredWireEncryptedShare {
+    c1: String,
+    c2: String,
+    share_index: u32,
+}
+
+// Recovery replay needs the reveal and signing inputs below. Keep this JSON out
+// of logs; it contains the same sensitive fields as JniVoteCommitmentResult.
+#[derive(Deserialize, Serialize)]
+pub(super) struct StoredVoteCommitmentBundle {
+    van_nullifier: String,
+    vote_authority_note_new: String,
+    vote_commitment: String,
+    proposal_id: u32,
+    proof: String,
+    enc_shares: Vec<StoredWireEncryptedShare>,
+    anchor_height: u32,
+    vote_round_id: String,
+    shares_hash: String,
+    share_blinds: Vec<String>,
+    share_comms: Vec<String>,
+    r_vpk_bytes: String,
+    alpha_v: String,
 }
 
 pub(super) fn jint_to_u32(value: jint, field: &str) -> anyhow::Result<u32> {
@@ -228,6 +287,29 @@ pub(super) fn fixed_bytes<const N: usize>(bytes: Vec<u8>, field: &str) -> anyhow
         .map_err(|_| anyhow!("{field} must be exactly {N} bytes, got {len}"))
 }
 
+fn hex_enc(bytes: &[u8]) -> String {
+    hex::encode(bytes)
+}
+
+fn hex_dec(value: &str, field: &str) -> anyhow::Result<Vec<u8>> {
+    hex::decode(value).map_err(|e| anyhow!("{field}: invalid hex: {e}"))
+}
+
+fn hex_dec_exact(value: &str, field: &str, expected: usize) -> anyhow::Result<Vec<u8>> {
+    require_len(hex_dec(value, field)?, field, expected)
+}
+
+pub(super) fn require_share_index(share_index: u32, field: &str) -> anyhow::Result<u32> {
+    if share_index < VOTE_SHARE_COUNT as u32 {
+        Ok(share_index)
+    } else {
+        Err(anyhow!(
+            "{field} must be in 0..{}, got {share_index}",
+            VOTE_SHARE_COUNT - 1
+        ))
+    }
+}
+
 pub(super) fn round_phase_to_u32(phase: RoundPhase) -> u32 {
     match phase {
         RoundPhase::Initialized => PHASE_INITIALIZED,
@@ -303,23 +385,20 @@ pub(super) fn network_from_id(id: jint) -> anyhow::Result<Network> {
     }
 }
 
-pub(super) fn hotkey_orchard_raw_address_from_wallet_seed(
-    wallet_seed: &[u8],
+pub(super) fn hotkey_orchard_raw_address(
+    hotkey_seed: &[u8],
     network: Network,
     account_index: u32,
-    address_index: u32,
 ) -> anyhow::Result<Vec<u8>> {
     let account_id = zip32::AccountId::try_from(account_index)
         .map_err(|_| anyhow!("invalid account_index {}", account_index))?;
-    let usk = UnifiedSpendingKey::from_seed(&network, wallet_seed, account_id)
-        .map_err(|e| anyhow!("failed to derive hotkey USK from wallet seed: {}", e))?;
+    let usk = UnifiedSpendingKey::from_seed(&network, hotkey_seed, account_id)
+        .map_err(|e| anyhow!("failed to derive hotkey USK: {}", e))?;
     let fvk = usk.to_unified_full_viewing_key();
     let orchard_fvk = fvk
         .orchard()
         .ok_or_else(|| anyhow!("hotkey UFVK has no Orchard component"))?;
-    // voting-circuits treats address_index as the diversifier index for the
-    // external Orchard scope when reconstructing the hotkey address for ZKP #2.
-    let addr = orchard_fvk.address_at(address_index, Scope::External);
+    let addr = orchard_fvk.address_at(HOTKEY_ADDRESS_INDEX, Scope::External);
     require_len(
         addr.to_raw_address_bytes().to_vec(),
         "hotkey_raw_address",
@@ -371,7 +450,10 @@ pub(super) fn java_note_info_array(
 }
 
 fn java_note_info(env: &mut JNIEnv<'_>, note: &JObject<'_>) -> anyhow::Result<NoteInfo> {
-    let scope = require_note_scope(u32::try_from(env.get_field(note, "scope", "I")?.i()?)?)?;
+    let scope = require_note_scope(jint_to_u32(
+        env.get_field(note, "scope", "I")?.i()?,
+        "scope",
+    )?)?;
 
     Ok(NoteInfo {
         commitment: require_len(
@@ -480,13 +562,10 @@ fn java_wire_encrypted_share(
     env: &mut JNIEnv<'_>,
     share: &JObject<'_>,
 ) -> anyhow::Result<WireEncryptedShare> {
-    let share_index = jint_to_u32(env.get_field(share, "shareIndex", "I")?.i()?, "shareIndex")?;
-    if share_index >= VOTE_SHARE_COUNT as u32 {
-        return Err(anyhow!(
-            "shareIndex must be in 0..{}, got {share_index}",
-            VOTE_SHARE_COUNT - 1
-        ));
-    }
+    let share_index = require_share_index(
+        jint_to_u32(env.get_field(share, "shareIndex", "I")?.i()?, "shareIndex")?,
+        "shareIndex",
+    )?;
 
     Ok(WireEncryptedShare {
         c1: require_len(
@@ -600,6 +679,170 @@ pub(super) fn java_vote_commitment_bundle(
             )?,
         },
     })
+}
+
+impl TryFrom<JavaVoteCommitmentBundle> for StoredVoteCommitmentBundle {
+    type Error = anyhow::Error;
+
+    fn try_from(commitment: JavaVoteCommitmentBundle) -> anyhow::Result<Self> {
+        let bundle = commitment.bundle;
+        Ok(StoredVoteCommitmentBundle {
+            van_nullifier: hex_enc(&bundle.van_nullifier),
+            vote_authority_note_new: hex_enc(&bundle.vote_authority_note_new),
+            vote_commitment: hex_enc(&bundle.vote_commitment),
+            proposal_id: bundle.proposal_id,
+            proof: hex_enc(&bundle.proof),
+            enc_shares: commitment
+                .enc_shares
+                .into_iter()
+                .map(StoredWireEncryptedShare::from)
+                .collect(),
+            anchor_height: bundle.anchor_height,
+            vote_round_id: bundle.vote_round_id,
+            shares_hash: hex_enc(&bundle.shares_hash),
+            share_blinds: bundle
+                .share_blinds
+                .iter()
+                .map(|value| hex_enc(value))
+                .collect(),
+            share_comms: bundle
+                .share_comms
+                .iter()
+                .map(|value| hex_enc(value))
+                .collect(),
+            r_vpk_bytes: hex_enc(&bundle.r_vpk_bytes),
+            alpha_v: hex_enc(&bundle.alpha_v),
+        })
+    }
+}
+
+impl StoredVoteCommitmentBundle {
+    pub(super) fn to_storage_json(&self) -> anyhow::Result<String> {
+        serde_json::to_string(self)
+            .map_err(|e| anyhow!("commitment bundle JSON serialization failed: {e}"))
+    }
+
+    pub(super) fn from_storage_json(value: &str) -> anyhow::Result<Self> {
+        serde_json::from_str(value).map_err(|e| anyhow!("commitment bundle JSON parse failed: {e}"))
+    }
+}
+
+impl From<WireEncryptedShare> for StoredWireEncryptedShare {
+    fn from(share: WireEncryptedShare) -> Self {
+        StoredWireEncryptedShare {
+            c1: hex_enc(&share.c1),
+            c2: hex_enc(&share.c2),
+            share_index: share.share_index,
+        }
+    }
+}
+
+impl TryFrom<StoredWireEncryptedShare> for WireEncryptedShare {
+    type Error = anyhow::Error;
+
+    fn try_from(share: StoredWireEncryptedShare) -> anyhow::Result<Self> {
+        Ok(WireEncryptedShare {
+            c1: hex_dec_exact(&share.c1, "encShares[].c1", PROTOCOL_FIELD_BYTES)?,
+            c2: hex_dec_exact(&share.c2, "encShares[].c2", PROTOCOL_FIELD_BYTES)?,
+            share_index: require_share_index(share.share_index, "encShares[].shareIndex")?,
+        })
+    }
+}
+
+impl From<VoteCommitmentBundle> for JniVoteCommitmentResultPayload {
+    fn from(bundle: VoteCommitmentBundle) -> Self {
+        JniVoteCommitmentResultPayload {
+            van_nullifier: bundle.van_nullifier,
+            vote_authority_note_new: bundle.vote_authority_note_new,
+            vote_commitment: bundle.vote_commitment,
+            proposal_id: bundle.proposal_id,
+            proof: bundle.proof,
+            enc_shares: bundle
+                .enc_shares
+                .into_iter()
+                .map(WireEncryptedShare::from)
+                .collect(),
+            anchor_height: bundle.anchor_height,
+            vote_round_id: bundle.vote_round_id,
+            shares_hash: bundle.shares_hash,
+            share_blinds: bundle.share_blinds,
+            share_comms: bundle.share_comms,
+            r_vpk_bytes: bundle.r_vpk_bytes,
+            alpha_v: bundle.alpha_v,
+        }
+    }
+}
+
+impl TryFrom<StoredVoteCommitmentBundle> for JniVoteCommitmentResultPayload {
+    type Error = anyhow::Error;
+
+    fn try_from(bundle: StoredVoteCommitmentBundle) -> anyhow::Result<Self> {
+        Ok(JniVoteCommitmentResultPayload {
+            van_nullifier: hex_dec_exact(
+                &bundle.van_nullifier,
+                "vanNullifier",
+                PROTOCOL_FIELD_BYTES,
+            )?,
+            vote_authority_note_new: hex_dec_exact(
+                &bundle.vote_authority_note_new,
+                "voteAuthorityNoteNew",
+                PROTOCOL_FIELD_BYTES,
+            )?,
+            vote_commitment: hex_dec_exact(
+                &bundle.vote_commitment,
+                "voteCommitment",
+                PROTOCOL_FIELD_BYTES,
+            )?,
+            proposal_id: bundle.proposal_id,
+            proof: hex_dec(&bundle.proof, "proof")?,
+            enc_shares: require_count(
+                bundle
+                    .enc_shares
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, share)| {
+                        WireEncryptedShare::try_from(share)
+                            .map_err(|e| anyhow!("encShares[{index}]: {e}"))
+                    })
+                    .collect::<anyhow::Result<Vec<_>>>()?,
+                "encShares",
+                VOTE_SHARE_COUNT,
+            )?,
+            anchor_height: bundle.anchor_height,
+            vote_round_id: bundle.vote_round_id,
+            shares_hash: hex_dec_exact(&bundle.shares_hash, "sharesHash", PROTOCOL_FIELD_BYTES)?,
+            share_blinds: require_count(
+                bundle
+                    .share_blinds
+                    .iter()
+                    .enumerate()
+                    .map(|(index, value)| {
+                        hex_dec_exact(
+                            value,
+                            &format!("shareBlinds[{index}]"),
+                            PROTOCOL_FIELD_BYTES,
+                        )
+                    })
+                    .collect::<anyhow::Result<Vec<_>>>()?,
+                "shareBlinds",
+                VOTE_SHARE_COUNT,
+            )?,
+            share_comms: require_count(
+                bundle
+                    .share_comms
+                    .iter()
+                    .enumerate()
+                    .map(|(index, value)| {
+                        hex_dec_exact(value, &format!("shareComms[{index}]"), PROTOCOL_FIELD_BYTES)
+                    })
+                    .collect::<anyhow::Result<Vec<_>>>()?,
+                "shareComms",
+                VOTE_SHARE_COUNT,
+            )?,
+            r_vpk_bytes: hex_dec_exact(&bundle.r_vpk_bytes, "rVpk", PROTOCOL_FIELD_BYTES)?,
+            alpha_v: hex_dec_exact(&bundle.alpha_v, "alphaV", PROTOCOL_FIELD_BYTES)?,
+        })
+    }
 }
 
 fn require_note_scope(scope: u32) -> anyhow::Result<u32> {
@@ -856,6 +1099,8 @@ fn make_jni_witness_data<'local>(
     })
 }
 
+// JNI object construction needs a JNIEnv-bound local frame, so these builders
+// stay explicit instead of being modeled as TryFrom conversions.
 pub(super) fn make_jni_van_witness<'local>(
     env: &mut JNIEnv<'local>,
     witness: voting::tree_sync::VanWitness,
@@ -934,55 +1179,61 @@ pub(super) fn make_jni_vote_commitment_result<'local>(
     env: &mut JNIEnv<'local>,
     bundle: VoteCommitmentBundle,
 ) -> anyhow::Result<jobject> {
+    make_jni_vote_commitment_result_payload(env, JniVoteCommitmentResultPayload::from(bundle))
+}
+
+fn make_jni_vote_commitment_result_payload<'local>(
+    env: &mut JNIEnv<'local>,
+    payload: JniVoteCommitmentResultPayload,
+) -> anyhow::Result<jobject> {
     let class = env.find_class(JNI_VOTE_COMMITMENT_RESULT)?;
-    let enc_shares = bundle
-        .enc_shares
-        .into_iter()
-        .map(WireEncryptedShare::from)
-        .collect();
-    let enc_shares = require_count(enc_shares, "enc_shares", VOTE_SHARE_COUNT)?;
+    let enc_shares = require_count(payload.enc_shares, "enc_shares", VOTE_SHARE_COUNT)?;
     let van_nullifier = make_jni_fixed_bytes(
         env,
-        bundle.van_nullifier,
+        payload.van_nullifier,
         "van_nullifier",
         PROTOCOL_FIELD_BYTES,
     )?;
     let vote_authority_note_new = make_jni_fixed_bytes(
         env,
-        bundle.vote_authority_note_new,
+        payload.vote_authority_note_new,
         "vote_authority_note_new",
         PROTOCOL_FIELD_BYTES,
     )?;
     let vote_commitment = make_jni_fixed_bytes(
         env,
-        bundle.vote_commitment,
+        payload.vote_commitment,
         "vote_commitment",
         PROTOCOL_FIELD_BYTES,
     )?;
-    let proof = make_jni_bytes(env, &bundle.proof)?;
+    let proof = make_jni_bytes(env, &payload.proof)?;
     let enc_shares = make_jni_wire_encrypted_share_array(env, enc_shares)?;
     let enc_shares = JObject::from(enc_shares);
-    let vote_round_id: JObject<'local> = env.new_string(bundle.vote_round_id)?.into();
-    let shares_hash =
-        make_jni_fixed_bytes(env, bundle.shares_hash, "shares_hash", PROTOCOL_FIELD_BYTES)?;
+    let vote_round_id: JObject<'local> = env.new_string(payload.vote_round_id)?.into();
+    let shares_hash = make_jni_fixed_bytes(
+        env,
+        payload.shares_hash,
+        "shares_hash",
+        PROTOCOL_FIELD_BYTES,
+    )?;
     let share_blinds = make_jni_fixed_byte_array_vec(
         env,
-        bundle.share_blinds,
+        payload.share_blinds,
         "share_blinds",
         VOTE_SHARE_COUNT,
         PROTOCOL_FIELD_BYTES,
     )?;
     let share_comms = make_jni_fixed_byte_array_vec(
         env,
-        bundle.share_comms,
+        payload.share_comms,
         "share_comms",
         VOTE_SHARE_COUNT,
         PROTOCOL_FIELD_BYTES,
     )?;
     let share_blinds = JObject::from(share_blinds);
     let share_comms = JObject::from(share_comms);
-    let r_vpk = make_jni_fixed_bytes(env, bundle.r_vpk_bytes, "r_vpk", PROTOCOL_FIELD_BYTES)?;
-    let alpha_v = make_jni_fixed_bytes(env, bundle.alpha_v, "alpha_v", PROTOCOL_FIELD_BYTES)?;
+    let r_vpk = make_jni_fixed_bytes(env, payload.r_vpk_bytes, "r_vpk", PROTOCOL_FIELD_BYTES)?;
+    let alpha_v = make_jni_fixed_bytes(env, payload.alpha_v, "alpha_v", PROTOCOL_FIELD_BYTES)?;
 
     Ok(env
         .new_object(
@@ -992,11 +1243,11 @@ pub(super) fn make_jni_vote_commitment_result<'local>(
                 JValue::Object(&van_nullifier),
                 JValue::Object(&vote_authority_note_new),
                 JValue::Object(&vote_commitment),
-                JValue::Int(u32_to_jint(bundle.proposal_id, "proposal_id")?),
+                JValue::Int(u32_to_jint(payload.proposal_id, "proposal_id")?),
                 JValue::Object(&proof),
                 JValue::Object(&enc_shares),
                 JValue::Long(u64_to_jlong(
-                    u64::from(bundle.anchor_height),
+                    u64::from(payload.anchor_height),
                     "anchor_height",
                 )?),
                 JValue::Object(&vote_round_id),
@@ -1008,6 +1259,25 @@ pub(super) fn make_jni_vote_commitment_result<'local>(
             ],
         )?
         .into_raw())
+}
+
+pub(super) fn make_jni_commitment_bundle_record<'local>(
+    env: &mut JNIEnv<'local>,
+    bundle: StoredVoteCommitmentBundle,
+    vc_tree_position: u64,
+) -> anyhow::Result<jobject> {
+    let class = env.find_class(JNI_COMMITMENT_BUNDLE_RECORD)?;
+    let commitment = make_jni_vote_commitment_result_payload(env, bundle.try_into()?)?;
+    let commitment = unsafe { JObject::from_raw(commitment) };
+    let record = env.new_object(
+        &class,
+        JNI_COMMITMENT_BUNDLE_RECORD_CTOR_SIG,
+        &[
+            JValue::Object(&commitment),
+            JValue::Long(u64_to_jlong(vc_tree_position, "vc_tree_position")?),
+        ],
+    )?;
+    Ok(record.into_raw())
 }
 
 pub(super) fn make_jni_share_payload_array<'local>(
@@ -1076,6 +1346,74 @@ fn make_jni_share_payload<'local>(
     )?)
 }
 
+pub(super) fn make_jni_share_delegation_record_array<'local>(
+    env: &mut JNIEnv<'local>,
+    records: Vec<voting::ShareDelegationRecord>,
+) -> anyhow::Result<jobjectArray> {
+    let len = usize_to_jint(records.len(), "share delegation record length")?;
+    let class = env.find_class(JNI_SHARE_DELEGATION_RECORD)?;
+    let mut records = records.into_iter().enumerate();
+    if let Some((_, first)) = records.next() {
+        let first = make_jni_share_delegation_record(env, first)?;
+        let array = env.new_object_array(len, &class, &first)?;
+        for (index, record) in records {
+            let record = make_jni_share_delegation_record(env, record)?;
+            env.set_object_array_element(
+                &array,
+                usize_to_jint(index, "share delegation record index")?,
+                record,
+            )?;
+        }
+        Ok(array.into_raw())
+    } else {
+        Ok(env.new_object_array(0, &class, JObject::null())?.into_raw())
+    }
+}
+
+fn make_jni_share_delegation_record<'local>(
+    env: &mut JNIEnv<'local>,
+    record: voting::ShareDelegationRecord,
+) -> anyhow::Result<JObject<'local>> {
+    let class = env.find_class(JNI_SHARE_DELEGATION_RECORD)?;
+    let round_id: JObject<'local> = env.new_string(record.round_id)?.into();
+    let sent_to_urls = make_jni_string_array(env, record.sent_to_urls)?;
+    let sent_to_urls = JObject::from(sent_to_urls);
+    let nullifier = make_jni_fixed_bytes(
+        env,
+        record.nullifier,
+        "share_delegation.nullifier",
+        SHARE_NULLIFIER_BYTES,
+    )?;
+
+    Ok(env.new_object(
+        &class,
+        JNI_SHARE_DELEGATION_RECORD_CTOR_SIG,
+        &[
+            JValue::Object(&round_id),
+            JValue::Int(u32_to_jint(record.bundle_index, "bundle_index")?),
+            JValue::Int(u32_to_jint(record.proposal_id, "proposal_id")?),
+            JValue::Int(u32_to_jint(record.share_index, "share_index")?),
+            JValue::Object(&sent_to_urls),
+            JValue::Object(&nullifier),
+            JValue::Bool(record.confirmed as jboolean),
+            JValue::Long(u64_to_jlong(record.submit_at, "submit_at")?),
+            JValue::Long(u64_to_jlong(record.created_at, "created_at")?),
+        ],
+    )?)
+}
+
+fn make_jni_string_array<'local>(
+    env: &mut JNIEnv<'local>,
+    values: Vec<String>,
+) -> anyhow::Result<JObjectArray<'local>> {
+    Ok(rust_vec_to_java(
+        env,
+        values,
+        "java/lang/String",
+        |env, value| Ok(JObject::from(env.new_string(value)?)),
+    )?)
+}
+
 /// Builds the Kotlin hotkey JNI model after enforcing the expected key widths.
 /// The secret key is intentionally not surfaced across JNI.
 pub(super) fn make_jni_voting_hotkey<'local>(
@@ -1083,13 +1421,11 @@ pub(super) fn make_jni_voting_hotkey<'local>(
     hotkey: voting::types::VotingHotkey,
 ) -> anyhow::Result<jobject> {
     let class = env.find_class(JNI_VOTING_HOTKEY)?;
-    let secret_key = SecretVec::new(hotkey.secret_key);
-    let secret_key_len = secret_key.expose_secret().len();
-    if secret_key_len != PROTOCOL_FIELD_BYTES {
-        return Err(anyhow!(
-            "hotkey_secret_key must be exactly {PROTOCOL_FIELD_BYTES} bytes, got {secret_key_len}"
-        ));
-    }
+    require_len(
+        hotkey.secret_key,
+        "hotkey_secret_key",
+        HOTKEY_SECRET_KEY_BYTES,
+    )?;
     let public_key = require_len(
         hotkey.public_key,
         "hotkey_public_key",
@@ -1489,20 +1825,6 @@ mod tests {
 
     const TEST_ROUND_ID: &str = "round-id";
     const TEST_WALLET_ID: &str = "wallet-id";
-
-    #[test]
-    fn hotkey_orchard_raw_address_uses_address_index() {
-        let seed = [0x42_u8; 64];
-
-        let index_zero =
-            hotkey_orchard_raw_address_from_wallet_seed(&seed, Network::TestNetwork, 0, 0).unwrap();
-        let index_one =
-            hotkey_orchard_raw_address_from_wallet_seed(&seed, Network::TestNetwork, 0, 1).unwrap();
-
-        assert_eq!(ORCHARD_RAW_ADDRESS_BYTES, index_zero.len());
-        assert_eq!(ORCHARD_RAW_ADDRESS_BYTES, index_one.len());
-        assert_ne!(index_zero, index_one);
-    }
 
     #[test]
     fn nu6_branch_id_comes_from_protocol_crate() {

--- a/backend-lib/src/main/rust/voting/helpers.rs
+++ b/backend-lib/src/main/rust/voting/helpers.rs
@@ -1161,19 +1161,21 @@ fn make_jni_wire_encrypted_share<'local>(
     env: &mut JNIEnv<'local>,
     share: WireEncryptedShare,
 ) -> anyhow::Result<JObject<'local>> {
-    let class = env.find_class(JNI_WIRE_ENCRYPTED_SHARE)?;
-    let c1 = make_jni_fixed_bytes(env, share.c1, "c1", PROTOCOL_FIELD_BYTES)?;
-    let c2 = make_jni_fixed_bytes(env, share.c2, "c2", PROTOCOL_FIELD_BYTES)?;
+    env.with_local_frame_returning_local(8, |env| {
+        let class = env.find_class(JNI_WIRE_ENCRYPTED_SHARE)?;
+        let c1 = make_jni_fixed_bytes(env, share.c1, "c1", PROTOCOL_FIELD_BYTES)?;
+        let c2 = make_jni_fixed_bytes(env, share.c2, "c2", PROTOCOL_FIELD_BYTES)?;
 
-    Ok(env.new_object(
-        &class,
-        JNI_WIRE_ENCRYPTED_SHARE_CTOR_SIG,
-        &[
-            JValue::Object(&c1),
-            JValue::Object(&c2),
-            JValue::Int(u32_to_jint(share.share_index, "share_index")?),
-        ],
-    )?)
+        Ok(env.new_object(
+            &class,
+            JNI_WIRE_ENCRYPTED_SHARE_CTOR_SIG,
+            &[
+                JValue::Object(&c1),
+                JValue::Object(&c2),
+                JValue::Int(u32_to_jint(share.share_index, "share_index")?),
+            ],
+        )?)
+    })
 }
 
 fn make_jni_wire_encrypted_share_array<'local>(
@@ -1186,9 +1188,11 @@ fn make_jni_wire_encrypted_share_array<'local>(
     if let Some((_, first)) = shares.next() {
         let first = make_jni_wire_encrypted_share(env, first)?;
         let array = env.new_object_array(len, &class, &first)?;
+        env.delete_local_ref(first)?;
         for (index, share) in shares {
             let share = make_jni_wire_encrypted_share(env, share)?;
-            env.set_object_array_element(&array, usize_to_jint(index, "shares index")?, share)?;
+            env.set_object_array_element(&array, usize_to_jint(index, "shares index")?, &share)?;
+            env.delete_local_ref(share)?;
         }
         Ok(array)
     } else {
@@ -1320,9 +1324,15 @@ pub(super) fn make_jni_share_payload_array<'local>(
     if let Some((_, first)) = payloads.next() {
         let first = make_jni_share_payload(env, first)?;
         let array = env.new_object_array(len, &class, &first)?;
+        env.delete_local_ref(first)?;
         for (index, payload) in payloads {
             let payload = make_jni_share_payload(env, payload)?;
-            env.set_object_array_element(&array, usize_to_jint(index, "payloads index")?, payload)?;
+            env.set_object_array_element(
+                &array,
+                usize_to_jint(index, "payloads index")?,
+                &payload,
+            )?;
+            env.delete_local_ref(payload)?;
         }
         Ok(array.into_raw())
     } else {
@@ -1334,46 +1344,49 @@ fn make_jni_share_payload<'local>(
     env: &mut JNIEnv<'local>,
     payload: SharePayload,
 ) -> anyhow::Result<JObject<'local>> {
-    let class = env.find_class(JNI_SHARE_PAYLOAD)?;
-    let shares_hash = make_jni_fixed_bytes(
-        env,
-        payload.shares_hash,
-        "shares_hash",
-        PROTOCOL_FIELD_BYTES,
-    )?;
-    let enc_share = make_jni_wire_encrypted_share(env, payload.enc_share)?;
-    let all_enc_shares = require_count(payload.all_enc_shares, "all_enc_shares", VOTE_SHARE_COUNT)?;
-    let all_enc_shares = make_jni_wire_encrypted_share_array(env, all_enc_shares)?;
-    let share_comms = make_jni_fixed_byte_array_vec(
-        env,
-        payload.share_comms,
-        "share_comms",
-        VOTE_SHARE_COUNT,
-        PROTOCOL_FIELD_BYTES,
-    )?;
-    let primary_blind = make_jni_fixed_bytes(
-        env,
-        payload.primary_blind,
-        "primary_blind",
-        PROTOCOL_FIELD_BYTES,
-    )?;
-    let all_enc_shares = JObject::from(all_enc_shares);
-    let share_comms = JObject::from(share_comms);
+    env.with_local_frame_returning_local(48, |env| {
+        let class = env.find_class(JNI_SHARE_PAYLOAD)?;
+        let shares_hash = make_jni_fixed_bytes(
+            env,
+            payload.shares_hash,
+            "shares_hash",
+            PROTOCOL_FIELD_BYTES,
+        )?;
+        let enc_share = make_jni_wire_encrypted_share(env, payload.enc_share)?;
+        let all_enc_shares =
+            require_count(payload.all_enc_shares, "all_enc_shares", VOTE_SHARE_COUNT)?;
+        let all_enc_shares = make_jni_wire_encrypted_share_array(env, all_enc_shares)?;
+        let share_comms = make_jni_fixed_byte_array_vec(
+            env,
+            payload.share_comms,
+            "share_comms",
+            VOTE_SHARE_COUNT,
+            PROTOCOL_FIELD_BYTES,
+        )?;
+        let primary_blind = make_jni_fixed_bytes(
+            env,
+            payload.primary_blind,
+            "primary_blind",
+            PROTOCOL_FIELD_BYTES,
+        )?;
+        let all_enc_shares = JObject::from(all_enc_shares);
+        let share_comms = JObject::from(share_comms);
 
-    Ok(env.new_object(
-        &class,
-        JNI_SHARE_PAYLOAD_CTOR_SIG,
-        &[
-            JValue::Object(&shares_hash),
-            JValue::Int(u32_to_jint(payload.proposal_id, "proposal_id")?),
-            JValue::Int(u32_to_jint(payload.vote_decision, "vote_decision")?),
-            JValue::Object(&enc_share),
-            JValue::Long(u64_to_jlong(payload.tree_position, "tree_position")?),
-            JValue::Object(&all_enc_shares),
-            JValue::Object(&share_comms),
-            JValue::Object(&primary_blind),
-        ],
-    )?)
+        Ok(env.new_object(
+            &class,
+            JNI_SHARE_PAYLOAD_CTOR_SIG,
+            &[
+                JValue::Object(&shares_hash),
+                JValue::Int(u32_to_jint(payload.proposal_id, "proposal_id")?),
+                JValue::Int(u32_to_jint(payload.vote_decision, "vote_decision")?),
+                JValue::Object(&enc_share),
+                JValue::Long(u64_to_jlong(payload.tree_position, "tree_position")?),
+                JValue::Object(&all_enc_shares),
+                JValue::Object(&share_comms),
+                JValue::Object(&primary_blind),
+            ],
+        )?)
+    })
 }
 
 pub(super) fn make_jni_share_delegation_record_array<'local>(
@@ -1386,13 +1399,15 @@ pub(super) fn make_jni_share_delegation_record_array<'local>(
     if let Some((_, first)) = records.next() {
         let first = make_jni_share_delegation_record(env, first)?;
         let array = env.new_object_array(len, &class, &first)?;
+        env.delete_local_ref(first)?;
         for (index, record) in records {
             let record = make_jni_share_delegation_record(env, record)?;
             env.set_object_array_element(
                 &array,
                 usize_to_jint(index, "share delegation record index")?,
-                record,
+                &record,
             )?;
+            env.delete_local_ref(record)?;
         }
         Ok(array.into_raw())
     } else {
@@ -1404,32 +1419,34 @@ fn make_jni_share_delegation_record<'local>(
     env: &mut JNIEnv<'local>,
     record: voting::ShareDelegationRecord,
 ) -> anyhow::Result<JObject<'local>> {
-    let class = env.find_class(JNI_SHARE_DELEGATION_RECORD)?;
-    let round_id: JObject<'local> = env.new_string(record.round_id)?.into();
-    let sent_to_urls = make_jni_string_array(env, record.sent_to_urls)?;
-    let sent_to_urls = JObject::from(sent_to_urls);
-    let nullifier = make_jni_fixed_bytes(
-        env,
-        record.nullifier,
-        "share_delegation.nullifier",
-        SHARE_NULLIFIER_BYTES,
-    )?;
+    env.with_local_frame_returning_local(24, |env| {
+        let class = env.find_class(JNI_SHARE_DELEGATION_RECORD)?;
+        let round_id: JObject<'_> = env.new_string(record.round_id)?.into();
+        let sent_to_urls = make_jni_string_array(env, record.sent_to_urls)?;
+        let sent_to_urls = JObject::from(sent_to_urls);
+        let nullifier = make_jni_fixed_bytes(
+            env,
+            record.nullifier,
+            "share_delegation.nullifier",
+            SHARE_NULLIFIER_BYTES,
+        )?;
 
-    Ok(env.new_object(
-        &class,
-        JNI_SHARE_DELEGATION_RECORD_CTOR_SIG,
-        &[
-            JValue::Object(&round_id),
-            JValue::Int(u32_to_jint(record.bundle_index, "bundle_index")?),
-            JValue::Int(u32_to_jint(record.proposal_id, "proposal_id")?),
-            JValue::Int(u32_to_jint(record.share_index, "share_index")?),
-            JValue::Object(&sent_to_urls),
-            JValue::Object(&nullifier),
-            JValue::Bool(record.confirmed as jboolean),
-            JValue::Long(u64_to_jlong(record.submit_at, "submit_at")?),
-            JValue::Long(u64_to_jlong(record.created_at, "created_at")?),
-        ],
-    )?)
+        Ok(env.new_object(
+            &class,
+            JNI_SHARE_DELEGATION_RECORD_CTOR_SIG,
+            &[
+                JValue::Object(&round_id),
+                JValue::Int(u32_to_jint(record.bundle_index, "bundle_index")?),
+                JValue::Int(u32_to_jint(record.proposal_id, "proposal_id")?),
+                JValue::Int(u32_to_jint(record.share_index, "share_index")?),
+                JValue::Object(&sent_to_urls),
+                JValue::Object(&nullifier),
+                JValue::Bool(record.confirmed as jboolean),
+                JValue::Long(u64_to_jlong(record.submit_at, "submit_at")?),
+                JValue::Long(u64_to_jlong(record.created_at, "created_at")?),
+            ],
+        )?)
+    })
 }
 
 fn make_jni_string_array<'local>(

--- a/backend-lib/src/main/rust/voting/helpers.rs
+++ b/backend-lib/src/main/rust/voting/helpers.rs
@@ -47,11 +47,11 @@ const JNI_VAN_WITNESS_CTOR_SIG: &str = "([[BJJ)V";
 // Must match JniWireEncryptedShare(ByteArray, ByteArray, Int) in
 // JniVotingModels.kt.
 const JNI_WIRE_ENCRYPTED_SHARE_CTOR_SIG: &str = "([B[BI)V";
-// Must match JniVoteCommitmentResult(ByteArray, ByteArray, ByteArray, Int,
+// Must match JniVoteCommitmentResult(ByteArray, ByteArray, ByteArray, Int, Int,
 // ByteArray, Array<JniWireEncryptedShare>, Long, String, ByteArray,
 // Array<ByteArray>, Array<ByteArray>, ByteArray, ByteArray) in
 // JniVotingModels.kt. Guarded by JniVotingModelsTest.
-const JNI_VOTE_COMMITMENT_RESULT_CTOR_SIG: &str = "([B[B[BI[B[Lcash/z/ecc/android/sdk/internal/model/voting/JniWireEncryptedShare;JLjava/lang/String;[B[[B[[B[B[B)V";
+const JNI_VOTE_COMMITMENT_RESULT_CTOR_SIG: &str = "([B[B[BII[B[Lcash/z/ecc/android/sdk/internal/model/voting/JniWireEncryptedShare;JLjava/lang/String;[B[[B[[B[B[B)V";
 // Must match JniCommitmentBundleRecord(JniVoteCommitmentResult, Long) in
 // JniVotingModels.kt. Guarded by JniVotingModelsTest.
 const JNI_COMMITMENT_BUNDLE_RECORD_CTOR_SIG: &str =
@@ -126,6 +126,7 @@ struct JniVoteCommitmentResultPayload {
     vote_authority_note_new: Vec<u8>,
     vote_commitment: Vec<u8>,
     proposal_id: u32,
+    bundle_index: u32,
     proof: Vec<u8>,
     enc_shares: Vec<WireEncryptedShare>,
     anchor_height: u32,
@@ -621,6 +622,7 @@ fn java_wire_encrypted_share_list_field(
 }
 
 pub(super) struct JavaVoteCommitmentBundle {
+    pub(super) bundle_index: u32,
     pub(super) enc_shares: Vec<WireEncryptedShare>,
     pub(super) bundle: VoteCommitmentBundle,
 }
@@ -646,6 +648,10 @@ pub(super) fn java_vote_commitment_bundle(
     )?;
 
     Ok(JavaVoteCommitmentBundle {
+        bundle_index: jint_to_u32(
+            env.get_field(commitment, "bundleIndex", "I")?.i()?,
+            "bundleIndex",
+        )?,
         enc_shares,
         bundle: VoteCommitmentBundle {
             van_nullifier: require_len(
@@ -766,13 +772,14 @@ impl TryFrom<StoredWireEncryptedShare> for WireEncryptedShare {
     }
 }
 
-impl From<VoteCommitmentBundle> for JniVoteCommitmentResultPayload {
-    fn from(bundle: VoteCommitmentBundle) -> Self {
-        JniVoteCommitmentResultPayload {
+impl JniVoteCommitmentResultPayload {
+    fn from_bundle(bundle: VoteCommitmentBundle, bundle_index: u32) -> Self {
+        Self {
             van_nullifier: bundle.van_nullifier,
             vote_authority_note_new: bundle.vote_authority_note_new,
             vote_commitment: bundle.vote_commitment,
             proposal_id: bundle.proposal_id,
+            bundle_index,
             proof: bundle.proof,
             enc_shares: bundle
                 .enc_shares
@@ -788,12 +795,8 @@ impl From<VoteCommitmentBundle> for JniVoteCommitmentResultPayload {
             alpha_v: bundle.alpha_v,
         }
     }
-}
 
-impl TryFrom<StoredVoteCommitmentBundle> for JniVoteCommitmentResultPayload {
-    type Error = anyhow::Error;
-
-    fn try_from(bundle: StoredVoteCommitmentBundle) -> anyhow::Result<Self> {
+    fn from_stored(bundle: StoredVoteCommitmentBundle, bundle_index: u32) -> anyhow::Result<Self> {
         Ok(JniVoteCommitmentResultPayload {
             van_nullifier: hex_dec_exact(
                 &bundle.van_nullifier,
@@ -811,6 +814,7 @@ impl TryFrom<StoredVoteCommitmentBundle> for JniVoteCommitmentResultPayload {
                 PROTOCOL_FIELD_BYTES,
             )?,
             proposal_id: bundle.proposal_id,
+            bundle_index,
             proof: hex_dec(&bundle.proof, "proof")?,
             enc_shares: require_count(
                 bundle
@@ -1195,8 +1199,12 @@ fn make_jni_wire_encrypted_share_array<'local>(
 pub(super) fn make_jni_vote_commitment_result<'local>(
     env: &mut JNIEnv<'local>,
     bundle: VoteCommitmentBundle,
+    bundle_index: u32,
 ) -> anyhow::Result<jobject> {
-    make_jni_vote_commitment_result_payload(env, JniVoteCommitmentResultPayload::from(bundle))
+    make_jni_vote_commitment_result_payload(
+        env,
+        JniVoteCommitmentResultPayload::from_bundle(bundle, bundle_index),
+    )
 }
 
 fn make_jni_vote_commitment_result_payload<'local>(
@@ -1261,6 +1269,7 @@ fn make_jni_vote_commitment_result_payload<'local>(
                 JValue::Object(&vote_authority_note_new),
                 JValue::Object(&vote_commitment),
                 JValue::Int(u32_to_jint(payload.proposal_id, "proposal_id")?),
+                JValue::Int(u32_to_jint(payload.bundle_index, "bundle_index")?),
                 JValue::Object(&proof),
                 JValue::Object(&enc_shares),
                 JValue::Long(u64_to_jlong(
@@ -1281,10 +1290,14 @@ fn make_jni_vote_commitment_result_payload<'local>(
 pub(super) fn make_jni_commitment_bundle_record<'local>(
     env: &mut JNIEnv<'local>,
     bundle: StoredVoteCommitmentBundle,
+    bundle_index: u32,
     vc_tree_position: u64,
 ) -> anyhow::Result<jobject> {
     let class = env.find_class(JNI_COMMITMENT_BUNDLE_RECORD)?;
-    let commitment = make_jni_vote_commitment_result_payload(env, bundle.try_into()?)?;
+    let commitment = make_jni_vote_commitment_result_payload(
+        env,
+        JniVoteCommitmentResultPayload::from_stored(bundle, bundle_index)?,
+    )?;
     let commitment = unsafe { JObject::from_raw(commitment) };
     let record = env.new_object(
         &class,

--- a/backend-lib/src/main/rust/voting/notes.rs
+++ b/backend-lib/src/main/rust/voting/notes.rs
@@ -183,9 +183,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_get
             // after the snapshot remain eligible for that snapshot.
             let notes = wallet_db
                 .get_unspent_orchard_notes_at_historical_height(account_uuid, height)
-                .map_err(|e| {
-                    anyhow!("get_unspent_orchard_notes_at_historical_height: {}", e)
-                })?;
+                .map_err(|e| anyhow!("get_unspent_orchard_notes_at_historical_height: {}", e))?;
 
             notes
                 .iter()

--- a/backend-lib/src/main/rust/voting/recovery.rs
+++ b/backend-lib/src/main/rust/voting/recovery.rs
@@ -1,0 +1,598 @@
+use super::db::*;
+use super::helpers::*;
+use super::*;
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_storeDelegationTxHashNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_handle: jlong,
+    round_id: JString<'local>,
+    bundle_index: jint,
+    tx_hash: JString<'local>,
+) -> jboolean {
+    let res = catch_unwind(&mut env, |env| {
+        let db = db_from_handle(db_handle)?;
+        let _access_lock = db.access_lock()?;
+        let round_id = java_string_to_rust(env, &round_id)?;
+        let bundle_index = jint_to_u32(bundle_index, "bundle_index")?;
+        let tx_hash = java_string_to_rust(env, &tx_hash)?;
+        db.store_delegation_tx_hash(&round_id, bundle_index, &tx_hash)
+            .map_err(|e| anyhow!("store_delegation_tx_hash: {e}"))?;
+        let stored = optional_recovery_lookup(
+            db.get_delegation_tx_hash(&round_id, bundle_index),
+            "get_delegation_tx_hash",
+        )?;
+        require_stored_value(stored.as_deref(), &tx_hash, "delegation tx hash")?;
+        Ok(JNI_TRUE)
+    });
+    unwrap_exc_or(&mut env, res, JNI_FALSE)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_getDelegationTxHashNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_handle: jlong,
+    round_id: JString<'local>,
+    bundle_index: jint,
+) -> jstring {
+    let res = catch_unwind(&mut env, |env| {
+        let db = db_from_handle(db_handle)?;
+        let _access_lock = db.access_lock()?;
+        let tx_hash = optional_recovery_lookup(
+            db.get_delegation_tx_hash(
+                &java_string_to_rust(env, &round_id)?,
+                jint_to_u32(bundle_index, "bundle_index")?,
+            ),
+            "get_delegation_tx_hash",
+        )?;
+        match tx_hash {
+            Some(value) => Ok(env.new_string(value)?.into_raw()),
+            None => Ok(std::ptr::null_mut()),
+        }
+    });
+    unwrap_exc_or(&mut env, res, std::ptr::null_mut())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_storeVoteTxHashNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_handle: jlong,
+    round_id: JString<'local>,
+    bundle_index: jint,
+    proposal_id: jint,
+    tx_hash: JString<'local>,
+) -> jboolean {
+    let res = catch_unwind(&mut env, |env| {
+        let db = db_from_handle(db_handle)?;
+        let _access_lock = db.access_lock()?;
+        let round_id = java_string_to_rust(env, &round_id)?;
+        let bundle_index = jint_to_u32(bundle_index, "bundle_index")?;
+        let proposal_id = jint_to_u32(proposal_id, "proposal_id")?;
+        let tx_hash = java_string_to_rust(env, &tx_hash)?;
+        db.store_vote_tx_hash(&round_id, bundle_index, proposal_id, &tx_hash)
+            .map_err(|e| anyhow!("store_vote_tx_hash: {e}"))?;
+        let stored = optional_recovery_lookup(
+            db.get_vote_tx_hash(&round_id, bundle_index, proposal_id),
+            "get_vote_tx_hash",
+        )?;
+        require_stored_value(stored.as_deref(), &tx_hash, "vote tx hash")?;
+        Ok(JNI_TRUE)
+    });
+    unwrap_exc_or(&mut env, res, JNI_FALSE)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_markVoteSubmittedNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_handle: jlong,
+    round_id: JString<'local>,
+    bundle_index: jint,
+    proposal_id: jint,
+) -> jboolean {
+    let res = catch_unwind(&mut env, |env| {
+        let db = db_from_handle(db_handle)?;
+        let _access_lock = db.access_lock()?;
+        db.mark_vote_submitted(
+            &java_string_to_rust(env, &round_id)?,
+            jint_to_u32(bundle_index, "bundle_index")?,
+            jint_to_u32(proposal_id, "proposal_id")?,
+        )
+        .map_err(|e| anyhow!("mark_vote_submitted: {e}"))?;
+        Ok(JNI_TRUE)
+    });
+    unwrap_exc_or(&mut env, res, JNI_FALSE)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_getVoteTxHashNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_handle: jlong,
+    round_id: JString<'local>,
+    bundle_index: jint,
+    proposal_id: jint,
+) -> jstring {
+    let res = catch_unwind(&mut env, |env| {
+        let db = db_from_handle(db_handle)?;
+        let _access_lock = db.access_lock()?;
+        let tx_hash = optional_recovery_lookup(
+            db.get_vote_tx_hash(
+                &java_string_to_rust(env, &round_id)?,
+                jint_to_u32(bundle_index, "bundle_index")?,
+                jint_to_u32(proposal_id, "proposal_id")?,
+            ),
+            "get_vote_tx_hash",
+        )?;
+        match tx_hash {
+            Some(value) => Ok(env.new_string(value)?.into_raw()),
+            None => Ok(std::ptr::null_mut()),
+        }
+    });
+    unwrap_exc_or(&mut env, res, std::ptr::null_mut())
+}
+
+fn optional_recovery_lookup<T, E>(
+    result: Result<Option<T>, E>,
+    label: &str,
+) -> anyhow::Result<Option<T>>
+where
+    E: std::fmt::Display,
+{
+    match result {
+        Ok(value) => Ok(value),
+        Err(error) if is_query_returned_no_rows(&error) => Ok(None),
+        Err(error) => Err(anyhow!("{label}: {error}")),
+    }
+}
+
+fn is_query_returned_no_rows(error: &impl std::fmt::Display) -> bool {
+    error
+        .to_string()
+        .to_ascii_lowercase()
+        .contains("query returned no rows")
+}
+
+fn require_stored_value(stored: Option<&str>, expected: &str, label: &str) -> anyhow::Result<()> {
+    match stored {
+        Some(value) if value == expected => Ok(()),
+        Some(_) => Err(anyhow!(
+            "{label} store verification returned a different value"
+        )),
+        None => Err(anyhow!("{label} store did not update any recovery row")),
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_storeCommitmentBundleNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_handle: jlong,
+    round_id: JString<'local>,
+    bundle_index: jint,
+    proposal_id: jint,
+    commitment: JObject<'local>,
+    vc_tree_position: jlong,
+) -> jboolean {
+    let res = catch_unwind(&mut env, |env| {
+        let db = db_from_handle(db_handle)?;
+        let _access_lock = db.access_lock()?;
+        let round_id = java_string_to_rust(env, &round_id)?;
+        let bundle_index = jint_to_u32(bundle_index, "bundle_index")?;
+        let proposal_id = jint_to_u32(proposal_id, "proposal_id")?;
+        let vc_tree_position = jlong_to_u64(vc_tree_position, "vc_tree_position")?;
+        let commitment = java_vote_commitment_bundle(env, &commitment)?;
+        require_commitment_matches_key(&commitment, &round_id, proposal_id)?;
+        let commitment = StoredVoteCommitmentBundle::try_from(commitment)?.to_storage_json()?;
+        db.store_commitment_bundle(
+            &round_id,
+            bundle_index,
+            proposal_id,
+            &commitment,
+            vc_tree_position,
+        )
+        .map_err(|e| anyhow!("store_commitment_bundle: {e}"))?;
+        let stored = optional_recovery_lookup(
+            db.get_commitment_bundle(&round_id, bundle_index, proposal_id),
+            "get_commitment_bundle",
+        )?;
+        require_stored_commitment(stored, &commitment, vc_tree_position)?;
+        Ok(JNI_TRUE)
+    });
+    unwrap_exc_or(&mut env, res, JNI_FALSE)
+}
+
+/// Requires the commitment payload identity to match the recovery storage key.
+/// Rejects mismatched round or proposal data before it can be persisted.
+fn require_commitment_matches_key(
+    commitment: &JavaVoteCommitmentBundle,
+    round_id: &str,
+    proposal_id: u32,
+) -> anyhow::Result<()> {
+    if commitment.bundle.vote_round_id != round_id {
+        return Err(anyhow!(
+            "commitment voteRoundId {} does not match roundId {round_id}",
+            commitment.bundle.vote_round_id
+        ));
+    }
+    if commitment.bundle.proposal_id != proposal_id {
+        return Err(anyhow!(
+            "commitment proposalId {} does not match proposalId {proposal_id}",
+            commitment.bundle.proposal_id
+        ));
+    }
+    Ok(())
+}
+
+/// Requires a just-stored commitment lookup to return the exact JSON payload
+/// and VC tree position. Fails closed when the row is missing or was overwritten.
+fn require_stored_commitment(
+    stored: Option<(String, u64)>,
+    expected_json: &str,
+    expected_position: u64,
+) -> anyhow::Result<()> {
+    match stored {
+        Some((json, position)) if json == expected_json && position == expected_position => Ok(()),
+        Some(_) => Err(anyhow!(
+            "commitment bundle store verification returned a different value"
+        )),
+        None => Err(anyhow!(
+            "commitment bundle store did not update any recovery row"
+        )),
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_getCommitmentBundleNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_handle: jlong,
+    round_id: JString<'local>,
+    bundle_index: jint,
+    proposal_id: jint,
+) -> jobject {
+    let res = catch_unwind(&mut env, |env| {
+        let db = db_from_handle(db_handle)?;
+        let _access_lock = db.access_lock()?;
+        let record = optional_recovery_lookup(
+            db.get_commitment_bundle(
+                &java_string_to_rust(env, &round_id)?,
+                jint_to_u32(bundle_index, "bundle_index")?,
+                jint_to_u32(proposal_id, "proposal_id")?,
+            ),
+            "get_commitment_bundle",
+        )?;
+        match record {
+            Some((commitment, vc_tree_position)) => {
+                let commitment = StoredVoteCommitmentBundle::from_storage_json(&commitment)?;
+                make_jni_commitment_bundle_record(env, commitment, vc_tree_position)
+            }
+            None => Ok(JObject::null().into_raw()),
+        }
+    });
+    unwrap_exc_or(&mut env, res, JObject::null().into_raw())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_clearRecoveryStateNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_handle: jlong,
+    round_id: JString<'local>,
+) -> jboolean {
+    let res = catch_unwind(&mut env, |env| {
+        let db = db_from_handle(db_handle)?;
+        let _access_lock = db.access_lock()?;
+        db.clear_recovery_state(&java_string_to_rust(env, &round_id)?)
+            .map_err(|e| anyhow!("clear_recovery_state: {e}"))?;
+        Ok(JNI_TRUE)
+    });
+    unwrap_exc_or(&mut env, res, JNI_FALSE)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_recordShareDelegationNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_handle: jlong,
+    round_id: JString<'local>,
+    bundle_index: jint,
+    proposal_id: jint,
+    share_index: jint,
+    sent_to_urls: JObjectArray<'local>,
+    nullifier: JByteArray<'local>,
+    submit_at: jlong,
+) -> jboolean {
+    let res = catch_unwind(&mut env, |env| {
+        let db = db_from_handle(db_handle)?;
+        let _access_lock = db.access_lock()?;
+        let sent_to_urls = java_string_array(env, &sent_to_urls, "sentToUrls")?;
+        db.record_share_delegation(
+            &java_string_to_rust(env, &round_id)?,
+            jint_to_u32(bundle_index, "bundle_index")?,
+            jint_to_u32(proposal_id, "proposal_id")?,
+            require_share_index(jint_to_u32(share_index, "share_index")?, "share_index")?,
+            &sent_to_urls,
+            &java_bytes_exact(env, &nullifier, "nullifier", SHARE_NULLIFIER_BYTES)?,
+            jlong_to_u64(submit_at, "submit_at")?,
+        )
+        .map_err(|e| anyhow!("record_share_delegation: {e}"))?;
+        Ok(JNI_TRUE)
+    });
+    unwrap_exc_or(&mut env, res, JNI_FALSE)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_getShareDelegationsNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_handle: jlong,
+    round_id: JString<'local>,
+) -> jobjectArray {
+    let res = catch_unwind(&mut env, |env| {
+        let db = db_from_handle(db_handle)?;
+        let _access_lock = db.access_lock()?;
+        let records = db
+            .get_share_delegations(&java_string_to_rust(env, &round_id)?)
+            .map_err(|e| anyhow!("get_share_delegations: {e}"))?;
+        make_jni_share_delegation_record_array(env, records)
+    });
+    unwrap_exc_or(&mut env, res, std::ptr::null_mut())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_getUnconfirmedDelegationsNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_handle: jlong,
+    round_id: JString<'local>,
+) -> jobjectArray {
+    let res = catch_unwind(&mut env, |env| {
+        let db = db_from_handle(db_handle)?;
+        let _access_lock = db.access_lock()?;
+        let records = db
+            .get_unconfirmed_delegations(&java_string_to_rust(env, &round_id)?)
+            .map_err(|e| anyhow!("get_unconfirmed_delegations: {e}"))?;
+        make_jni_share_delegation_record_array(env, records)
+    });
+    unwrap_exc_or(&mut env, res, std::ptr::null_mut())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_markShareConfirmedNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_handle: jlong,
+    round_id: JString<'local>,
+    bundle_index: jint,
+    proposal_id: jint,
+    share_index: jint,
+) -> jboolean {
+    let res = catch_unwind(&mut env, |env| {
+        let db = db_from_handle(db_handle)?;
+        let _access_lock = db.access_lock()?;
+        db.mark_share_confirmed(
+            &java_string_to_rust(env, &round_id)?,
+            jint_to_u32(bundle_index, "bundle_index")?,
+            jint_to_u32(proposal_id, "proposal_id")?,
+            require_share_index(jint_to_u32(share_index, "share_index")?, "share_index")?,
+        )
+        .map_err(|e| anyhow!("mark_share_confirmed: {e}"))?;
+        Ok(JNI_TRUE)
+    });
+    unwrap_exc_or(&mut env, res, JNI_FALSE)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_addSentServersNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_handle: jlong,
+    round_id: JString<'local>,
+    bundle_index: jint,
+    proposal_id: jint,
+    share_index: jint,
+    new_urls: JObjectArray<'local>,
+) -> jboolean {
+    let res = catch_unwind(&mut env, |env| {
+        let db = db_from_handle(db_handle)?;
+        let _access_lock = db.access_lock()?;
+        let new_urls = java_string_array(env, &new_urls, "newUrls")?;
+        db.add_sent_servers(
+            &java_string_to_rust(env, &round_id)?,
+            jint_to_u32(bundle_index, "bundle_index")?,
+            jint_to_u32(proposal_id, "proposal_id")?,
+            require_share_index(jint_to_u32(share_index, "share_index")?, "share_index")?,
+            &new_urls,
+        )
+        .map_err(|e| anyhow!("add_sent_servers: {e}"))?;
+        Ok(JNI_TRUE)
+    });
+    unwrap_exc_or(&mut env, res, JNI_FALSE)
+}
+
+#[cfg(feature = "android-test-fixtures")]
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_storeVoteFixtureNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_handle: jlong,
+    round_id: JString<'local>,
+    bundle_index: jint,
+    proposal_id: jint,
+    choice: jint,
+) {
+    let res = catch_unwind(&mut env, |env| {
+        let db = db_from_handle(db_handle)?;
+        let _access_lock = db.access_lock()?;
+        let round_id = java_string_to_rust(env, &round_id)?;
+        let bundle_index = jint_to_u32(bundle_index, "bundle_index")?;
+        let proposal_id = jint_to_u32(proposal_id, "proposal_id")?;
+        let choice = jint_to_u32(choice, "choice")?;
+        let conn = db.conn();
+        let wallet_id = db.wallet_id();
+        voting::storage::queries::store_vote(
+            &conn,
+            &round_id,
+            &wallet_id,
+            bundle_index,
+            proposal_id,
+            choice,
+            &[0xAA; PROTOCOL_FIELD_BYTES],
+        )
+        .map_err(|e| anyhow!("store_vote fixture: {e}"))?;
+        Ok(())
+    });
+    unwrap_exc_or(&mut env, res, ())
+}
+
+fn java_string_array(
+    env: &mut JNIEnv<'_>,
+    array: &JObjectArray<'_>,
+    field: &str,
+) -> anyhow::Result<Vec<String>> {
+    let count = env.get_array_length(array)?;
+    (0..count)
+        .map(|index| {
+            let value = env.get_object_array_element(array, index)?;
+            let value = JString::from(value);
+            java_string_to_rust(env, &value).map_err(|e| anyhow!("{field}[{index}]: {e}"))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn optional_recovery_lookup_maps_missing_rows_to_none() {
+        let result: anyhow::Result<Option<String>> =
+            optional_recovery_lookup(Err("Query returned no rows"), "get_vote_tx_hash");
+
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn optional_recovery_lookup_keeps_unexpected_errors_fatal() {
+        let result: anyhow::Result<Option<String>> =
+            optional_recovery_lookup(Err("database is locked"), "get_vote_tx_hash");
+
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("get_vote_tx_hash"));
+        assert!(error.contains("database is locked"));
+    }
+
+    #[test]
+    fn stored_value_verification_rejects_missing_or_changed_rows() {
+        require_stored_value(Some("tx-1"), "tx-1", "vote tx hash").unwrap();
+
+        assert!(
+            require_stored_value(None, "tx-1", "vote tx hash")
+                .unwrap_err()
+                .to_string()
+                .contains("did not update")
+        );
+        assert!(
+            require_stored_value(Some("tx-2"), "tx-1", "vote tx hash")
+                .unwrap_err()
+                .to_string()
+                .contains("different value")
+        );
+    }
+
+    #[test]
+    fn commitment_store_key_must_match_payload() {
+        let commitment = commitment_bundle("round-1", 7);
+
+        require_commitment_matches_key(&commitment, "round-1", 7).unwrap();
+        assert!(
+            require_commitment_matches_key(&commitment, "round-2", 7)
+                .unwrap_err()
+                .to_string()
+                .contains("voteRoundId")
+        );
+        assert!(
+            require_commitment_matches_key(&commitment, "round-1", 8)
+                .unwrap_err()
+                .to_string()
+                .contains("proposalId")
+        );
+    }
+
+    #[test]
+    fn stored_commitment_verification_rejects_missing_or_changed_rows() {
+        require_stored_commitment(Some(("json".to_string(), 12)), "json", 12).unwrap();
+
+        assert!(
+            require_stored_commitment(None, "json", 12)
+                .unwrap_err()
+                .to_string()
+                .contains("did not update")
+        );
+        assert!(
+            require_stored_commitment(Some(("other".to_string(), 12)), "json", 12)
+                .unwrap_err()
+                .to_string()
+                .contains("different value")
+        );
+        assert!(
+            require_stored_commitment(Some(("json".to_string(), 13)), "json", 12)
+                .unwrap_err()
+                .to_string()
+                .contains("different value")
+        );
+    }
+
+    fn commitment_bundle(round_id: &str, proposal_id: u32) -> JavaVoteCommitmentBundle {
+        JavaVoteCommitmentBundle {
+            enc_shares: vec![],
+            bundle: VoteCommitmentBundle {
+                van_nullifier: vec![1; PROTOCOL_FIELD_BYTES],
+                vote_authority_note_new: vec![2; PROTOCOL_FIELD_BYTES],
+                vote_commitment: vec![3; PROTOCOL_FIELD_BYTES],
+                proposal_id,
+                proof: vec![4; PROTOCOL_FIELD_BYTES],
+                enc_shares: vec![],
+                anchor_height: 5,
+                vote_round_id: round_id.to_string(),
+                shares_hash: vec![6; PROTOCOL_FIELD_BYTES],
+                share_blinds: vec![vec![7; PROTOCOL_FIELD_BYTES]; VOTE_SHARE_COUNT],
+                share_comms: vec![vec![8; PROTOCOL_FIELD_BYTES]; VOTE_SHARE_COUNT],
+                r_vpk_bytes: vec![9; PROTOCOL_FIELD_BYTES],
+                alpha_v: vec![10; PROTOCOL_FIELD_BYTES],
+            },
+        }
+    }
+}

--- a/backend-lib/src/main/rust/voting/recovery.rs
+++ b/backend-lib/src/main/rust/voting/recovery.rs
@@ -197,7 +197,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_sto
         let proposal_id = jint_to_u32(proposal_id, "proposal_id")?;
         let vc_tree_position = jlong_to_u64(vc_tree_position, "vc_tree_position")?;
         let commitment = java_vote_commitment_bundle(env, &commitment)?;
-        require_commitment_matches_key(&commitment, &round_id, proposal_id)?;
+        require_commitment_matches_key(&commitment, &round_id, bundle_index, proposal_id)?;
         let commitment = StoredVoteCommitmentBundle::try_from(commitment)?.to_storage_json()?;
         db.store_commitment_bundle(
             &round_id,
@@ -222,6 +222,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_sto
 fn require_commitment_matches_key(
     commitment: &JavaVoteCommitmentBundle,
     round_id: &str,
+    bundle_index: u32,
     proposal_id: u32,
 ) -> anyhow::Result<()> {
     if commitment.bundle.vote_round_id != round_id {
@@ -234,6 +235,12 @@ fn require_commitment_matches_key(
         return Err(anyhow!(
             "commitment proposalId {} does not match proposalId {proposal_id}",
             commitment.bundle.proposal_id
+        ));
+    }
+    if commitment.bundle_index != bundle_index {
+        return Err(anyhow!(
+            "commitment bundleIndex {} does not match bundleIndex {bundle_index}",
+            commitment.bundle_index
         ));
     }
     Ok(())
@@ -282,7 +289,12 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_get
         match record {
             Some((commitment, vc_tree_position)) => {
                 let commitment = StoredVoteCommitmentBundle::from_storage_json(&commitment)?;
-                make_jni_commitment_bundle_record(env, commitment, vc_tree_position)
+                make_jni_commitment_bundle_record(
+                    env,
+                    commitment,
+                    jint_to_u32(bundle_index, "bundle_index")?,
+                    vc_tree_position,
+                )
             }
             None => Ok(JObject::null().into_raw()),
         }
@@ -536,18 +548,24 @@ mod tests {
     fn commitment_store_key_must_match_payload() {
         let commitment = commitment_bundle("round-1", 7);
 
-        require_commitment_matches_key(&commitment, "round-1", 7).unwrap();
+        require_commitment_matches_key(&commitment, "round-1", 1, 7).unwrap();
         assert!(
-            require_commitment_matches_key(&commitment, "round-2", 7)
+            require_commitment_matches_key(&commitment, "round-2", 1, 7)
                 .unwrap_err()
                 .to_string()
                 .contains("voteRoundId")
         );
         assert!(
-            require_commitment_matches_key(&commitment, "round-1", 8)
+            require_commitment_matches_key(&commitment, "round-1", 1, 8)
                 .unwrap_err()
                 .to_string()
                 .contains("proposalId")
+        );
+        assert!(
+            require_commitment_matches_key(&commitment, "round-1", 2, 7)
+                .unwrap_err()
+                .to_string()
+                .contains("bundleIndex")
         );
     }
 
@@ -577,6 +595,7 @@ mod tests {
 
     fn commitment_bundle(round_id: &str, proposal_id: u32) -> JavaVoteCommitmentBundle {
         JavaVoteCommitmentBundle {
+            bundle_index: 1,
             enc_shares: vec![],
             bundle: VoteCommitmentBundle {
                 van_nullifier: vec![1; PROTOCOL_FIELD_BYTES],

--- a/backend-lib/src/main/rust/voting/recovery.rs
+++ b/backend-lib/src/main/rust/voting/recovery.rs
@@ -21,11 +21,6 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_sto
         let tx_hash = java_string_to_rust(env, &tx_hash)?;
         db.store_delegation_tx_hash(&round_id, bundle_index, &tx_hash)
             .map_err(|e| anyhow!("store_delegation_tx_hash: {e}"))?;
-        let stored = optional_recovery_lookup(
-            db.get_delegation_tx_hash(&round_id, bundle_index),
-            "get_delegation_tx_hash",
-        )?;
-        require_stored_value(stored.as_deref(), &tx_hash, "delegation tx hash")?;
         Ok(JNI_TRUE)
     });
     unwrap_exc_or(&mut env, res, JNI_FALSE)
@@ -80,11 +75,6 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_sto
         let tx_hash = java_string_to_rust(env, &tx_hash)?;
         db.store_vote_tx_hash(&round_id, bundle_index, proposal_id, &tx_hash)
             .map_err(|e| anyhow!("store_vote_tx_hash: {e}"))?;
-        let stored = optional_recovery_lookup(
-            db.get_vote_tx_hash(&round_id, bundle_index, proposal_id),
-            "get_vote_tx_hash",
-        )?;
-        require_stored_value(stored.as_deref(), &tx_hash, "vote tx hash")?;
         Ok(JNI_TRUE)
     });
     unwrap_exc_or(&mut env, res, JNI_FALSE)
@@ -166,16 +156,6 @@ fn is_query_returned_no_rows(error: &impl std::fmt::Display) -> bool {
         .contains("query returned no rows")
 }
 
-fn require_stored_value(stored: Option<&str>, expected: &str, label: &str) -> anyhow::Result<()> {
-    match stored {
-        Some(value) if value == expected => Ok(()),
-        Some(_) => Err(anyhow!(
-            "{label} store verification returned a different value"
-        )),
-        None => Err(anyhow!("{label} store did not update any recovery row")),
-    }
-}
-
 #[unsafe(no_mangle)]
 pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_storeCommitmentBundleNative<
     'local,
@@ -207,11 +187,6 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_sto
             vc_tree_position,
         )
         .map_err(|e| anyhow!("store_commitment_bundle: {e}"))?;
-        let stored = optional_recovery_lookup(
-            db.get_commitment_bundle(&round_id, bundle_index, proposal_id),
-            "get_commitment_bundle",
-        )?;
-        require_stored_commitment(stored, &commitment, vc_tree_position)?;
         Ok(JNI_TRUE)
     });
     unwrap_exc_or(&mut env, res, JNI_FALSE)
@@ -244,24 +219,6 @@ fn require_commitment_matches_key(
         ));
     }
     Ok(())
-}
-
-/// Requires a just-stored commitment lookup to return the exact JSON payload
-/// and VC tree position. Fails closed when the row is missing or was overwritten.
-fn require_stored_commitment(
-    stored: Option<(String, u64)>,
-    expected_json: &str,
-    expected_position: u64,
-) -> anyhow::Result<()> {
-    match stored {
-        Some((json, position)) if json == expected_json && position == expected_position => Ok(()),
-        Some(_) => Err(anyhow!(
-            "commitment bundle store verification returned a different value"
-        )),
-        None => Err(anyhow!(
-            "commitment bundle store did not update any recovery row"
-        )),
-    }
 }
 
 #[unsafe(no_mangle)]
@@ -527,24 +484,6 @@ mod tests {
     }
 
     #[test]
-    fn stored_value_verification_rejects_missing_or_changed_rows() {
-        require_stored_value(Some("tx-1"), "tx-1", "vote tx hash").unwrap();
-
-        assert!(
-            require_stored_value(None, "tx-1", "vote tx hash")
-                .unwrap_err()
-                .to_string()
-                .contains("did not update")
-        );
-        assert!(
-            require_stored_value(Some("tx-2"), "tx-1", "vote tx hash")
-                .unwrap_err()
-                .to_string()
-                .contains("different value")
-        );
-    }
-
-    #[test]
     fn commitment_store_key_must_match_payload() {
         let commitment = commitment_bundle("round-1", 7);
 
@@ -566,30 +505,6 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("bundleIndex")
-        );
-    }
-
-    #[test]
-    fn stored_commitment_verification_rejects_missing_or_changed_rows() {
-        require_stored_commitment(Some(("json".to_string(), 12)), "json", 12).unwrap();
-
-        assert!(
-            require_stored_commitment(None, "json", 12)
-                .unwrap_err()
-                .to_string()
-                .contains("did not update")
-        );
-        assert!(
-            require_stored_commitment(Some(("other".to_string(), 12)), "json", 12)
-                .unwrap_err()
-                .to_string()
-                .contains("different value")
-        );
-        assert!(
-            require_stored_commitment(Some(("json".to_string(), 13)), "json", 12)
-                .unwrap_err()
-                .to_string()
-                .contains("different value")
         );
     }
 

--- a/backend-lib/src/main/rust/voting/vote.rs
+++ b/backend-lib/src/main/rust/voting/vote.rs
@@ -72,8 +72,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_sig
         // through instead of reconstructing the sighash locally.
         let sig = voting::vote_commitment::sign_cast_vote(
             hotkey_seed.expose_secret(),
-            u32::try_from(network_id)
-                .map_err(|_| anyhow!("network_id must be non-negative, got {network_id}"))?,
+            jint_to_u32(network_id, "network_id")?,
             &commitment.vote_round_id,
             &commitment.r_vpk_bytes,
             &commitment.van_nullifier,
@@ -128,8 +127,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_bui
                 &round_id,
                 jint_to_u32(bundle_index, "bundle_index")?,
                 hotkey_seed.expose_secret(),
-                u32::try_from(network_id)
-                    .map_err(|_| anyhow!("network_id must be non-negative, got {network_id}"))?,
+                jint_to_u32(network_id, "network_id")?,
                 jint_to_u32(proposal_id, "proposal_id")?,
                 jint_to_u32(choice, "choice")?,
                 jint_to_u32(num_options, "num_options")?,

--- a/backend-lib/src/main/rust/voting/vote.rs
+++ b/backend-lib/src/main/rust/voting/vote.rs
@@ -111,21 +111,17 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_bui
         let db = db_from_handle(db_handle)?;
         let _access_lock = db.access_lock()?;
         let round_id = java_string_to_rust(env, &round_id)?;
+        let bundle_index = jint_to_u32(bundle_index, "bundle_index")?;
         require_supported_vote_account(account_index)?;
         let hotkey_seed =
             java_secret_bytes_at_least(env, &hotkey_seed, "hotkey_seed", PROTOCOL_FIELD_BYTES)?;
         let witness = java_van_witness(env, &witness)?;
-        require_delegation_ready_for_vote(
-            &db,
-            &round_id,
-            jint_to_u32(bundle_index, "bundle_index")?,
-            &witness,
-        )?;
+        require_delegation_ready_for_vote(&db, &round_id, bundle_index, &witness)?;
         let reporter = progress_reporter_from_callback(env, &progress_callback)?;
         let bundle = db
             .build_vote_commitment(
                 &round_id,
-                jint_to_u32(bundle_index, "bundle_index")?,
+                bundle_index,
                 hotkey_seed.expose_secret(),
                 jint_to_u32(network_id, "network_id")?,
                 jint_to_u32(proposal_id, "proposal_id")?,
@@ -138,7 +134,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_bui
                 reporter.as_ref(),
             )
             .map_err(|e| anyhow!("build_vote_commitment: {}", e))?;
-        make_jni_vote_commitment_result(env, bundle)
+        make_jni_vote_commitment_result(env, bundle, bundle_index)
     });
     unwrap_exc_or(&mut env, res, JObject::null().into_raw())
 }

--- a/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModelsTest.kt
+++ b/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModelsTest.kt
@@ -3,11 +3,10 @@ package cash.z.ecc.android.sdk.internal.model.voting
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class JniVotingModelsTest {
     @Test
-    fun vote_commitment_result_to_string_redacts_signing_material() {
+    fun vote_commitment_result_to_string_omits_commitment_details() {
         val text =
             JniVoteCommitmentResult(
                 vanNullifier = byteArrayOf(1),
@@ -25,9 +24,12 @@ class JniVotingModelsTest {
                 alphaV = byteArrayOf(103)
             ).toString()
 
-        assertTrue(text.contains("shareBlinds=***"))
-        assertTrue(text.contains("rVpk=***"))
-        assertTrue(text.contains("alphaV=***"))
+        assertEquals("JniVoteCommitmentResult(redacted)", text)
+        assertFalse(text.contains("round"))
+        assertFalse(text.contains("proposalId"))
+        assertFalse(text.contains("shareBlinds"))
+        assertFalse(text.contains("rVpk"))
+        assertFalse(text.contains("alphaV"))
         assertFalse(text.contains("101"))
         assertFalse(text.contains("102"))
         assertFalse(text.contains("103"))
@@ -112,6 +114,20 @@ class JniVotingModelsTest {
     }
 
     @Test
+    fun commitment_bundle_record_constructor_matches_rust_jni_signature() {
+        val constructor =
+            JniCommitmentBundleRecord::class.java.getDeclaredConstructor(
+                JniVoteCommitmentResult::class.java,
+                Long::class.javaPrimitiveType
+            )
+
+        assertEquals(
+            "(Lcash/z/ecc/android/sdk/internal/model/voting/JniVoteCommitmentResult;J)V",
+            constructor.jniDescriptor()
+        )
+    }
+
+    @Test
     fun share_payload_constructor_matches_rust_jni_signature() {
         val constructor =
             JniSharePayload::class.java.getDeclaredConstructor(
@@ -133,6 +149,27 @@ class JniVotingModelsTest {
         )
     }
 
+    @Test
+    fun share_delegation_record_constructor_matches_rust_jni_signature() {
+        val constructor =
+            JniShareDelegationRecord::class.java.getDeclaredConstructor(
+                String::class.java,
+                Int::class.javaPrimitiveType,
+                Int::class.javaPrimitiveType,
+                Int::class.javaPrimitiveType,
+                Array<String>::class.java,
+                ByteArray::class.java,
+                Boolean::class.javaPrimitiveType,
+                Long::class.javaPrimitiveType,
+                Long::class.javaPrimitiveType
+            )
+
+        assertEquals(
+            "(Ljava/lang/String;III[Ljava/lang/String;[BZJJ)V",
+            constructor.jniDescriptor()
+        )
+    }
+
     private fun java.lang.reflect.Constructor<*>.jniDescriptor() =
         parameterTypes.joinToString(prefix = "(", postfix = ")V", separator = "") { parameter ->
             parameter.jniDescriptor()
@@ -142,6 +179,7 @@ class JniVotingModelsTest {
         when {
             isArray -> "[${requireNotNull(componentType).jniDescriptor()}"
             this == java.lang.Byte.TYPE -> "B"
+            this == java.lang.Boolean.TYPE -> "Z"
             this == java.lang.Integer.TYPE -> "I"
             this == java.lang.Long.TYPE -> "J"
             isPrimitive -> error("Unsupported JNI primitive parameter: $name")

--- a/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModelsTest.kt
+++ b/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModelsTest.kt
@@ -13,6 +13,7 @@ class JniVotingModelsTest {
                 voteAuthorityNoteNew = byteArrayOf(2),
                 voteCommitment = byteArrayOf(3),
                 proposalId = 4,
+                bundleIndex = 5,
                 proof = byteArrayOf(5),
                 encShares = listOf(JniWireEncryptedShare(byteArrayOf(6), byteArrayOf(7), 0)),
                 anchorHeight = 8,
@@ -95,6 +96,7 @@ class JniVotingModelsTest {
                 ByteArray::class.java,
                 ByteArray::class.java,
                 Int::class.javaPrimitiveType,
+                Int::class.javaPrimitiveType,
                 ByteArray::class.java,
                 Array<JniWireEncryptedShare>::class.java,
                 Long::class.javaPrimitiveType,
@@ -107,7 +109,7 @@ class JniVotingModelsTest {
             )
 
         assertEquals(
-            "([B[B[BI[B[Lcash/z/ecc/android/sdk/internal/model/voting/" +
+            "([B[B[BII[B[Lcash/z/ecc/android/sdk/internal/model/voting/" +
                 "JniWireEncryptedShare;JLjava/lang/String;[B[[B[[B[B[B)V",
             constructor.jniDescriptor()
         )

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImplTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImplTest.kt
@@ -32,7 +32,6 @@ import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @Suppress("LargeClass", "LongMethod", "LongParameterList", "MagicNumber", "TooManyFunctions")
@@ -514,27 +513,6 @@ class TypesafeVotingBackendImplTest {
 
             assertEquals(VotingTxHashLookup.Missing, db.getDelegationTxHash("round", 0))
             assertEquals(VotingTxHashLookup.Missing, db.getVoteTxHash("round", 0, 0))
-        }
-
-    @Test
-    fun missing_recovery_rows_from_native_exception_map_to_expected_state() =
-        runTest {
-            val backend =
-                RecordingVotingDbBackend(
-                    proofResult = jniDelegationProofResult(),
-                    submissionResult = jniDelegationSubmissionResult(),
-                    keystoneSubmissionResult = jniDelegationSubmissionResult(),
-                    recoveryLookupException =
-                        RuntimeException(
-                            "native lookup failed",
-                            IllegalStateException("query returned no rows")
-                        )
-                )
-            val db = TypesafeVotingDbImpl(backend)
-
-            assertEquals(VotingTxHashLookup.Missing, db.getDelegationTxHash("round", 0))
-            assertEquals(VotingTxHashLookup.Missing, db.getVoteTxHash("round", 0, 0))
-            assertNull(db.getCommitmentBundle("round", 0, 0))
         }
 
     @Test

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImplTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImplTest.kt
@@ -501,6 +501,31 @@ class TypesafeVotingBackendImplTest {
         }
 
     @Test
+    fun store_commitment_bundle_rejects_mismatched_bundle_index() =
+        runTest {
+            val backend =
+                RecordingVotingDbBackend(
+                    proofResult = jniDelegationProofResult(),
+                    submissionResult = jniDelegationSubmissionResult(),
+                    keystoneSubmissionResult = jniDelegationSubmissionResult()
+                )
+            val db = TypesafeVotingDbImpl(backend)
+
+            val error =
+                assertFailsWith<IllegalArgumentException> {
+                    db.storeCommitmentBundle(
+                        roundId = "round-recovery",
+                        bundleIndex = 2,
+                        proposalId = 1,
+                        commitment = jniVoteCommitmentResult(bundleIndex = 1),
+                        vcTreePosition = 99
+                    )
+                }
+
+            assertTrue(error.message.orEmpty().contains("bundleIndex"))
+        }
+
+    @Test
     fun missing_tx_hashes_map_to_typed_missing_state() =
         runTest {
             val backend =
@@ -634,6 +659,7 @@ class TypesafeVotingBackendImplTest {
         proposalId: Int = 1,
         proof: ByteArray = ByteArray(PROOF_BYTES) { 13 },
         encShares: List<JniWireEncryptedShare> = wireShares(),
+        bundleIndex: Int = 1,
         anchorHeight: Long = 2,
         voteRoundId: String = "round-vote",
         sharesHash: ByteArray = field(14),
@@ -646,6 +672,7 @@ class TypesafeVotingBackendImplTest {
         voteAuthorityNoteNew = voteAuthorityNoteNew,
         voteCommitment = voteCommitment,
         proposalId = proposalId,
+        bundleIndex = bundleIndex,
         proof = proof,
         encShares = encShares,
         anchorHeight = anchorHeight,
@@ -824,6 +851,7 @@ class TypesafeVotingBackendImplTest {
                 voteAuthorityNoteNew = ByteArray(JNI_PROTOCOL_FIELD_BYTES_SIZE),
                 voteCommitment = ByteArray(JNI_PROTOCOL_FIELD_BYTES_SIZE),
                 proposalId = 1,
+                bundleIndex = 1,
                 proof = ByteArray(PROOF_BYTES),
                 encShares =
                     List(JNI_VOTE_SHARE_COUNT) { index ->

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImplTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImplTest.kt
@@ -8,6 +8,7 @@ import cash.z.ecc.android.sdk.internal.jni.JNI_VAN_WITNESS_PATH_DEPTH
 import cash.z.ecc.android.sdk.internal.jni.JNI_VOTE_SHARE_COUNT
 import cash.z.ecc.android.sdk.internal.jni.VotingProofProgressCallback
 import cash.z.ecc.android.sdk.internal.model.voting.JniBundleSetupResult
+import cash.z.ecc.android.sdk.internal.model.voting.JniCommitmentBundleRecord
 import cash.z.ecc.android.sdk.internal.model.voting.JniDelegationPirPrecomputeResult
 import cash.z.ecc.android.sdk.internal.model.voting.JniDelegationProofResult
 import cash.z.ecc.android.sdk.internal.model.voting.JniDelegationSubmissionResult
@@ -15,6 +16,7 @@ import cash.z.ecc.android.sdk.internal.model.voting.JniGovernancePczt
 import cash.z.ecc.android.sdk.internal.model.voting.JniNoteInfo
 import cash.z.ecc.android.sdk.internal.model.voting.JniRoundState
 import cash.z.ecc.android.sdk.internal.model.voting.JniRoundSummary
+import cash.z.ecc.android.sdk.internal.model.voting.JniShareDelegationRecord
 import cash.z.ecc.android.sdk.internal.model.voting.JniSharePayload
 import cash.z.ecc.android.sdk.internal.model.voting.JniVanWitness
 import cash.z.ecc.android.sdk.internal.model.voting.JniVoteCommitmentResult
@@ -30,9 +32,10 @@ import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-@Suppress("LongMethod", "LongParameterList", "MagicNumber", "TooManyFunctions")
+@Suppress("LargeClass", "LongMethod", "LongParameterList", "MagicNumber", "TooManyFunctions")
 class TypesafeVotingBackendImplTest {
     @Test
     fun delegation_proof_result_checks_non_empty_proof() {
@@ -239,9 +242,7 @@ class TypesafeVotingBackendImplTest {
                     pirServerUrl = "https://pir.example",
                     networkId = 1,
                     notes = notes,
-                    walletSeed = walletSeed,
-                    accountIndex = 5,
-                    addressIndex = 6
+                    hotkeySeed = walletSeed
                 ) { progress ->
                     progressValue = progress
                 }
@@ -250,9 +251,7 @@ class TypesafeVotingBackendImplTest {
             assertEquals("https://pir.example", backend.buildAndProvePirServerUrl)
             assertEquals(1, backend.buildAndProveNetworkId)
             assertEquals(jniNotes, backend.buildAndProveNotes)
-            assertContentEquals(walletSeed, backend.buildAndProveWalletSeed)
-            assertEquals(5, backend.buildAndProveAccountIndex)
-            assertEquals(6, backend.buildAndProveAddressIndex)
+            assertContentEquals(walletSeed, backend.buildAndProveHotkeySeed)
             assertNotNull(backend.buildAndProveProgress).onProgress(0.75)
             assertEquals(0.75, progressValue)
             assertContentEquals(field(13), proof.nfSigned)
@@ -384,6 +383,181 @@ class TypesafeVotingBackendImplTest {
         }
 
     @Test
+    fun recovery_methods_forward_arguments_and_map_results() =
+        runTest {
+            val commitment = jniVoteCommitmentResult(voteCommitment = field(31))
+            val commitmentRecord =
+                JniCommitmentBundleRecord(
+                    commitment = commitment,
+                    vcTreePosition = 99
+                )
+            val shareRecord =
+                jniShareDelegationRecord(
+                    nullifier = field(32),
+                    confirmed = false
+                )
+            val unconfirmedRecord =
+                jniShareDelegationRecord(
+                    shareIndex = 2,
+                    nullifier = field(33),
+                    confirmed = false
+                )
+            val backend =
+                RecordingVotingDbBackend(
+                    proofResult = jniDelegationProofResult(),
+                    submissionResult = jniDelegationSubmissionResult(),
+                    keystoneSubmissionResult = jniDelegationSubmissionResult(),
+                    delegationTxHash = "delegation-tx",
+                    voteTxHash = "vote-tx",
+                    commitmentRecord = commitmentRecord,
+                    shareRecords = arrayOf(shareRecord),
+                    unconfirmedShareRecords = arrayOf(unconfirmedRecord)
+                )
+            val db = TypesafeVotingDbImpl(backend)
+
+            db.storeDelegationTxHash("round-recovery", 1, "delegation-tx")
+            assertEquals("round-recovery", backend.storeDelegationTxRoundId)
+            assertEquals(1, backend.storeDelegationTxBundleIndex)
+            assertEquals("delegation-tx", backend.storeDelegationTxHash)
+
+            assertEquals(
+                VotingTxHashLookup.Found("delegation-tx"),
+                db.getDelegationTxHash("round-recovery", 1)
+            )
+            assertEquals("round-recovery", backend.getDelegationTxRoundId)
+            assertEquals(1, backend.getDelegationTxBundleIndex)
+
+            db.storeVoteTxHash("round-recovery", 1, 2, "vote-tx")
+            assertEquals("round-recovery", backend.storeVoteTxRoundId)
+            assertEquals(1, backend.storeVoteTxBundleIndex)
+            assertEquals(2, backend.storeVoteTxProposalId)
+            assertEquals("vote-tx", backend.storeVoteTxHash)
+
+            db.markVoteSubmitted("round-recovery", 1, 2)
+            assertEquals("round-recovery", backend.markVoteRoundId)
+            assertEquals(1, backend.markVoteBundleIndex)
+            assertEquals(2, backend.markVoteProposalId)
+
+            assertEquals(
+                VotingTxHashLookup.Found("vote-tx"),
+                db.getVoteTxHash("round-recovery", 1, 2)
+            )
+            assertEquals("round-recovery", backend.getVoteTxRoundId)
+            assertEquals(1, backend.getVoteTxBundleIndex)
+            assertEquals(2, backend.getVoteTxProposalId)
+
+            db.storeCommitmentBundle("round-recovery", 1, 2, commitment, 99)
+            assertEquals("round-recovery", backend.storeCommitmentRoundId)
+            assertEquals(1, backend.storeCommitmentBundleIndex)
+            assertEquals(2, backend.storeCommitmentProposalId)
+            assertEquals(commitment, backend.storeCommitment)
+            assertEquals(99, backend.storeCommitmentTreePosition)
+
+            val recoveredCommitment = db.getCommitmentBundle("round-recovery", 1, 2)
+            assertEquals(CommitmentBundleRecord(commitment, 99), recoveredCommitment)
+            assertEquals("round-recovery", backend.getCommitmentRoundId)
+            assertEquals(1, backend.getCommitmentBundleIndex)
+            assertEquals(2, backend.getCommitmentProposalId)
+
+            db.recordShareDelegation(
+                roundId = "round-recovery",
+                bundleIndex = 1,
+                proposalId = 2,
+                shareIndex = 3,
+                sentToUrls = listOf("https://helper.example"),
+                nullifier = field(34),
+                submitAt = 123
+            )
+            assertEquals("round-recovery", backend.recordShareRoundId)
+            assertEquals(1, backend.recordShareBundleIndex)
+            assertEquals(2, backend.recordShareProposalId)
+            assertEquals(3, backend.recordShareIndex)
+            assertEquals(listOf("https://helper.example"), backend.recordShareSentToUrls)
+            assertContentEquals(field(34), backend.recordShareNullifier)
+            assertEquals(123, backend.recordShareSubmitAt)
+
+            assertEquals(listOf(shareRecord.toShareDelegationRecordForTest()), db.getShareDelegations("round-recovery"))
+            assertEquals("round-recovery", backend.getSharesRoundId)
+            assertEquals(
+                listOf(unconfirmedRecord.toShareDelegationRecordForTest()),
+                db.getUnconfirmedDelegations("round-recovery")
+            )
+            assertEquals("round-recovery", backend.getUnconfirmedSharesRoundId)
+
+            db.markShareConfirmed("round-recovery", 1, 2, 3)
+            assertEquals("round-recovery", backend.markShareRoundId)
+            assertEquals(1, backend.markShareBundleIndex)
+            assertEquals(2, backend.markShareProposalId)
+            assertEquals(3, backend.markShareIndex)
+
+            db.addSentServers("round-recovery", 1, 2, 3, listOf("https://helper-2.example"))
+            assertEquals("round-recovery", backend.addSentRoundId)
+            assertEquals(1, backend.addSentBundleIndex)
+            assertEquals(2, backend.addSentProposalId)
+            assertEquals(3, backend.addSentShareIndex)
+            assertEquals(listOf("https://helper-2.example"), backend.addSentNewUrls)
+
+            db.clearRecoveryState("round-recovery")
+            assertEquals("round-recovery", backend.clearRecoveryRoundId)
+        }
+
+    @Test
+    fun missing_tx_hashes_map_to_typed_missing_state() =
+        runTest {
+            val backend =
+                RecordingVotingDbBackend(
+                    proofResult = jniDelegationProofResult(),
+                    submissionResult = jniDelegationSubmissionResult(),
+                    keystoneSubmissionResult = jniDelegationSubmissionResult()
+                )
+            val db = TypesafeVotingDbImpl(backend)
+
+            assertEquals(VotingTxHashLookup.Missing, db.getDelegationTxHash("round", 0))
+            assertEquals(VotingTxHashLookup.Missing, db.getVoteTxHash("round", 0, 0))
+        }
+
+    @Test
+    fun missing_recovery_rows_from_native_exception_map_to_expected_state() =
+        runTest {
+            val backend =
+                RecordingVotingDbBackend(
+                    proofResult = jniDelegationProofResult(),
+                    submissionResult = jniDelegationSubmissionResult(),
+                    keystoneSubmissionResult = jniDelegationSubmissionResult(),
+                    recoveryLookupException =
+                        RuntimeException(
+                            "native lookup failed",
+                            IllegalStateException("query returned no rows")
+                        )
+                )
+            val db = TypesafeVotingDbImpl(backend)
+
+            assertEquals(VotingTxHashLookup.Missing, db.getDelegationTxHash("round", 0))
+            assertEquals(VotingTxHashLookup.Missing, db.getVoteTxHash("round", 0, 0))
+            assertNull(db.getCommitmentBundle("round", 0, 0))
+        }
+
+    @Test
+    fun unexpected_recovery_lookup_exceptions_still_fail() =
+        runTest {
+            val backend =
+                RecordingVotingDbBackend(
+                    proofResult = jniDelegationProofResult(),
+                    submissionResult = jniDelegationSubmissionResult(),
+                    keystoneSubmissionResult = jniDelegationSubmissionResult(),
+                    recoveryLookupException = RuntimeException("database is locked")
+                )
+            val db = TypesafeVotingDbImpl(backend)
+
+            val error =
+                assertFailsWith<RuntimeException> {
+                    db.getDelegationTxHash("round", 0)
+                }
+
+            assertEquals("database is locked", error.message)
+        }
+
+    @Test
     fun vote_commitment_wrapper_rejects_invalid_commitment_result() =
         runTest {
             val backend =
@@ -504,6 +678,41 @@ class TypesafeVotingBackendImplTest {
         rVpk = rVpk,
         alphaV = alphaV
     )
+
+    private fun jniShareDelegationRecord(
+        roundId: String = "round-recovery",
+        bundleIndex: Int = 1,
+        proposalId: Int = 2,
+        shareIndex: Int = 3,
+        sentToUrls: List<String> = listOf("https://helper.example"),
+        nullifier: ByteArray = field(19),
+        confirmed: Boolean = false,
+        submitAt: Long = 123,
+        createdAt: Long = 456
+    ) = JniShareDelegationRecord(
+        roundId = roundId,
+        bundleIndex = bundleIndex,
+        proposalId = proposalId,
+        shareIndex = shareIndex,
+        sentToUrls = sentToUrls,
+        nullifier = nullifier,
+        confirmed = confirmed,
+        submitAt = submitAt,
+        createdAt = createdAt
+    )
+
+    private fun JniShareDelegationRecord.toShareDelegationRecordForTest() =
+        ShareDelegationRecord(
+            roundId = roundId,
+            bundleIndex = bundleIndex,
+            proposalId = proposalId,
+            shareIndex = shareIndex,
+            sentToUrls = sentToUrls,
+            nullifier = nullifier,
+            confirmed = confirmed,
+            submitAt = submitAt,
+            createdAt = createdAt
+        )
 
     private fun wireShares(
         count: Int = JNI_VOTE_SHARE_COUNT,
@@ -654,7 +863,13 @@ class TypesafeVotingBackendImplTest {
                 rVpk = ByteArray(JNI_PROTOCOL_FIELD_BYTES_SIZE),
                 alphaV = ByteArray(JNI_PROTOCOL_FIELD_BYTES_SIZE)
             ),
-        private val syncHeight: Long = 1
+        private val syncHeight: Long = 1,
+        private val delegationTxHash: String? = null,
+        private val voteTxHash: String? = null,
+        private val commitmentRecord: JniCommitmentBundleRecord? = null,
+        private val shareRecords: Array<JniShareDelegationRecord> = emptyArray(),
+        private val unconfirmedShareRecords: Array<JniShareDelegationRecord> = emptyArray(),
+        private val recoveryLookupException: RuntimeException? = null
     ) : VotingDbBackend {
         var storeWitnessesRoundId: String? = null
         var storeWitnessesBundleIndex: Int? = null
@@ -670,9 +885,7 @@ class TypesafeVotingBackendImplTest {
         var buildAndProvePirServerUrl: String? = null
         var buildAndProveNetworkId: Int? = null
         var buildAndProveNotes: List<JniNoteInfo>? = null
-        var buildAndProveWalletSeed: ByteArray = ByteArray(0)
-        var buildAndProveAccountIndex: Int? = null
-        var buildAndProveAddressIndex: Int? = null
+        var buildAndProveHotkeySeed: ByteArray = ByteArray(0)
         var buildAndProveProgress: VotingProofProgressCallback? = null
         var submissionRoundId: String? = null
         var submissionBundleIndex: Int? = null
@@ -711,6 +924,48 @@ class TypesafeVotingBackendImplTest {
         var buildVoteAccountIndex: Int? = null
         var buildVoteSingleShare: Boolean? = null
         var buildVoteProgress: VotingProofProgressCallback? = null
+        var storeDelegationTxRoundId: String? = null
+        var storeDelegationTxBundleIndex: Int? = null
+        var storeDelegationTxHash: String? = null
+        var getDelegationTxRoundId: String? = null
+        var getDelegationTxBundleIndex: Int? = null
+        var storeVoteTxRoundId: String? = null
+        var storeVoteTxBundleIndex: Int? = null
+        var storeVoteTxProposalId: Int? = null
+        var storeVoteTxHash: String? = null
+        var markVoteRoundId: String? = null
+        var markVoteBundleIndex: Int? = null
+        var markVoteProposalId: Int? = null
+        var getVoteTxRoundId: String? = null
+        var getVoteTxBundleIndex: Int? = null
+        var getVoteTxProposalId: Int? = null
+        var storeCommitmentRoundId: String? = null
+        var storeCommitmentBundleIndex: Int? = null
+        var storeCommitmentProposalId: Int? = null
+        var storeCommitment: JniVoteCommitmentResult? = null
+        var storeCommitmentTreePosition: Long? = null
+        var getCommitmentRoundId: String? = null
+        var getCommitmentBundleIndex: Int? = null
+        var getCommitmentProposalId: Int? = null
+        var clearRecoveryRoundId: String? = null
+        var recordShareRoundId: String? = null
+        var recordShareBundleIndex: Int? = null
+        var recordShareProposalId: Int? = null
+        var recordShareIndex: Int? = null
+        var recordShareSentToUrls: List<String>? = null
+        var recordShareNullifier: ByteArray = ByteArray(0)
+        var recordShareSubmitAt: Long? = null
+        var getSharesRoundId: String? = null
+        var getUnconfirmedSharesRoundId: String? = null
+        var markShareRoundId: String? = null
+        var markShareBundleIndex: Int? = null
+        var markShareProposalId: Int? = null
+        var markShareIndex: Int? = null
+        var addSentRoundId: String? = null
+        var addSentBundleIndex: Int? = null
+        var addSentProposalId: Int? = null
+        var addSentShareIndex: Int? = null
+        var addSentNewUrls: List<String>? = null
 
         override suspend fun close() = unused()
 
@@ -756,9 +1011,9 @@ class TypesafeVotingBackendImplTest {
             accountIndex: Int,
             notes: List<JniNoteInfo>,
             walletSeed: ByteArray,
+            hotkeySeed: ByteArray,
             seedFingerprint: ByteArray,
-            roundName: String,
-            addressIndex: Int
+            roundName: String
         ): JniGovernancePczt = unused()
 
         override suspend fun storeWitnesses(
@@ -794,9 +1049,7 @@ class TypesafeVotingBackendImplTest {
             pirServerUrl: String,
             networkId: Int,
             notes: List<JniNoteInfo>,
-            walletSeed: ByteArray,
-            accountIndex: Int,
-            addressIndex: Int,
+            hotkeySeed: ByteArray,
             proofProgress: VotingProofProgressCallback?
         ): JniDelegationProofResult {
             buildAndProveRoundId = roundId
@@ -804,9 +1057,7 @@ class TypesafeVotingBackendImplTest {
             buildAndProvePirServerUrl = pirServerUrl
             buildAndProveNetworkId = networkId
             buildAndProveNotes = notes
-            buildAndProveWalletSeed = walletSeed
-            buildAndProveAccountIndex = accountIndex
-            buildAndProveAddressIndex = addressIndex
+            buildAndProveHotkeySeed = hotkeySeed
             buildAndProveProgress = proofProgress
             return proofResult
         }
@@ -919,6 +1170,139 @@ class TypesafeVotingBackendImplTest {
             buildVoteSingleShare = singleShare
             buildVoteProgress = proofProgress
             return commitmentResult
+        }
+
+        override suspend fun storeDelegationTxHash(
+            roundId: String,
+            bundleIndex: Int,
+            txHash: String
+        ) {
+            storeDelegationTxRoundId = roundId
+            storeDelegationTxBundleIndex = bundleIndex
+            storeDelegationTxHash = txHash
+        }
+
+        override suspend fun getDelegationTxHash(roundId: String, bundleIndex: Int): String? {
+            getDelegationTxRoundId = roundId
+            getDelegationTxBundleIndex = bundleIndex
+            recoveryLookupException?.let { throw it }
+            return delegationTxHash
+        }
+
+        override suspend fun storeVoteTxHash(
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int,
+            txHash: String
+        ) {
+            storeVoteTxRoundId = roundId
+            storeVoteTxBundleIndex = bundleIndex
+            storeVoteTxProposalId = proposalId
+            storeVoteTxHash = txHash
+        }
+
+        override suspend fun markVoteSubmitted(roundId: String, bundleIndex: Int, proposalId: Int) {
+            markVoteRoundId = roundId
+            markVoteBundleIndex = bundleIndex
+            markVoteProposalId = proposalId
+        }
+
+        override suspend fun getVoteTxHash(
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int
+        ): String? {
+            getVoteTxRoundId = roundId
+            getVoteTxBundleIndex = bundleIndex
+            getVoteTxProposalId = proposalId
+            recoveryLookupException?.let { throw it }
+            return voteTxHash
+        }
+
+        override suspend fun storeCommitmentBundle(
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int,
+            commitment: JniVoteCommitmentResult,
+            vcTreePosition: Long
+        ) {
+            storeCommitmentRoundId = roundId
+            storeCommitmentBundleIndex = bundleIndex
+            storeCommitmentProposalId = proposalId
+            storeCommitment = commitment
+            storeCommitmentTreePosition = vcTreePosition
+        }
+
+        override suspend fun getCommitmentBundle(
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int
+        ): JniCommitmentBundleRecord? {
+            getCommitmentRoundId = roundId
+            getCommitmentBundleIndex = bundleIndex
+            getCommitmentProposalId = proposalId
+            recoveryLookupException?.let { throw it }
+            return commitmentRecord
+        }
+
+        override suspend fun clearRecoveryState(roundId: String) {
+            clearRecoveryRoundId = roundId
+        }
+
+        override suspend fun recordShareDelegation(
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int,
+            shareIndex: Int,
+            sentToUrls: List<String>,
+            nullifier: ByteArray,
+            submitAt: Long
+        ) {
+            recordShareRoundId = roundId
+            recordShareBundleIndex = bundleIndex
+            recordShareProposalId = proposalId
+            recordShareIndex = shareIndex
+            recordShareSentToUrls = sentToUrls
+            recordShareNullifier = nullifier
+            recordShareSubmitAt = submitAt
+        }
+
+        override suspend fun getShareDelegations(roundId: String): Array<JniShareDelegationRecord> {
+            getSharesRoundId = roundId
+            return shareRecords
+        }
+
+        override suspend fun getUnconfirmedDelegations(
+            roundId: String
+        ): Array<JniShareDelegationRecord> {
+            getUnconfirmedSharesRoundId = roundId
+            return unconfirmedShareRecords
+        }
+
+        override suspend fun markShareConfirmed(
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int,
+            shareIndex: Int
+        ) {
+            markShareRoundId = roundId
+            markShareBundleIndex = bundleIndex
+            markShareProposalId = proposalId
+            markShareIndex = shareIndex
+        }
+
+        override suspend fun addSentServers(
+            roundId: String,
+            bundleIndex: Int,
+            proposalId: Int,
+            shareIndex: Int,
+            newUrls: List<String>
+        ) {
+            addSentRoundId = roundId
+            addSentBundleIndex = bundleIndex
+            addSentProposalId = proposalId
+            addSentShareIndex = shareIndex
+            addSentNewUrls = newUrls
         }
 
         private fun unused(): Nothing = error("unused")

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackend.kt
@@ -249,6 +249,9 @@ internal interface TypesafeVotingDb {
         shareIndex: Int
     )
 
+    /**
+     * Appends [newUrls] to the sent-server list for this share, ignoring duplicates.
+     */
     suspend fun addSentServers(
         roundId: String,
         bundleIndex: Int,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackend.kt
@@ -110,9 +110,9 @@ internal interface TypesafeVotingDb {
         accountIndex: Int,
         notes: List<VotingNoteInfo>,
         walletSeed: ByteArray,
+        hotkeySeed: ByteArray,
         seedFingerprint: ByteArray,
-        roundName: String,
-        addressIndex: Int
+        roundName: String
     ): GovernancePcztResult
 
     suspend fun storeWitnesses(
@@ -136,9 +136,7 @@ internal interface TypesafeVotingDb {
         pirServerUrl: String,
         networkId: Int,
         notes: List<VotingNoteInfo>,
-        walletSeed: ByteArray,
-        accountIndex: Int,
-        addressIndex: Int,
+        hotkeySeed: ByteArray,
         proofProgress: ((Double) -> Unit)? = null
     ): DelegationProofResult
 
@@ -194,6 +192,70 @@ internal interface TypesafeVotingDb {
         singleShare: Boolean = false,
         proofProgress: ((Double) -> Unit)? = null
     ): JniVoteCommitmentResult
+
+    suspend fun storeDelegationTxHash(roundId: String, bundleIndex: Int, txHash: String)
+
+    suspend fun getDelegationTxHash(roundId: String, bundleIndex: Int): VotingTxHashLookup
+
+    suspend fun storeVoteTxHash(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int,
+        txHash: String
+    )
+
+    suspend fun markVoteSubmitted(roundId: String, bundleIndex: Int, proposalId: Int)
+
+    suspend fun getVoteTxHash(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int
+    ): VotingTxHashLookup
+
+    suspend fun storeCommitmentBundle(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int,
+        commitment: JniVoteCommitmentResult,
+        vcTreePosition: Long
+    )
+
+    suspend fun getCommitmentBundle(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int
+    ): CommitmentBundleRecord?
+
+    suspend fun clearRecoveryState(roundId: String)
+
+    suspend fun recordShareDelegation(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int,
+        shareIndex: Int,
+        sentToUrls: List<String>,
+        nullifier: ByteArray,
+        submitAt: Long
+    )
+
+    suspend fun getShareDelegations(roundId: String): List<ShareDelegationRecord>
+
+    suspend fun getUnconfirmedDelegations(roundId: String): List<ShareDelegationRecord>
+
+    suspend fun markShareConfirmed(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int,
+        shareIndex: Int
+    )
+
+    suspend fun addSentServers(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int,
+        shareIndex: Int,
+        newUrls: List<String>
+    )
 }
 
 internal data class VotingNoteInfo(
@@ -345,6 +407,58 @@ internal data class DelegationSubmissionResult(
         result = 31 * result + govComm.contentHashCode()
         result = 31 * result + govNullifiers.contentDeepHashCode()
         result = 31 * result + voteRoundId.hashCode()
+        return result
+    }
+}
+
+internal sealed interface VotingTxHashLookup {
+    data object Missing : VotingTxHashLookup
+
+    data class Found(
+        val txHash: String
+    ) : VotingTxHashLookup
+}
+
+internal data class CommitmentBundleRecord(
+    val commitment: JniVoteCommitmentResult,
+    val vcTreePosition: Long
+)
+
+internal data class ShareDelegationRecord(
+    val roundId: String,
+    val bundleIndex: Int,
+    val proposalId: Int,
+    val shareIndex: Int,
+    val sentToUrls: List<String>,
+    val nullifier: ByteArray,
+    val confirmed: Boolean,
+    val submitAt: Long,
+    val createdAt: Long
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ShareDelegationRecord) return false
+        return roundId == other.roundId &&
+            bundleIndex == other.bundleIndex &&
+            proposalId == other.proposalId &&
+            shareIndex == other.shareIndex &&
+            sentToUrls == other.sentToUrls &&
+            nullifier.contentEquals(other.nullifier) &&
+            confirmed == other.confirmed &&
+            submitAt == other.submitAt &&
+            createdAt == other.createdAt
+    }
+
+    override fun hashCode(): Int {
+        var result = roundId.hashCode()
+        result = 31 * result + bundleIndex
+        result = 31 * result + proposalId
+        result = 31 * result + shareIndex
+        result = 31 * result + sentToUrls.hashCode()
+        result = 31 * result + nullifier.contentHashCode()
+        result = 31 * result + confirmed.hashCode()
+        result = 31 * result + submitAt.hashCode()
+        result = 31 * result + createdAt.hashCode()
         return result
     }
 }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
@@ -449,6 +449,9 @@ internal interface VotingDbBackend {
         shareIndex: Int
     )
 
+    /**
+     * Appends [newUrls] to the sent-server list for this share, ignoring duplicates.
+     */
     suspend fun addSentServers(
         roundId: String,
         bundleIndex: Int,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
@@ -1017,6 +1017,9 @@ internal class TypesafeVotingDbImpl(
         vcTreePosition: Long
     ) {
         commitment.requireValid()
+        require(commitment.bundleIndex == bundleIndex) {
+            "commitment bundleIndex ${commitment.bundleIndex} does not match bundleIndex $bundleIndex"
+        }
         votingDb.storeCommitmentBundle(
             roundId,
             bundleIndex,
@@ -1205,6 +1208,7 @@ private fun JniVoteCommitmentResult.requireValid() {
     vanNullifier.requireByteArraySize("vanNullifier", JNI_PROTOCOL_FIELD_BYTES_SIZE)
     voteAuthorityNoteNew.requireByteArraySize("voteAuthorityNoteNew", JNI_PROTOCOL_FIELD_BYTES_SIZE)
     voteCommitment.requireByteArraySize("voteCommitment", JNI_PROTOCOL_FIELD_BYTES_SIZE)
+    require(bundleIndex >= 0) { "bundleIndex must be non-negative, got $bundleIndex" }
     proof.requireByteArrayNotEmpty("proof")
     encShares.requireCount("encShares", JNI_VOTE_SHARE_COUNT)
     encShares.forEachIndexed { index, share -> share.requireValid("encShares[$index]") }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
@@ -11,6 +11,7 @@ import cash.z.ecc.android.sdk.internal.jni.JNI_VOTE_SHARE_COUNT
 import cash.z.ecc.android.sdk.internal.jni.VotingProofProgressCallback
 import cash.z.ecc.android.sdk.internal.jni.VotingRustBackend
 import cash.z.ecc.android.sdk.internal.model.voting.JniBundleSetupResult
+import cash.z.ecc.android.sdk.internal.model.voting.JniCommitmentBundleRecord
 import cash.z.ecc.android.sdk.internal.model.voting.JniDelegationPirPrecomputeResult
 import cash.z.ecc.android.sdk.internal.model.voting.JniDelegationProofResult
 import cash.z.ecc.android.sdk.internal.model.voting.JniDelegationSubmissionResult
@@ -18,6 +19,7 @@ import cash.z.ecc.android.sdk.internal.model.voting.JniGovernancePczt
 import cash.z.ecc.android.sdk.internal.model.voting.JniNoteInfo
 import cash.z.ecc.android.sdk.internal.model.voting.JniRoundState
 import cash.z.ecc.android.sdk.internal.model.voting.JniRoundSummary
+import cash.z.ecc.android.sdk.internal.model.voting.JniShareDelegationRecord
 import cash.z.ecc.android.sdk.internal.model.voting.JniSharePayload
 import cash.z.ecc.android.sdk.internal.model.voting.JniVanWitness
 import cash.z.ecc.android.sdk.internal.model.voting.JniVoteCommitmentResult
@@ -308,9 +310,9 @@ internal interface VotingDbBackend {
         accountIndex: Int,
         notes: List<JniNoteInfo>,
         walletSeed: ByteArray,
+        hotkeySeed: ByteArray,
         seedFingerprint: ByteArray,
-        roundName: String,
-        addressIndex: Int
+        roundName: String
     ): JniGovernancePczt
 
     suspend fun storeWitnesses(
@@ -334,9 +336,7 @@ internal interface VotingDbBackend {
         pirServerUrl: String,
         networkId: Int,
         notes: List<JniNoteInfo>,
-        walletSeed: ByteArray,
-        accountIndex: Int,
-        addressIndex: Int,
+        hotkeySeed: ByteArray,
         proofProgress: VotingProofProgressCallback?
     ): JniDelegationProofResult
 
@@ -392,6 +392,70 @@ internal interface VotingDbBackend {
         singleShare: Boolean,
         proofProgress: VotingProofProgressCallback?
     ): JniVoteCommitmentResult
+
+    suspend fun storeDelegationTxHash(roundId: String, bundleIndex: Int, txHash: String)
+
+    suspend fun getDelegationTxHash(roundId: String, bundleIndex: Int): String?
+
+    suspend fun storeVoteTxHash(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int,
+        txHash: String
+    )
+
+    suspend fun markVoteSubmitted(roundId: String, bundleIndex: Int, proposalId: Int)
+
+    suspend fun getVoteTxHash(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int
+    ): String?
+
+    suspend fun storeCommitmentBundle(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int,
+        commitment: JniVoteCommitmentResult,
+        vcTreePosition: Long
+    )
+
+    suspend fun getCommitmentBundle(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int
+    ): JniCommitmentBundleRecord?
+
+    suspend fun clearRecoveryState(roundId: String)
+
+    suspend fun recordShareDelegation(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int,
+        shareIndex: Int,
+        sentToUrls: List<String>,
+        nullifier: ByteArray,
+        submitAt: Long
+    )
+
+    suspend fun getShareDelegations(roundId: String): Array<JniShareDelegationRecord>
+
+    suspend fun getUnconfirmedDelegations(roundId: String): Array<JniShareDelegationRecord>
+
+    suspend fun markShareConfirmed(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int,
+        shareIndex: Int
+    )
+
+    suspend fun addSentServers(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int,
+        shareIndex: Int,
+        newUrls: List<String>
+    )
 }
 
 @Suppress("TooManyFunctions", "LongParameterList")
@@ -454,9 +518,9 @@ private class RustVotingDbBackend(
         accountIndex: Int,
         notes: List<JniNoteInfo>,
         walletSeed: ByteArray,
+        hotkeySeed: ByteArray,
         seedFingerprint: ByteArray,
-        roundName: String,
-        addressIndex: Int
+        roundName: String
     ): JniGovernancePczt =
         votingDb.buildGovernancePczt(
             roundId,
@@ -466,9 +530,9 @@ private class RustVotingDbBackend(
             accountIndex,
             notes,
             walletSeed,
+            hotkeySeed,
             seedFingerprint,
-            roundName,
-            addressIndex
+            roundName
         )
 
     override suspend fun storeWitnesses(
@@ -499,9 +563,7 @@ private class RustVotingDbBackend(
         pirServerUrl: String,
         networkId: Int,
         notes: List<JniNoteInfo>,
-        walletSeed: ByteArray,
-        accountIndex: Int,
-        addressIndex: Int,
+        hotkeySeed: ByteArray,
         proofProgress: VotingProofProgressCallback?
     ): JniDelegationProofResult =
         votingDb.buildAndProveDelegation(
@@ -510,9 +572,7 @@ private class RustVotingDbBackend(
             pirServerUrl,
             networkId,
             notes,
-            walletSeed,
-            accountIndex,
-            addressIndex,
+            hotkeySeed,
             proofProgress
         )
 
@@ -607,6 +667,92 @@ private class RustVotingDbBackend(
             singleShare,
             proofProgress
         )
+
+    override suspend fun storeDelegationTxHash(roundId: String, bundleIndex: Int, txHash: String) =
+        votingDb.storeDelegationTxHash(roundId, bundleIndex, txHash)
+
+    override suspend fun getDelegationTxHash(roundId: String, bundleIndex: Int): String? =
+        votingDb.getDelegationTxHash(roundId, bundleIndex)
+
+    override suspend fun storeVoteTxHash(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int,
+        txHash: String
+    ) = votingDb.storeVoteTxHash(roundId, bundleIndex, proposalId, txHash)
+
+    override suspend fun markVoteSubmitted(roundId: String, bundleIndex: Int, proposalId: Int) =
+        votingDb.markVoteSubmitted(roundId, bundleIndex, proposalId)
+
+    override suspend fun getVoteTxHash(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int
+    ): String? =
+        votingDb.getVoteTxHash(roundId, bundleIndex, proposalId)
+
+    override suspend fun storeCommitmentBundle(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int,
+        commitment: JniVoteCommitmentResult,
+        vcTreePosition: Long
+    ) = votingDb.storeCommitmentBundle(
+        roundId,
+        bundleIndex,
+        proposalId,
+        commitment,
+        vcTreePosition
+    )
+
+    override suspend fun getCommitmentBundle(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int
+    ): JniCommitmentBundleRecord? =
+        votingDb.getCommitmentBundle(roundId, bundleIndex, proposalId)
+
+    override suspend fun clearRecoveryState(roundId: String) =
+        votingDb.clearRecoveryState(roundId)
+
+    override suspend fun recordShareDelegation(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int,
+        shareIndex: Int,
+        sentToUrls: List<String>,
+        nullifier: ByteArray,
+        submitAt: Long
+    ) = votingDb.recordShareDelegation(
+        roundId,
+        bundleIndex,
+        proposalId,
+        shareIndex,
+        sentToUrls,
+        nullifier,
+        submitAt
+    )
+
+    override suspend fun getShareDelegations(roundId: String): Array<JniShareDelegationRecord> =
+        votingDb.getShareDelegations(roundId)
+
+    override suspend fun getUnconfirmedDelegations(roundId: String): Array<JniShareDelegationRecord> =
+        votingDb.getUnconfirmedDelegations(roundId)
+
+    override suspend fun markShareConfirmed(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int,
+        shareIndex: Int
+    ) = votingDb.markShareConfirmed(roundId, bundleIndex, proposalId, shareIndex)
+
+    override suspend fun addSentServers(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int,
+        shareIndex: Int,
+        newUrls: List<String>
+    ) = votingDb.addSentServers(roundId, bundleIndex, proposalId, shareIndex, newUrls)
 }
 
 @Suppress("TooManyFunctions", "LongParameterList")
@@ -671,9 +817,9 @@ internal class TypesafeVotingDbImpl(
         accountIndex: Int,
         notes: List<VotingNoteInfo>,
         walletSeed: ByteArray,
+        hotkeySeed: ByteArray,
         seedFingerprint: ByteArray,
-        roundName: String,
-        addressIndex: Int
+        roundName: String
     ): GovernancePcztResult =
         votingDb
             .buildGovernancePczt(
@@ -684,9 +830,9 @@ internal class TypesafeVotingDbImpl(
                 accountIndex,
                 notes.toJniNoteInfos(),
                 walletSeed,
+                hotkeySeed,
                 seedFingerprint,
-                roundName,
-                addressIndex
+                roundName
             ).toGovernancePcztResult()
 
     override suspend fun storeWitnesses(
@@ -718,9 +864,7 @@ internal class TypesafeVotingDbImpl(
         pirServerUrl: String,
         networkId: Int,
         notes: List<VotingNoteInfo>,
-        walletSeed: ByteArray,
-        accountIndex: Int,
-        addressIndex: Int,
+        hotkeySeed: ByteArray,
         proofProgress: ((Double) -> Unit)?
     ): DelegationProofResult =
         votingDb
@@ -730,9 +874,7 @@ internal class TypesafeVotingDbImpl(
                 pirServerUrl,
                 networkId,
                 notes.toJniNoteInfos(),
-                walletSeed,
-                accountIndex,
-                addressIndex,
+                hotkeySeed,
                 proofProgress?.asVotingProgressCallback()
             ).toDelegationProofResult()
 
@@ -837,6 +979,113 @@ internal class TypesafeVotingDbImpl(
             ).also { commitment ->
                 commitment.requireValid()
             }
+
+    override suspend fun storeDelegationTxHash(roundId: String, bundleIndex: Int, txHash: String) =
+        votingDb.storeDelegationTxHash(roundId, bundleIndex, txHash)
+
+    override suspend fun getDelegationTxHash(
+        roundId: String,
+        bundleIndex: Int
+    ): VotingTxHashLookup =
+        runExpectedMissingRowLookup {
+            votingDb.getDelegationTxHash(roundId, bundleIndex).toVotingTxHashLookup()
+        } ?: VotingTxHashLookup.Missing
+
+    override suspend fun storeVoteTxHash(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int,
+        txHash: String
+    ) = votingDb.storeVoteTxHash(roundId, bundleIndex, proposalId, txHash)
+
+    override suspend fun markVoteSubmitted(roundId: String, bundleIndex: Int, proposalId: Int) =
+        votingDb.markVoteSubmitted(roundId, bundleIndex, proposalId)
+
+    override suspend fun getVoteTxHash(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int
+    ): VotingTxHashLookup =
+        runExpectedMissingRowLookup {
+            votingDb.getVoteTxHash(roundId, bundleIndex, proposalId).toVotingTxHashLookup()
+        } ?: VotingTxHashLookup.Missing
+
+    override suspend fun storeCommitmentBundle(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int,
+        commitment: JniVoteCommitmentResult,
+        vcTreePosition: Long
+    ) {
+        commitment.requireValid()
+        votingDb.storeCommitmentBundle(
+            roundId,
+            bundleIndex,
+            proposalId,
+            commitment,
+            vcTreePosition
+        )
+    }
+
+    override suspend fun getCommitmentBundle(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int
+    ): CommitmentBundleRecord? =
+        runExpectedMissingRowLookup {
+            votingDb
+                .getCommitmentBundle(roundId, bundleIndex, proposalId)
+                ?.toCommitmentBundleRecord()
+        }
+
+    override suspend fun clearRecoveryState(roundId: String) =
+        votingDb.clearRecoveryState(roundId)
+
+    override suspend fun recordShareDelegation(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int,
+        shareIndex: Int,
+        sentToUrls: List<String>,
+        nullifier: ByteArray,
+        submitAt: Long
+    ) {
+        nullifier.requireByteArraySize("nullifier", JNI_PROTOCOL_FIELD_BYTES_SIZE)
+        votingDb.recordShareDelegation(
+            roundId,
+            bundleIndex,
+            proposalId,
+            shareIndex,
+            sentToUrls,
+            nullifier,
+            submitAt
+        )
+    }
+
+    override suspend fun getShareDelegations(roundId: String): List<ShareDelegationRecord> =
+        votingDb
+            .getShareDelegations(roundId)
+            .map { it.toShareDelegationRecord() }
+
+    override suspend fun getUnconfirmedDelegations(roundId: String): List<ShareDelegationRecord> =
+        votingDb
+            .getUnconfirmedDelegations(roundId)
+            .map { it.toShareDelegationRecord() }
+
+    override suspend fun markShareConfirmed(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int,
+        shareIndex: Int
+    ) = votingDb.markShareConfirmed(roundId, bundleIndex, proposalId, shareIndex)
+
+    override suspend fun addSentServers(
+        roundId: String,
+        bundleIndex: Int,
+        proposalId: Int,
+        shareIndex: Int,
+        newUrls: List<String>
+    ) = votingDb.addSentServers(roundId, bundleIndex, proposalId, shareIndex, newUrls)
 }
 
 internal fun JniGovernancePczt.toGovernancePcztResult(): GovernancePcztResult {
@@ -912,6 +1161,36 @@ internal fun JniDelegationSubmissionResult.toDelegationSubmissionResult(): Deleg
     )
 }
 
+private fun String?.toVotingTxHashLookup(): VotingTxHashLookup =
+    if (this == null) {
+        VotingTxHashLookup.Missing
+    } else {
+        VotingTxHashLookup.Found(this)
+    }
+
+private fun JniCommitmentBundleRecord.toCommitmentBundleRecord(): CommitmentBundleRecord {
+    commitment.requireValid()
+    return CommitmentBundleRecord(
+        commitment = commitment,
+        vcTreePosition = vcTreePosition
+    )
+}
+
+private fun JniShareDelegationRecord.toShareDelegationRecord(): ShareDelegationRecord {
+    nullifier.requireByteArraySize("nullifier", JNI_PROTOCOL_FIELD_BYTES_SIZE)
+    return ShareDelegationRecord(
+        roundId = roundId,
+        bundleIndex = bundleIndex,
+        proposalId = proposalId,
+        shareIndex = shareIndex,
+        sentToUrls = sentToUrls,
+        nullifier = nullifier,
+        confirmed = confirmed,
+        submitAt = submitAt,
+        createdAt = createdAt
+    )
+}
+
 private fun JniVanWitness.requireValid() {
     authPath.requireByteArrayCount("authPath", JNI_VAN_WITNESS_PATH_DEPTH)
     authPath.requireEachByteArraySize("authPath", JNI_PROTOCOL_FIELD_BYTES_SIZE)
@@ -953,6 +1232,25 @@ private fun JniSharePayload.requireValid() {
 
 private fun ((Double) -> Unit).asVotingProgressCallback() =
     VotingProofProgressCallback { progress -> invoke(progress) }
+
+@Suppress("TooGenericExceptionCaught")
+private suspend fun <T> runExpectedMissingRowLookup(block: suspend () -> T): T? =
+    try {
+        block()
+    } catch (exception: RuntimeException) {
+        if (exception.isQueryReturnedNoRows()) {
+            null
+        } else {
+            throw exception
+        }
+    }
+
+private fun Throwable.isQueryReturnedNoRows(): Boolean =
+    generateSequence(this) { throwable -> throwable.cause }
+        .any { throwable ->
+            throwable.message
+                ?.contains("Query returned no rows", ignoreCase = true) == true
+        }
 
 private fun ByteArray.requireByteArraySize(name: String, expectedSize: Int) =
     require(size == expectedSize) {

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
@@ -990,9 +990,7 @@ internal class TypesafeVotingDbImpl(
         roundId: String,
         bundleIndex: Int
     ): VotingTxHashLookup =
-        runExpectedMissingRowLookup {
-            votingDb.getDelegationTxHash(roundId, bundleIndex).toVotingTxHashLookup()
-        } ?: VotingTxHashLookup.Missing
+        votingDb.getDelegationTxHash(roundId, bundleIndex).toVotingTxHashLookup()
 
     override suspend fun storeVoteTxHash(
         roundId: String,
@@ -1009,9 +1007,7 @@ internal class TypesafeVotingDbImpl(
         bundleIndex: Int,
         proposalId: Int
     ): VotingTxHashLookup =
-        runExpectedMissingRowLookup {
-            votingDb.getVoteTxHash(roundId, bundleIndex, proposalId).toVotingTxHashLookup()
-        } ?: VotingTxHashLookup.Missing
+        votingDb.getVoteTxHash(roundId, bundleIndex, proposalId).toVotingTxHashLookup()
 
     override suspend fun storeCommitmentBundle(
         roundId: String,
@@ -1035,11 +1031,9 @@ internal class TypesafeVotingDbImpl(
         bundleIndex: Int,
         proposalId: Int
     ): CommitmentBundleRecord? =
-        runExpectedMissingRowLookup {
-            votingDb
-                .getCommitmentBundle(roundId, bundleIndex, proposalId)
-                ?.toCommitmentBundleRecord()
-        }
+        votingDb
+            .getCommitmentBundle(roundId, bundleIndex, proposalId)
+            ?.toCommitmentBundleRecord()
 
     override suspend fun clearRecoveryState(roundId: String) =
         votingDb.clearRecoveryState(roundId)
@@ -1235,25 +1229,6 @@ private fun JniSharePayload.requireValid() {
 
 private fun ((Double) -> Unit).asVotingProgressCallback() =
     VotingProofProgressCallback { progress -> invoke(progress) }
-
-@Suppress("TooGenericExceptionCaught")
-private suspend fun <T> runExpectedMissingRowLookup(block: suspend () -> T): T? =
-    try {
-        block()
-    } catch (exception: RuntimeException) {
-        if (exception.isQueryReturnedNoRows()) {
-            null
-        } else {
-            throw exception
-        }
-    }
-
-private fun Throwable.isQueryReturnedNoRows(): Boolean =
-    generateSequence(this) { throwable -> throwable.cause }
-        .any { throwable ->
-            throwable.message
-                ?.contains("Query returned no rows", ignoreCase = true) == true
-        }
 
 private fun ByteArray.requireByteArraySize(name: String, expectedSize: Int) =
     require(size == expectedSize) {


### PR DESCRIPTION
Part of zodl-inc/zodl-android#2193.
Slice of zcash/zcash-android-wallet-sdk#1924 (umbrella draft PR being split into reviewable pieces).
Stacked on zcash/zcash-android-wallet-sdk#1952 (PR 7 — vote tree sync, commitment, and cast-vote payloads).
Resolves MOB-1109

## Why

Eighth slice of the Android shielded-voting integration. PR 7 (#1952) lands the
SDK-side path from snapshot-note witnesses to a fully signed cast-vote message.
This PR adds the recovery and share-tracking state that lets a wallet replay,
retry, and confirm those workflows after restart or partial failure.

Native side: a new `voting/recovery.rs` module exposes 12 JNI entry points
covering delegation/vote tx-hash store+lookup with typed missing-state, a
`markVoteSubmitted` flag, commitment-bundle persistence with hex-encoded JSON
storage, `clearRecoveryState`, share-delegation recording/listing, an
unconfirmed-delegations query, share confirmation, and additive
`addSentServers`. Commitment bundles round-trip through a shared
`JniVoteCommitmentResultPayload` builder so freshly built and replayed bundles
go through the same byte-boundary validation.

SDK side: 13 new suspend functions on `TypesafeVotingDb` + matching
`VotingDbBackend` / `RustVotingDbBackend` / `TypesafeVotingDbImpl` wiring, with
typed `VotingTxHashLookup` (`Missing` / `Found`), `CommitmentBundleRecord`,
and `ShareDelegationRecord` models so the SDK boundary distinguishes missing
state from native errors.

`zcash_voting` is bumped to 0.5.12 for the recovery DB methods this PR calls
and the matching governance/delegation hotkey-seed parameterization. No new
app-facing `Synchronizer` voting API is added.


## Validation

- `cargo check --manifest-path backend-lib/Cargo.toml --locked`
- `cargo fmt --manifest-path backend-lib/Cargo.toml --check`
- `./gradlew :backend-lib:compileReleaseKotlin :sdk-lib:compileReleaseKotlin`
- `./gradlew ktlint detektAll`
- `./gradlew checkProperties`
- `git diff --check`

# Author

- [x] **Self-review** your own code in GitHub web interface
- [x] Add **automated tests** as appropriate
- [x] Update the **manual tests** as appropriate
- [x] Check the **code coverage** report for the automated tests
- [x] Update **documentation** as appropriate
- [x] **Run the demo app** and try the changes
- [x] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer

# Reviewer

- [ ] Check the code with the Code Review Guidelines checklist
- [ ] Perform an **ad hoc review**
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation** as appropriate
- [ ] **Run the demo app** and try the changes
