### PR TITLE
CI: use dtolnay/rust-toolchain action instead of manual rustup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -30,12 +30,11 @@ runs:
         SDKMANAGER=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
         echo "y" | $SDKMANAGER "ndk;27.0.12077973"
     - name: Setup Rust
-      shell: bash
-      run: |
-        rustup install ${{ inputs.rust-version }}
-        rustup default ${{ inputs.rust-version }}
-        rustup target add armv7-linux-androideabi aarch64-linux-android i686-linux-android x86_64-linux-android
-        rustup component add clippy
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+      with:
+        toolchain: ${{ inputs.rust-version }}
+        targets: armv7-linux-androideabi,aarch64-linux-android,i686-linux-android,x86_64-linux-android
+        components: clippy
     - name: Configure Gradle
       shell: bash
       run: |


### PR DESCRIPTION
See https://github.com/zcash/zcash-android-wallet-sdk/pull/1988/changes#r3443271564