### PR TITLE
Bump zcash_voting to 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added internal shielded voting recovery and share-tracking persistence for replaying,
   retrying, and confirming delegation and vote submission workflows.
 - Pinned `orchard` to `=0.13.1` with `unstable-voting-circuits` to match `zcash_voting` / `voting-circuits` requirements.
+- Updated `zcash_voting` to 0.7.0.
 
 ## [2.5.0] - 2026-05-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added internal shielded voting recovery and share-tracking persistence for replaying,
   retrying, and confirming delegation and vote submission workflows.
 - Pinned `orchard` to `=0.13.1` with `unstable-voting-circuits` to match `zcash_voting` / `voting-circuits` requirements.
-- Updated `zcash_voting` to 0.7.0.
+- Updated `zcash_voting` to 0.8.1.
 
 ## [2.5.0] - 2026-05-01
 

--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -7137,9 +7137,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb4c54bb4850795760612921fa2ac0a1b5e90f5af756d3f433b3990b916d8cfe"
+checksum = "c2345d90daf1c4c30c1e6276d0c3e1f7e7952d3923ed31abee22f3c7fa090dec"
 dependencies = [
  "anyhow",
  "blake2b_simd",

--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -6054,9 +6054,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vote-commitment-tree"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fb2456313f571003c0bed8d38fb166d78da85653caf828823c1a82f4e1aef1"
+checksum = "be25d43d8b918599f579168a7aa2c0a12b2557bdc641324510f0d5797b1d59ac"
 dependencies = [
  "anyhow",
  "ff",
@@ -6071,9 +6071,9 @@ dependencies = [
 
 [[package]]
 name = "vote-commitment-tree-client"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb05b7a0434a89c2d9017bbab9a5157f1992fb746dce58a1077669e9dd0a13c5"
+checksum = "4ad6904ca2fdff4e39cea4700e924227eda14fb123b4212f917d0aea2b0a39c8"
 dependencies = [
  "base64",
  "ff",
@@ -7137,9 +7137,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "0.5.12"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066eefe9678138a8450c20ec222da402bb92bb3f46351958a9661a75733c0bc8"
+checksum = "eb4c54bb4850795760612921fa2ac0a1b5e90f5af756d3f433b3990b916d8cfe"
 dependencies = [
  "anyhow",
  "blake2b_simd",

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -96,18 +96,18 @@ rust-analyzer = "0.0.1"
 # The Android JNI boundary for voting code is `src/main/rust/voting.rs`.
 # Its share-nullifier entry point forwards to
 # `zcash_voting::share_tracking::compute_share_nullifier`:
-# https://github.com/valargroup/zcash_voting/blob/zcash_voting-v0.5.12/zcash_voting/src/share_tracking.rs
+# https://github.com/valargroup/zcash_voting/blob/zcash_voting-v0.7.0/zcash_voting/src/share_tracking.rs
 #
 # The transitive `voting-circuits` dependency contains the share-reveal circuit
 # and the Poseidon-based `share_nullifier_hash` implementation:
-# https://github.com/valargroup/voting-circuits/blob/v0.4.1/voting-circuits/src/share_reveal/circuit.rs
+# https://github.com/valargroup/voting-circuits/blob/v0.4.2/voting-circuits/src/share_reveal/circuit.rs
 # Default features stay disabled. The `client-pir` feature is needed for
 # delegation proof precompute and proof generation. The `client-tree-sync`
 # feature is needed for vote commitment tree sync and VAN witnesses.
 # Expected PIR/tree-sync networking transitives include `pir-client`, `pir-types`,
 # `valar-ypir`, `valar-spiral-rs`, `vote-commitment-tree-client`, and
 # `hyper-rustls`.
-zcash_voting = { version = "0.5.12", default-features = false, features = [
+zcash_voting = { version = "0.7.0", default-features = false, features = [
     "client-pir",
     "client-tree-sync",
 ] }

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -96,7 +96,7 @@ rust-analyzer = "0.0.1"
 # The Android JNI boundary for voting code is `src/main/rust/voting.rs`.
 # Its share-nullifier entry point forwards to
 # `zcash_voting::share_tracking::compute_share_nullifier`:
-# https://github.com/valargroup/zcash_voting/blob/zcash_voting-v0.7.0/zcash_voting/src/share_tracking.rs
+# https://github.com/valargroup/zcash_voting/blob/zcash_voting-v0.8.1/zcash_voting/src/share_tracking.rs
 #
 # The transitive `voting-circuits` dependency contains the share-reveal circuit
 # and the Poseidon-based `share_nullifier_hash` implementation:
@@ -107,7 +107,7 @@ rust-analyzer = "0.0.1"
 # Expected PIR/tree-sync networking transitives include `pir-client`, `pir-types`,
 # `valar-ypir`, `valar-spiral-rs`, `vote-commitment-tree-client`, and
 # `hyper-rustls`.
-zcash_voting = { version = "0.7.0", default-features = false, features = [
+zcash_voting = { version = "0.8.1", default-features = false, features = [
     "client-pir",
     "client-tree-sync",
 ] }

--- a/backend-lib/src/main/rust/voting/notes.rs
+++ b/backend-lib/src/main/rust/voting/notes.rs
@@ -353,7 +353,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_gen
         let seed = java_secret_bytes_at_least(env, &seed, "seed", PROTOCOL_FIELD_BYTES)?;
         let round_id = java_string_to_rust(env, &round_id)?;
         let hotkey = db
-            .generate_hotkey(&round_id, seed.expose_secret())
+            .generate_hotkey(seed.expose_secret())
             .map_err(|e| anyhow!("generate_hotkey: {}", e))?;
         update_round_phase_forward(&db, &round_id, RoundPhase::HotkeyGenerated)?;
         make_jni_voting_hotkey(env, hotkey)


### PR DESCRIPTION
## Summary
- Bumps `zcash_voting` to `0.8.1` and refreshes the related lockfile entry.
- Updates the voting dependency notes for the resolved upstream tag.
- Keeps the existing hotkey generation adaptation for the upstream `generate_hotkey(seed)` API.

## Validation
- `cargo test --manifest-path backend-lib/Cargo.toml voting::`
- `./gradlew :backend-lib:testDebugUnitTest --tests cash.z.ecc.android.sdk.internal.model.voting.JniVotingModelsTest`
- `./gradlew :backend-lib:compileDebugAndroidTestKotlin :sdk-lib:compileDebugKotlin :sdk-lib:compileDebugAndroidTestKotlin`
