### PR TITLE
Bump zcash_voting to 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now takes the raw hotkey address directly, and a new `deriveHotkeyRawAddress` helper
   exposes raw-address derivation to callers that do not retain the hotkey seed.
 - Pinned `orchard` to `=0.13.1` with `unstable-voting-circuits` to match `zcash_voting` / `voting-circuits` requirements.
-- Updated `zcash_voting` to 0.8.1.
+- Pinned `zcash_voting` to `=0.10.1`.
 
 ## [2.5.0] - 2026-05-01
 

--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -6016,9 +6016,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vote-commitment-tree"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be25d43d8b918599f579168a7aa2c0a12b2557bdc641324510f0d5797b1d59ac"
+checksum = "870b893a2c53ec015d46fd3a33cf91715a9a968d34531208144f48e46398321c"
 dependencies = [
  "anyhow",
  "ff",
@@ -6033,9 +6033,9 @@ dependencies = [
 
 [[package]]
 name = "vote-commitment-tree-client"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad6904ca2fdff4e39cea4700e924227eda14fb123b4212f917d0aea2b0a39c8"
+checksum = "03af018a5afbd7e58f2b233c96e64cc581d56cf12dd7daedd337cf6eaa10f80e"
 dependencies = [
  "base64",
  "ff",
@@ -6049,9 +6049,9 @@ dependencies = [
 
 [[package]]
 name = "voting-circuits"
-version = "0.4.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0436d69b5884ca107db3de1be5e3e92981a35cd15dbfc6919361316a5dfa8e89"
+checksum = "30a5b61b6f99af50df900d839b9440fa36709166449c7fa831169391bc5f44bc"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -6060,6 +6060,7 @@ dependencies = [
  "halo2_poseidon",
  "halo2_proofs",
  "incrementalmerkletree",
+ "itertools 0.14.0",
  "lazy_static",
  "orchard",
  "pasta_curves",
@@ -7134,9 +7135,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "0.8.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2345d90daf1c4c30c1e6276d0c3e1f7e7952d3923ed31abee22f3c7fa090dec"
+checksum = "f23827ed8aa8fe8bd1bdda0f72cfffca36fe1d8fafde82e72b0f5561a7aae845"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -7151,19 +7152,24 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
+ "imt-tree",
  "incrementalmerkletree",
  "nonempty",
  "orchard",
  "pasta_curves",
  "pczt",
  "pir-client",
+ "pir-types",
  "rand 0.8.6",
  "rusqlite",
  "serde",
  "serde_json",
+ "sinsemilla",
  "subtle",
  "thiserror 2.0.18",
  "tokio",
+ "valar-spiral-rs",
+ "valar-ypir",
  "vote-commitment-tree",
  "vote-commitment-tree-client",
  "voting-circuits",

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -94,18 +94,18 @@ xz2 = { version = "0.1", features = ["static"] }
 # The Android JNI boundary for voting code is `src/main/rust/voting.rs`.
 # Its share-nullifier entry point forwards to
 # `zcash_voting::share_tracking::compute_share_nullifier`:
-# https://github.com/valargroup/zcash_voting/blob/zcash_voting-v0.8.1/zcash_voting/src/share_tracking.rs
+# https://github.com/valargroup/zcash_voting/blob/zcash_voting-v0.10.1/zcash_voting/src/share_tracking.rs
 #
 # The transitive `voting-circuits` dependency contains the share-reveal circuit
 # and the Poseidon-based `share_nullifier_hash` implementation:
-# https://github.com/valargroup/voting-circuits/blob/v0.4.2/voting-circuits/src/share_reveal/circuit.rs
+# https://github.com/valargroup/voting-circuits/blob/v0.6.0/voting-circuits/src/share_reveal/circuit.rs
 # Default features stay disabled. The `client-pir` feature is needed for
 # delegation proof precompute and proof generation. The `client-tree-sync`
 # feature is needed for vote commitment tree sync and VAN witnesses.
 # Expected PIR/tree-sync networking transitives include `pir-client`, `pir-types`,
 # `valar-ypir`, `valar-spiral-rs`, `vote-commitment-tree-client`, and
 # `hyper-rustls`.
-zcash_voting = { version = "0.8.1", default-features = false, features = [
+zcash_voting = { version = "=0.10.1", default-features = false, features = [
     "client-pir",
     "client-tree-sync",
 ] }


### PR DESCRIPTION
Updates the Android backend Rust dependency to zcash_voting 0.10.1 and refreshes the locked voting crate set to the published releases. The nearby Cargo comments and changelog now point at the matching zcash_voting and voting-circuits tags.

Validation:
- cargo metadata --manifest-path backend-lib/Cargo.toml --locked --format-version 1
- cargo tree --manifest-path backend-lib/Cargo.toml --locked -i zcash_voting
- cargo check --manifest-path backend-lib/Cargo.toml --locked
- cargo test --manifest-path backend-lib/Cargo.toml --locked voting::

Note: full backend cargo test currently fails in utils::exception::tests::unknown_any, while all voting tests pass.