### PR TITLE
[MOB-1339] Route legacy create-and-submit through PendingSubmitPlanStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The legacy `Synchronizer.createProposedTransactions` and `Synchronizer.createTransactionFromPczt`
+  helpers now register transactions in `PendingSubmitPlanStore` so the sync loop's
+  `resubmitUnminedTransactions` step correctly skips in-flight submits instead of racing them
+  with a second `txManager.submit()` and producing `transaction already exists in mempool`
+  rejections.
+
 ### Added
 - New wallets now fetch a recent tree state from the lightwalletd server, reducing unnecessary block
   scanning for wallets with no transaction history while retaining reorg safety. Initialization falls back

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,19 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - The legacy `Synchronizer.createProposedTransactions` and `Synchronizer.createTransactionFromPczt`
-  helpers now register transactions in `PendingSubmitPlanStore` so the sync loop's
-  `resubmitUnminedTransactions` step correctly skips in-flight submits instead of racing them
-  with a second `txManager.submit()` and producing `transaction already exists in mempool`
-  rejections. The public `Broadcaster.submit` and both legacy helpers also record their endpoint
-  after the submit RPC returns (rather than before), so the in-flight window stays at
-  `AwaitingPlan`; the endpoint write is wrapped in `NonCancellable` so a coroutine cancellation
-  mid-submit cannot leave the plan stranded at `AwaitingPlan` forever.
+  helpers now register transactions in `PendingSubmitPlanStore`. Before this change the legacy
+  paths bypassed the plan store entirely, so a sync-loop `resubmitUnminedTransactions` tick that
+  fired during the active `submit()` RPC could race the foreground submit with a second
+  `txManager.submit()`. With the plan-store dance, the in-flight window is `AwaitingPlan` and the
+  resubmit step skips it. Note that `resubmitUnminedTransactions` is DB-driven (loads
+  unmined-and-not-expired txs from the wallet DB) and does not query the mempool, so a tx that
+  has been accepted into a server's mempool but not yet mined will still be re-broadcast on the
+  next sync tick — that mempool-duplication path is handled by the "verify against the server"
+  reclassification (separate `## Fixed` entry below). This entry narrows the *in-flight* race
+  window specifically. The public `Broadcaster.submit` and both legacy helpers record their
+  endpoint after the submit RPC returns (rather than before), and the write is wrapped in
+  `NonCancellable` so a coroutine cancellation mid-submit cannot leave the plan stranded at
+  `AwaitingPlan`.
 - `Synchronizer.submitTransaction` (and the broadcaster equivalent) now verifies submit failures
   against the server before surfacing them: when the submit RPC returns a non-zero error code
   (and not a gRPC-layer failure), the SDK immediately asks the same lightwalletd whether the tx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   helpers now register transactions in `PendingSubmitPlanStore` so the sync loop's
   `resubmitUnminedTransactions` step correctly skips in-flight submits instead of racing them
   with a second `txManager.submit()` and producing `transaction already exists in mempool`
-  rejections.
+  rejections. The public `Broadcaster.submit` and both legacy helpers also record their endpoint
+  after the submit RPC returns (rather than before), so the in-flight window stays at
+  `AwaitingPlan`; the endpoint write is wrapped in `NonCancellable` so a coroutine cancellation
+  mid-submit cannot leave the plan stranded at `AwaitingPlan` forever.
 - `Synchronizer.submitTransaction` (and the broadcaster equivalent) now verifies submit failures
   against the server before surfacing them: when the submit RPC returns a non-zero error code
   (and not a gRPC-layer failure), the SDK immediately asks the same lightwalletd whether the tx

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/SdkBroadcaster.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/SdkBroadcaster.kt
@@ -50,31 +50,38 @@ internal class SdkBroadcaster(
         return transactionSubmitter.submit(transaction, endpoint)
     }
 
-    // Legacy Synchronizer APIs stay eligible for automatic resubmission, so these helpers
-    // bypass public Broadcaster methods that record submitted endpoints.
+    // Legacy Synchronizer APIs route through the same plan-store machinery as the public
+    // Broadcaster so the sync-loop's resubmit step skips in-flight submits.
     internal suspend fun createAndSubmitProposedTransactions(
         proposal: Proposal,
         usk: UnifiedSpendingKey,
         endpoint: LightWalletEndpoint
     ): Flow<TransactionSubmitResult> =
-        txManager
-            .createProposedTransactions(proposal, usk)
-            .map { it.toCreatedTransaction() }
-            .createSubmitResultFlow { transaction ->
-                transactionSubmitter.submit(transaction, endpoint)
-            }
+        pendingSubmitPlanStore.createAndMarkAwaitingSubmitPlan {
+            txManager
+                .createProposedTransactions(proposal, usk)
+                .map { it.toCreatedTransaction() }
+        }.createSubmitResultFlow { transaction ->
+            pendingSubmitPlanStore.addSubmitEndpoint(transaction, endpoint)
+            transactionSubmitter.submit(transaction, endpoint)
+        }
 
     internal suspend fun createAndSubmitTransactionFromPczt(
         pcztWithProofs: Pczt,
         pcztWithSignatures: Pczt,
         endpoint: LightWalletEndpoint
     ): Flow<TransactionSubmitResult> =
-        listOf(
-            txManager
-                .extractAndStoreTxFromPczt(pcztWithProofs, pcztWithSignatures)
-                .toCreatedTransaction()
-        ).asFlow()
-            .map { transaction -> transactionSubmitter.submit(transaction, endpoint) }
+        pendingSubmitPlanStore.createAndMarkAwaitingSubmitPlan {
+            listOf(
+                txManager
+                    .extractAndStoreTxFromPczt(pcztWithProofs, pcztWithSignatures)
+                    .toCreatedTransaction()
+            )
+        }.asFlow()
+            .map { transaction ->
+                pendingSubmitPlanStore.addSubmitEndpoint(transaction, endpoint)
+                transactionSubmitter.submit(transaction, endpoint)
+            }
 }
 
 internal interface TransactionSubmitter {

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/SdkBroadcaster.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/SdkBroadcaster.kt
@@ -45,16 +45,7 @@ internal class SdkBroadcaster(
     override suspend fun submit(
         transaction: CreatedTransaction,
         endpoint: LightWalletEndpoint
-    ): TransactionSubmitResult {
-        // Record the endpoint AFTER the submit returns so the in-flight window stays at
-        // AwaitingPlan (or the prior Ready state) — the sync loop's resubmit step skips
-        // AwaitingPlan and otherwise dedupes against the endpoints recorded here, so
-        // recording before the submit returns would let a concurrent resubmit race the
-        // in-flight broadcast against an endpoint we've claimed but not actually hit yet.
-        val result = transactionSubmitter.submit(transaction, endpoint)
-        pendingSubmitPlanStore.addSubmitEndpoint(transaction, endpoint)
-        return result
-    }
+    ): TransactionSubmitResult = recordingEndpointAfterSubmit(transaction, endpoint)
 
     // Legacy Synchronizer APIs route through the same plan-store machinery as the public
     // Broadcaster so the sync-loop's resubmit step skips in-flight submits.
@@ -69,9 +60,7 @@ internal class SdkBroadcaster(
                     .createProposedTransactions(proposal, usk)
                     .map { it.toCreatedTransaction() }
             }.createSubmitResultFlow { transaction ->
-                val result = transactionSubmitter.submit(transaction, endpoint)
-                pendingSubmitPlanStore.addSubmitEndpoint(transaction, endpoint)
-                result
+                recordingEndpointAfterSubmit(transaction, endpoint)
             }
 
     internal suspend fun createAndSubmitTransactionFromPczt(
@@ -88,10 +77,24 @@ internal class SdkBroadcaster(
                 )
             }.asFlow()
             .map { transaction ->
-                val result = transactionSubmitter.submit(transaction, endpoint)
-                pendingSubmitPlanStore.addSubmitEndpoint(transaction, endpoint)
-                result
+                recordingEndpointAfterSubmit(transaction, endpoint)
             }
+
+    // Record the endpoint after submit returns so the in-flight window stays at AwaitingPlan
+    // and the sync loop's resubmit step doesn't race it. NonCancellable so a cancelled submit
+    // doesn't strand the plan at AwaitingPlan forever — the resubmit loop skips that state.
+    private suspend fun recordingEndpointAfterSubmit(
+        transaction: CreatedTransaction,
+        endpoint: LightWalletEndpoint
+    ): TransactionSubmitResult {
+        try {
+            return transactionSubmitter.submit(transaction, endpoint)
+        } finally {
+            withContext(NonCancellable) {
+                pendingSubmitPlanStore.addSubmitEndpoint(transaction, endpoint)
+            }
+        }
+    }
 }
 
 internal interface TransactionSubmitter {
@@ -127,6 +130,8 @@ private fun List<CreatedTransaction>.createSubmitResultFlow(
     return asFlow()
         .map { transaction ->
             if (anySubmissionFailed) {
+                // Skip both submit and addSubmitEndpoint — later legs of dependent proposals
+                // (shield → spend) stay AwaitingPlan and are skipped by the resubmit loop.
                 TransactionSubmitResult.NotAttempted(transaction.txId)
             } else {
                 val submission = submit(transaction)

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/SdkBroadcaster.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/SdkBroadcaster.kt
@@ -46,8 +46,14 @@ internal class SdkBroadcaster(
         transaction: CreatedTransaction,
         endpoint: LightWalletEndpoint
     ): TransactionSubmitResult {
+        // Record the endpoint AFTER the submit returns so the in-flight window stays at
+        // AwaitingPlan (or the prior Ready state) — the sync loop's resubmit step skips
+        // AwaitingPlan and otherwise dedupes against the endpoints recorded here, so
+        // recording before the submit returns would let a concurrent resubmit race the
+        // in-flight broadcast against an endpoint we've claimed but not actually hit yet.
+        val result = transactionSubmitter.submit(transaction, endpoint)
         pendingSubmitPlanStore.addSubmitEndpoint(transaction, endpoint)
-        return transactionSubmitter.submit(transaction, endpoint)
+        return result
     }
 
     // Legacy Synchronizer APIs route through the same plan-store machinery as the public
@@ -57,30 +63,34 @@ internal class SdkBroadcaster(
         usk: UnifiedSpendingKey,
         endpoint: LightWalletEndpoint
     ): Flow<TransactionSubmitResult> =
-        pendingSubmitPlanStore.createAndMarkAwaitingSubmitPlan {
-            txManager
-                .createProposedTransactions(proposal, usk)
-                .map { it.toCreatedTransaction() }
-        }.createSubmitResultFlow { transaction ->
-            pendingSubmitPlanStore.addSubmitEndpoint(transaction, endpoint)
-            transactionSubmitter.submit(transaction, endpoint)
-        }
+        pendingSubmitPlanStore
+            .createAndMarkAwaitingSubmitPlan {
+                txManager
+                    .createProposedTransactions(proposal, usk)
+                    .map { it.toCreatedTransaction() }
+            }.createSubmitResultFlow { transaction ->
+                val result = transactionSubmitter.submit(transaction, endpoint)
+                pendingSubmitPlanStore.addSubmitEndpoint(transaction, endpoint)
+                result
+            }
 
     internal suspend fun createAndSubmitTransactionFromPczt(
         pcztWithProofs: Pczt,
         pcztWithSignatures: Pczt,
         endpoint: LightWalletEndpoint
     ): Flow<TransactionSubmitResult> =
-        pendingSubmitPlanStore.createAndMarkAwaitingSubmitPlan {
-            listOf(
-                txManager
-                    .extractAndStoreTxFromPczt(pcztWithProofs, pcztWithSignatures)
-                    .toCreatedTransaction()
-            )
-        }.asFlow()
+        pendingSubmitPlanStore
+            .createAndMarkAwaitingSubmitPlan {
+                listOf(
+                    txManager
+                        .extractAndStoreTxFromPczt(pcztWithProofs, pcztWithSignatures)
+                        .toCreatedTransaction()
+                )
+            }.asFlow()
             .map { transaction ->
+                val result = transactionSubmitter.submit(transaction, endpoint)
                 pendingSubmitPlanStore.addSubmitEndpoint(transaction, endpoint)
-                transactionSubmitter.submit(transaction, endpoint)
+                result
             }
 }
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/SdkBroadcaster.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/SdkBroadcaster.kt
@@ -81,8 +81,9 @@ internal class SdkBroadcaster(
             }
 
     // Record the endpoint after submit returns so the in-flight window stays at AwaitingPlan
-    // and the sync loop's resubmit step doesn't race it. NonCancellable so a cancelled submit
-    // doesn't strand the plan at AwaitingPlan forever — the resubmit loop skips that state.
+    // and the sync loop's resubmit step doesn't race it. finally + NonCancellable fires on
+    // every exit (Success/Failure/throw) — AwaitingPlan strands the tx (resubmit skips that
+    // state), Ready is the state the resubmit loop retries through SubmitPlanExecutor.
     private suspend fun recordingEndpointAfterSubmit(
         transaction: CreatedTransaction,
         endpoint: LightWalletEndpoint

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/transaction/SdkBroadcasterTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/transaction/SdkBroadcasterTest.kt
@@ -144,7 +144,7 @@ class SdkBroadcasterTest {
         }
 
     @Test
-    fun sdk_legacy_proposed_transactions_do_not_register_submit_plans() =
+    fun sdk_legacy_proposed_transactions_register_submit_plan_with_endpoint() =
         runBlocking {
             val endpoint = LightWalletEndpoint("current.z.cash", 443, true)
             val encodedTransaction = encodedTransaction(8)
@@ -158,7 +158,80 @@ class SdkBroadcasterTest {
                     .toList()
 
             assertEquals(listOf(TransactionSubmitResult.Success(encodedTransaction.txId)), result)
-            assertEquals(null, pendingSubmitPlanStore.getSubmitPlan(encodedTransaction.txId))
+            assertEquals(
+                PendingSubmitPlanStore.StoredSubmitPlan.Ready(TransactionSubmitPlan(listOf(endpoint))),
+                pendingSubmitPlanStore.getSubmitPlan(encodedTransaction.txId)
+            )
+        }
+
+    @Test
+    fun sdk_legacy_pczt_transactions_register_submit_plan_with_endpoint() =
+        runBlocking {
+            val endpoint = LightWalletEndpoint("current.z.cash", 443, true)
+            val encodedTransaction = encodedTransaction(10)
+            val txManager = FakeOutboundTransactionManager(pcztTransaction = encodedTransaction)
+            val pendingSubmitPlanStore = PendingSubmitPlanStore()
+            val broadcaster = SdkBroadcaster(txManager, FakeTransactionSubmitter(), pendingSubmitPlanStore)
+
+            val result =
+                broadcaster
+                    .createAndSubmitTransactionFromPczt(
+                        Pczt(byteArrayOf(1)),
+                        Pczt(byteArrayOf(2)),
+                        endpoint
+                    ).toList()
+
+            assertEquals(listOf(TransactionSubmitResult.Success(encodedTransaction.txId)), result)
+            assertEquals(
+                PendingSubmitPlanStore.StoredSubmitPlan.Ready(TransactionSubmitPlan(listOf(endpoint))),
+                pendingSubmitPlanStore.getSubmitPlan(encodedTransaction.txId)
+            )
+        }
+
+    @Test
+    fun sdk_legacy_proposed_transactions_mark_awaiting_plan_before_submit_completes() =
+        runBlocking {
+            val endpoint = LightWalletEndpoint("current.z.cash", 443, true)
+            val encodedTransaction = encodedTransaction(11)
+            val createStarted = CompletableDeferred<Unit>()
+            val allowCreateToFinish = CompletableDeferred<Unit>()
+            val pendingSubmitPlanStore = PendingSubmitPlanStore()
+            val txManager =
+                FakeOutboundTransactionManager(
+                    proposedTransactions = listOf(encodedTransaction),
+                    beforeReturningProposedTransactions = {
+                        createStarted.complete(Unit)
+                        allowCreateToFinish.await()
+                    }
+                )
+            val broadcaster = SdkBroadcaster(txManager, FakeTransactionSubmitter(), pendingSubmitPlanStore)
+
+            val createJob =
+                async(start = CoroutineStart.UNDISPATCHED) {
+                    broadcaster
+                        .createAndSubmitProposedTransactions(fakeProposal(), fakeUsk(), endpoint)
+                        .toList()
+                }
+
+            createStarted.await()
+
+            val retainCompleted = CompletableDeferred<Unit>()
+            val retainJob =
+                launch(start = CoroutineStart.UNDISPATCHED) {
+                    pendingSubmitPlanStore.loadTransactionsAndRetainSubmitPlans(
+                        loadTransactions = { listOf(encodedTransaction.txId) },
+                        transactionId = { it }
+                    )
+                    retainCompleted.complete(Unit)
+                }
+
+            assertFalse(retainCompleted.isCompleted)
+
+            allowCreateToFinish.complete(Unit)
+
+            createJob.await()
+            retainCompleted.await()
+            retainJob.join()
         }
 
     @Test

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/transaction/SdkBroadcasterTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/transaction/SdkBroadcasterTest.kt
@@ -13,6 +13,7 @@ import cash.z.ecc.android.sdk.model.TransactionSubmitResult
 import cash.z.ecc.android.sdk.model.UnifiedSpendingKey
 import cash.z.ecc.android.sdk.model.Zatoshi
 import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
+import java.io.IOException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
@@ -348,6 +349,30 @@ class SdkBroadcasterTest {
             submitStarted.await()
             submitJob.cancelAndJoin()
 
+            assertEquals(
+                PendingSubmitPlanStore.StoredSubmitPlan.Ready(TransactionSubmitPlan(listOf(endpoint))),
+                pendingSubmitPlanStore.getSubmitPlan(transaction.txId)
+            )
+        }
+
+    @Test
+    fun broadcaster_submit_records_endpoint_even_if_submit_throws_non_cancellation() =
+        runBlocking {
+            val endpoint = LightWalletEndpoint("submit.z.cash", 443, true)
+            val transaction = encodedTransaction(15).toCreatedTransactionForTest()
+            val pendingSubmitPlanStore = PendingSubmitPlanStore()
+            val boom = IOException("simulated network failure")
+            val submitter = FakeTransactionSubmitter(beforeReturning = { throw boom })
+            val broadcaster = SdkBroadcaster(FakeOutboundTransactionManager(), submitter, pendingSubmitPlanStore)
+            pendingSubmitPlanStore.createAndMarkAwaitingSubmitPlan { listOf(transaction) }
+
+            val thrown =
+                runCatching { broadcaster.submit(transaction, endpoint) }.exceptionOrNull()
+
+            assertEquals(boom, thrown)
+            // The endpoint must be recorded so the resubmit loop retries through SubmitPlanExecutor.
+            // Leaving the plan at AwaitingPlan would strand the tx — the resubmit loop skips
+            // AwaitingPlan entries on the assumption they were never submitted from this session.
             assertEquals(
                 PendingSubmitPlanStore.StoredSubmitPlan.Ready(TransactionSubmitPlan(listOf(endpoint))),
                 pendingSubmitPlanStore.getSubmitPlan(transaction.txId)

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/transaction/SdkBroadcasterTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/transaction/SdkBroadcasterTest.kt
@@ -189,7 +189,7 @@ class SdkBroadcasterTest {
         }
 
     @Test
-    fun sdk_legacy_proposed_transactions_mark_awaiting_plan_before_submit_completes() =
+    fun sdk_legacy_proposed_transactions_block_retain_while_create_in_progress() =
         runBlocking {
             val endpoint = LightWalletEndpoint("current.z.cash", 443, true)
             val encodedTransaction = encodedTransaction(11)
@@ -232,6 +232,92 @@ class SdkBroadcasterTest {
             createJob.await()
             retainCompleted.await()
             retainJob.join()
+        }
+
+    @Test
+    fun sdk_legacy_proposed_transactions_stay_awaiting_plan_while_submit_in_progress() =
+        runBlocking {
+            val endpoint = LightWalletEndpoint("current.z.cash", 443, true)
+            val encodedTransaction = encodedTransaction(12)
+            val submitStarted = CompletableDeferred<Unit>()
+            val allowSubmitToFinish = CompletableDeferred<Unit>()
+            val pendingSubmitPlanStore = PendingSubmitPlanStore()
+            val txManager = FakeOutboundTransactionManager(proposedTransactions = listOf(encodedTransaction))
+            val submitter =
+                FakeTransactionSubmitter(
+                    beforeReturning = {
+                        submitStarted.complete(Unit)
+                        allowSubmitToFinish.await()
+                    }
+                )
+            val broadcaster = SdkBroadcaster(txManager, submitter, pendingSubmitPlanStore)
+
+            val submitJob =
+                async(start = CoroutineStart.UNDISPATCHED) {
+                    broadcaster
+                        .createAndSubmitProposedTransactions(fakeProposal(), fakeUsk(), endpoint)
+                        .toList()
+                }
+
+            submitStarted.await()
+
+            // While submit is in flight, plan must still be AwaitingPlan so the sync loop's
+            // resubmitUnminedTransactions step skips it instead of racing the in-flight broadcast.
+            assertEquals(
+                PendingSubmitPlanStore.StoredSubmitPlan.AwaitingPlan,
+                pendingSubmitPlanStore.getSubmitPlan(encodedTransaction.txId)
+            )
+
+            allowSubmitToFinish.complete(Unit)
+            submitJob.await()
+
+            assertEquals(
+                PendingSubmitPlanStore.StoredSubmitPlan.Ready(TransactionSubmitPlan(listOf(endpoint))),
+                pendingSubmitPlanStore.getSubmitPlan(encodedTransaction.txId)
+            )
+        }
+
+    @Test
+    fun broadcaster_submit_stays_awaiting_plan_while_submit_in_progress() =
+        runBlocking {
+            val endpoint = LightWalletEndpoint("submit.z.cash", 443, true)
+            val encodedTransaction = encodedTransaction(13)
+            val submitStarted = CompletableDeferred<Unit>()
+            val allowSubmitToFinish = CompletableDeferred<Unit>()
+            val pendingSubmitPlanStore = PendingSubmitPlanStore()
+            val submitter =
+                FakeTransactionSubmitter(
+                    beforeReturning = {
+                        submitStarted.complete(Unit)
+                        allowSubmitToFinish.await()
+                    }
+                )
+            val broadcaster = SdkBroadcaster(FakeOutboundTransactionManager(), submitter, pendingSubmitPlanStore)
+            val transaction = encodedTransaction.toCreatedTransactionForTest()
+
+            // The public Broadcaster.submit expects createProposedTransactions has already
+            // registered the txid as AwaitingPlan. Simulate that here.
+            pendingSubmitPlanStore.createAndMarkAwaitingSubmitPlan { listOf(transaction) }
+
+            val submitJob =
+                async(start = CoroutineStart.UNDISPATCHED) {
+                    broadcaster.submit(transaction, endpoint)
+                }
+
+            submitStarted.await()
+
+            assertEquals(
+                PendingSubmitPlanStore.StoredSubmitPlan.AwaitingPlan,
+                pendingSubmitPlanStore.getSubmitPlan(transaction.txId)
+            )
+
+            allowSubmitToFinish.complete(Unit)
+            submitJob.await()
+
+            assertEquals(
+                PendingSubmitPlanStore.StoredSubmitPlan.Ready(TransactionSubmitPlan(listOf(endpoint))),
+                pendingSubmitPlanStore.getSubmitPlan(transaction.txId)
+            )
         }
 
     @Test
@@ -351,7 +437,8 @@ class SdkBroadcasterTest {
     private class FakeTransactionSubmitter(
         private val resultFactory: (CreatedTransaction) -> TransactionSubmitResult = {
             TransactionSubmitResult.Success(it.txId)
-        }
+        },
+        private val beforeReturning: suspend () -> Unit = {}
     ) : TransactionSubmitter {
         val submissions = mutableListOf<Submission>()
 
@@ -360,6 +447,7 @@ class SdkBroadcasterTest {
             endpoint: LightWalletEndpoint
         ): TransactionSubmitResult {
             submissions += Submission(transaction, endpoint)
+            beforeReturning()
             return resultFactory(transaction)
         }
     }

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/transaction/SdkBroadcasterTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/transaction/SdkBroadcasterTest.kt
@@ -13,7 +13,6 @@ import cash.z.ecc.android.sdk.model.TransactionSubmitResult
 import cash.z.ecc.android.sdk.model.UnifiedSpendingKey
 import cash.z.ecc.android.sdk.model.Zatoshi
 import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
-import java.io.IOException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
@@ -23,6 +22,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.mockito.Mockito.mock
+import java.io.IOException
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/transaction/SdkBroadcasterTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/transaction/SdkBroadcasterTest.kt
@@ -16,6 +16,7 @@ import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -313,6 +314,39 @@ class SdkBroadcasterTest {
 
             allowSubmitToFinish.complete(Unit)
             submitJob.await()
+
+            assertEquals(
+                PendingSubmitPlanStore.StoredSubmitPlan.Ready(TransactionSubmitPlan(listOf(endpoint))),
+                pendingSubmitPlanStore.getSubmitPlan(transaction.txId)
+            )
+        }
+
+    @Test
+    fun broadcaster_submit_records_endpoint_even_if_cancelled_mid_submit() =
+        runBlocking {
+            val endpoint = LightWalletEndpoint("submit.z.cash", 443, true)
+            val encodedTransaction = encodedTransaction(14)
+            val submitStarted = CompletableDeferred<Unit>()
+            val neverFinish = CompletableDeferred<Unit>()
+            val pendingSubmitPlanStore = PendingSubmitPlanStore()
+            val submitter =
+                FakeTransactionSubmitter(
+                    beforeReturning = {
+                        submitStarted.complete(Unit)
+                        neverFinish.await()
+                    }
+                )
+            val broadcaster = SdkBroadcaster(FakeOutboundTransactionManager(), submitter, pendingSubmitPlanStore)
+            val transaction = encodedTransaction.toCreatedTransactionForTest()
+            pendingSubmitPlanStore.createAndMarkAwaitingSubmitPlan { listOf(transaction) }
+
+            val submitJob =
+                launch(start = CoroutineStart.UNDISPATCHED) {
+                    broadcaster.submit(transaction, endpoint)
+                }
+
+            submitStarted.await()
+            submitJob.cancelAndJoin()
 
             assertEquals(
                 PendingSubmitPlanStore.StoredSubmitPlan.Ready(TransactionSubmitPlan(listOf(endpoint))),


### PR DESCRIPTION
Linear: [MOB-1339](https://linear.app/zodl/issue/MOB-1339)

## What this PR does
Routes the legacy `Synchronizer.createProposedTransactions` and `Synchronizer.createTransactionFromPczt` helpers through `PendingSubmitPlanStore` so the sync loop's `resubmitUnminedTransactions` step skips in-flight submits instead of racing them with a second `txManager.submit()` and producing `transaction already exists in mempool` rejections.

Reviews surfaced two adjacent concerns that this PR now also addresses:

1. **Record after submit** — In the original commit, `addSubmitEndpoint(...)` was called *before* `transactionSubmitter.submit(...)`. That transitioned the store from `AwaitingPlan` → `Ready(endpoints)` before the actual submit RPC fired, leaving an in-flight window where the resubmit step no longer saw `AwaitingPlan` and could race the broadcast. The reorder applies to the public `Broadcaster.submit` as well, keeping the three call sites consistent.
2. **Survive submit-mid-cancellation** — A naive reorder would strand the plan at `AwaitingPlan` forever if `transactionSubmitter.submit(...)` threw a `CancellationException` (app teardown, scope cancel), because `addSubmitEndpoint` would never run and the resubmit loop skips `AwaitingPlan` entries. The three call sites fold into a `recordingEndpointAfterSubmit` helper that wraps `addSubmitEndpoint` in `try/finally` with `withContext(NonCancellable)`, matching the existing `EndpointTransactionSubmitter.submit` dispose pattern in this file.

The PR also clarifies a misleading comment about `SubmitPlanExecutor` "dedupe" semantics (it iterates `endpoints.distinct()` and stops on first non-Failure; it doesn't dedupe per-endpoint), and documents why `createSubmitResultFlow` leaves later legs of a partially-failed multi-tx proposal at `AwaitingPlan` (dependent proposals — shield → spend — shouldn't retry the later leg if an earlier leg failed).

## Files
- **Modified**: `sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/SdkBroadcaster.kt` — legacy helpers route through `PendingSubmitPlanStore`; public `Broadcaster.submit` and both legacy helpers fold into `recordingEndpointAfterSubmit` (record after submit, `NonCancellable` finally).
- **Modified**: `sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/transaction/SdkBroadcasterTest.kt` — coverage for plan registration on both legacy paths, mutex-during-create contract, the `AwaitingPlan`-during-submit window for both the legacy helper and the public `Broadcaster.submit`, and the cancellation-mid-submit contract.
- **Modified**: `CHANGELOG.md` — Unreleased / Fixed entry.

## Test plan
- [ ] CI's `test_android_modules_unit` runs the full `SdkBroadcasterTest` suite (verify the new `broadcaster_submit_records_endpoint_even_if_cancelled_mid_submit` and the renamed/added blocking-submitter tests).
- [x] Existing `submit_targets_requested_endpoint` continues to pass (post-submit state is `Ready` with endpoint recorded).