### PR TITLE
chore: Unpin zcash_voting from Cargo.toml in favor of lockfile

### DIFF
--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -105,7 +105,7 @@ xz2 = { version = "0.1", features = ["static"] }
 # Expected PIR/tree-sync networking transitives include `pir-client`, `pir-types`,
 # `valar-ypir`, `valar-spiral-rs`, `vote-commitment-tree-client`, and
 # `hyper-rustls`.
-zcash_voting = { version = "=0.10.1", default-features = false, features = [
+zcash_voting = { version = "0.10.1", default-features = false, features = [
     "client-pir",
     "client-tree-sync",
 ] }


### PR DESCRIPTION
This PR unpins zcash_voting in `Cargo.toml`, in favor of lockfile pinning. Pin was mistakenly added in https://github.com/zcash/zcash-android-wallet-sdk/pull/1961