### PR TITLE
Use reorg-safe tree state for new wallets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- New wallets now fetch the chain-tip tree state from the lightwalletd server, eliminating unnecessary block
-  scanning for wallets with no transaction history. Initialization falls back to the bundled checkpoint if this
-  optimization does not complete within 5 seconds.
+- New wallets now fetch a recent tree state from the lightwalletd server, reducing unnecessary block
+  scanning for wallets with no transaction history while retaining reorg safety. Initialization falls back
+  to the bundled checkpoint if this optimization does not complete within 5 seconds.
 - `Synchronizer.broadcaster` API for creating transactions without immediate
   submission and submitting stored transactions to selected lightwalletd
   endpoints. Automatic retry uses the endpoints submitted through the

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
@@ -1149,7 +1149,11 @@ internal suspend fun resolveWalletInitializationState(
 
     is WalletInitMode.NewWallet -> {
         WalletInitializationState(
-            treeState = downloader.fetchNewWalletTreeState(sdkFlags, newWalletTreeStateTimeout) ?: fallbackTreeState,
+            treeState =
+                downloader.fetchNewWalletTreeState(
+                    sdkFlags,
+                    newWalletTreeStateTimeout
+                ) ?: fallbackTreeState,
             recoverUntil = null
         )
     }
@@ -1189,16 +1193,18 @@ private suspend fun CompactBlockDownloader.fetchNewWalletTreeState(
     }.also {
         if (!completed) {
             Twig.warn {
-                "Chain tip tree state fetch for new wallet timed out after $timeout, falling back to bundled checkpoint"
+                "Recent tree state fetch for new wallet timed out after $timeout, falling back to bundled checkpoint"
             }
         }
     }
 }
 
-private suspend fun CompactBlockDownloader.fetchNewWalletTreeState(sdkFlags: SdkFlags): TreeState? =
+private suspend fun CompactBlockDownloader.fetchNewWalletTreeState(
+    sdkFlags: SdkFlags
+): TreeState? =
     when (val heightResponse = getLatestBlockHeight(sdkFlags ifTor ServiceMode.UniqueTor)) {
         is Response.Success -> {
-            fetchTreeStateAtTip(heightResponse.result, sdkFlags)
+            fetchTreeStateNearTip(heightResponse.result, sdkFlags)
         }
 
         is Response.Failure -> {
@@ -1210,19 +1216,26 @@ private suspend fun CompactBlockDownloader.fetchNewWalletTreeState(sdkFlags: Sdk
         }
     }
 
-private suspend fun CompactBlockDownloader.fetchTreeStateAtTip(
+private suspend fun CompactBlockDownloader.fetchTreeStateNearTip(
     tipHeight: BlockHeightUnsafe,
     sdkFlags: SdkFlags
-): TreeState? =
-    when (
+): TreeState? {
+    val treeStateHeight =
+        BlockHeightUnsafe(
+            tipHeight.value - CompactBlockProcessor.MAX_REORG_SIZE
+        )
+
+    return when (
         val treeStateResponse =
             getTreeState(
-                height = tipHeight,
+                height = treeStateHeight,
                 serviceMode = sdkFlags ifTor ServiceMode.UniqueTor
             )
     ) {
         is Response.Success -> {
-            Twig.info { "New wallet: using chain tip tree state at height ${tipHeight.value}" }
+            Twig.info {
+                "New wallet: using reorg-safe tree state at height ${treeStateHeight.value}, tip ${tipHeight.value}"
+            }
             TreeState.new(treeStateResponse.result)
         }
 
@@ -1234,3 +1247,4 @@ private suspend fun CompactBlockDownloader.fetchTreeStateAtTip(
             null
         }
     }
+}

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/SynchronizerWalletInitializationTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/SynchronizerWalletInitializationTest.kt
@@ -1,5 +1,6 @@
 package cash.z.ecc.android.sdk
 
+import cash.z.ecc.android.sdk.block.processor.CompactBlockProcessor
 import cash.z.ecc.android.sdk.internal.block.CompactBlockDownloader
 import cash.z.ecc.android.sdk.internal.model.JniBlockMeta
 import cash.z.ecc.android.sdk.internal.model.TreeState
@@ -29,34 +30,35 @@ import kotlin.time.Duration.Companion.milliseconds
 
 class SynchronizerWalletInitializationTest {
     @Test
-    fun new_wallet_uses_chain_tip_tree_state_when_fetches_succeed() =
+    fun new_wallet_uses_reorg_safe_tree_state_when_fetches_succeed() =
         runBlocking {
             val tipHeight = BlockHeightUnsafe(2_000_000)
-            val chainTipTreeState = treeStateUnsafe(height = tipHeight.value)
+            val treeStateHeight = BlockHeightUnsafe(tipHeight.value - CompactBlockProcessor.MAX_REORG_SIZE)
+            val recentTreeState = treeStateUnsafe(height = treeStateHeight.value)
             val walletClient =
                 FakeCombinedWalletClient(
                     latestBlockHeightResponse = Response.Success(tipHeight),
-                    treeStateResponse = Response.Success(chainTipTreeState)
+                    treeStateResponse = Response.Success(recentTreeState)
                 )
 
             val result =
                 resolveWalletInitializationState(
                     downloader = downloader(walletClient),
-                    fallbackTreeState = treeState(height = 1_000_000),
+                    fallbackTreeState = treeState(height = fallbackTreeStateHeight.value),
                     sdkFlags = sdkFlags,
                     walletInitMode = WalletInitMode.NewWallet
                 )
 
-            assertTrue(chainTipTreeState.encoded.contentEquals(result.treeState.encoded))
+            assertTrue(recentTreeState.encoded.contentEquals(result.treeState.encoded))
             assertEquals(null, result.recoverUntil)
             assertEquals(listOf<ServiceMode>(ServiceMode.Direct), walletClient.latestBlockHeightRequests)
-            assertEquals(listOf(TreeStateRequest(tipHeight, ServiceMode.Direct)), walletClient.treeStateRequests)
+            assertEquals(listOf(TreeStateRequest(treeStateHeight, ServiceMode.Direct)), walletClient.treeStateRequests)
         }
 
     @Test
     fun new_wallet_falls_back_to_checkpoint_when_height_fetch_fails() =
         runBlocking {
-            val fallbackTreeState = treeState(height = 1_000_000)
+            val fallbackTreeState = treeState(height = fallbackTreeStateHeight.value)
             val walletClient =
                 FakeCombinedWalletClient(
                     latestBlockHeightResponse = failure(),
@@ -80,7 +82,7 @@ class SynchronizerWalletInitializationTest {
     @Test
     fun new_wallet_falls_back_to_checkpoint_when_height_fetch_times_out() =
         runBlocking {
-            val fallbackTreeState = treeState(height = 1_000_000)
+            val fallbackTreeState = treeState(height = fallbackTreeStateHeight.value)
             val neverCompletes = CompletableDeferred<Unit>()
             val walletClient =
                 FakeCombinedWalletClient(
@@ -108,7 +110,8 @@ class SynchronizerWalletInitializationTest {
     fun new_wallet_falls_back_to_checkpoint_when_tree_state_fetch_fails() =
         runBlocking {
             val tipHeight = BlockHeightUnsafe(2_000_000)
-            val fallbackTreeState = treeState(height = 1_000_000)
+            val treeStateHeight = BlockHeightUnsafe(tipHeight.value - CompactBlockProcessor.MAX_REORG_SIZE)
+            val fallbackTreeState = treeState(height = fallbackTreeStateHeight.value)
             val walletClient =
                 FakeCombinedWalletClient(
                     latestBlockHeightResponse = Response.Success(tipHeight),
@@ -126,14 +129,15 @@ class SynchronizerWalletInitializationTest {
             assertSame(fallbackTreeState, result.treeState)
             assertEquals(null, result.recoverUntil)
             assertEquals(listOf<ServiceMode>(ServiceMode.Direct), walletClient.latestBlockHeightRequests)
-            assertEquals(listOf(TreeStateRequest(tipHeight, ServiceMode.Direct)), walletClient.treeStateRequests)
+            assertEquals(listOf(TreeStateRequest(treeStateHeight, ServiceMode.Direct)), walletClient.treeStateRequests)
         }
 
     @Test
     fun new_wallet_falls_back_to_checkpoint_when_tree_state_fetch_times_out() =
         runBlocking {
             val tipHeight = BlockHeightUnsafe(2_000_000)
-            val fallbackTreeState = treeState(height = 1_000_000)
+            val treeStateHeight = BlockHeightUnsafe(tipHeight.value - CompactBlockProcessor.MAX_REORG_SIZE)
+            val fallbackTreeState = treeState(height = fallbackTreeStateHeight.value)
             val neverCompletes = CompletableDeferred<Unit>()
             val walletClient =
                 FakeCombinedWalletClient(
@@ -154,7 +158,7 @@ class SynchronizerWalletInitializationTest {
             assertSame(fallbackTreeState, result.treeState)
             assertEquals(null, result.recoverUntil)
             assertEquals(listOf<ServiceMode>(ServiceMode.Direct), walletClient.latestBlockHeightRequests)
-            assertEquals(listOf(TreeStateRequest(tipHeight, ServiceMode.Direct)), walletClient.treeStateRequests)
+            assertEquals(listOf(TreeStateRequest(treeStateHeight, ServiceMode.Direct)), walletClient.treeStateRequests)
         }
 
     private class FakeCombinedWalletClient(
@@ -244,6 +248,7 @@ class SynchronizerWalletInitializationTest {
 
     private companion object {
         val sdkFlags = SdkFlags(isTorEnabled = false, isExchangeRateEnabled = false)
+        val fallbackTreeStateHeight = BlockHeight(1_000_000)
 
         fun downloader(walletClient: CombinedWalletClient) =
             CompactBlockDownloader(walletClient, FakeCompactBlockRepository())


### PR DESCRIPTION
New wallets now request the lightwalletd tree state 100 blocks below the reported tip instead of at the exact tip. This keeps the fast initialization path while avoiding a tree state that is still inside the reorg window.

Validation: `./scripts/ci-local.sh quick`