### PR TITLE
Orchard -> Ironwood migration: denomination-split planning (JNI layer)

### DIFF
--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/Backend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/Backend.kt
@@ -1,5 +1,6 @@
 package cash.z.ecc.android.sdk.internal
 
+import cash.z.ecc.android.sdk.internal.model.DenominationPlan
 import cash.z.ecc.android.sdk.internal.model.JniAccount
 import cash.z.ecc.android.sdk.internal.model.JniAccountUsk
 import cash.z.ecc.android.sdk.internal.model.JniBlockMeta
@@ -34,6 +35,18 @@ interface Backend {
         value: Long,
         memo: ByteArray? = null
     ): ProposalUnsafe
+
+    /**
+     * Plans how to split a spendable Orchard balance into round-ZEC-denominated outputs ahead of
+     * an Orchard -> Ironwood migration transfer. Pure arithmetic - does not touch the wallet DB or
+     * build any transaction.
+     */
+    suspend fun planOrchardDenominationSplit(
+        totalInputZatoshi: Long,
+        prepFeeZatoshi: Long,
+        migrationFeeZatoshi: Long,
+        minimumOutputZatoshi: Long
+    ): DenominationPlan
 
     /**
      * @throws RuntimeException as a common indicator of the operation failure

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/FakeRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/FakeRustBackend.kt
@@ -1,6 +1,7 @@
 package cash.z.ecc.android.sdk.internal.jni
 
 import cash.z.ecc.android.sdk.internal.Backend
+import cash.z.ecc.android.sdk.internal.model.DenominationPlan
 import cash.z.ecc.android.sdk.internal.model.JniAccount
 import cash.z.ecc.android.sdk.internal.model.JniAccountUsk
 import cash.z.ecc.android.sdk.internal.model.JniBlockMeta
@@ -117,6 +118,15 @@ class FakeRustBackend(
         memo: ByteArray?,
         transparentReceiver: String?
     ): ProposalUnsafe? {
+        error("Intentionally not implemented yet.")
+    }
+
+    override suspend fun planOrchardDenominationSplit(
+        totalInputZatoshi: Long,
+        prepFeeZatoshi: Long,
+        migrationFeeZatoshi: Long,
+        minimumOutputZatoshi: Long
+    ): DenominationPlan {
         error("Intentionally not implemented yet.")
     }
 

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/RustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/RustBackend.kt
@@ -4,6 +4,7 @@ import cash.z.ecc.android.sdk.internal.Backend
 import cash.z.ecc.android.sdk.internal.SdkDispatchers
 import cash.z.ecc.android.sdk.internal.ext.deleteRecursivelySuspend
 import cash.z.ecc.android.sdk.internal.ext.deleteSuspend
+import cash.z.ecc.android.sdk.internal.model.DenominationPlan
 import cash.z.ecc.android.sdk.internal.model.JniAccount
 import cash.z.ecc.android.sdk.internal.model.JniAccountUsk
 import cash.z.ecc.android.sdk.internal.model.JniBlockMeta
@@ -428,6 +429,23 @@ class RustBackend private constructor(
                     value,
                     memo,
                     networkId = networkId,
+                )
+            )
+        }
+
+    override suspend fun planOrchardDenominationSplit(
+        totalInputZatoshi: Long,
+        prepFeeZatoshi: Long,
+        migrationFeeZatoshi: Long,
+        minimumOutputZatoshi: Long
+    ): DenominationPlan =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            DenominationPlan.parse(
+                Companion.planOrchardDenominationSplit(
+                    totalInputZatoshi,
+                    prepFeeZatoshi,
+                    migrationFeeZatoshi,
+                    minimumOutputZatoshi
                 )
             )
         }
@@ -884,6 +902,14 @@ class RustBackend private constructor(
             memo: ByteArray?,
             networkId: Int,
         ): ByteArray
+
+        @JvmStatic
+        private external fun planOrchardDenominationSplit(
+            totalInputZatoshi: Long,
+            prepFeeZatoshi: Long,
+            migrationFeeZatoshi: Long,
+            minimumOutputZatoshi: Long
+        ): LongArray
 
         @JvmStatic
         @Suppress("LongParameterList")

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/DenominationPlan.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/DenominationPlan.kt
@@ -1,0 +1,43 @@
+package cash.z.ecc.android.sdk.internal.model
+
+/**
+ * A plan for splitting a spendable Orchard balance into round-ZEC-denominated
+ * outputs ahead of an Orchard -> Ironwood migration transfer.
+ *
+ * @param migrationOutputs round-ZEC-denominated output values, descending order of denomination.
+ * @param orchardChange sub-ZEC residual kept as Orchard change rather than migrated, when it's too
+ *   small to be worth a dedicated migration output but still above the minimum output threshold.
+ */
+data class DenominationPlan(
+    val migrationOutputs: List<Long>,
+    val orchardChange: Long?,
+    val prepFeeZatoshi: Long,
+    val migrationFeeZatoshi: Long,
+    val totalInputZatoshi: Long,
+    val totalMigratableZatoshi: Long
+) {
+    companion object {
+        /**
+         * Parses the packed `long[]` returned by the Rust `planOrchardDenominationSplit` JNI call:
+         * `[prepFeeZatoshi, migrationFeeZatoshi, totalInputZatoshi, totalMigratableZatoshi,
+         *   orchardChange (-1 if none), outputCount, output_0, output_1, ...]`
+         */
+        fun parse(encoded: LongArray): DenominationPlan {
+            require(encoded.size >= 6) { "Denomination plan array must have at least 6 elements" }
+
+            val outputCount = encoded[5].toInt()
+            require(encoded.size == 6 + outputCount) {
+                "Denomination plan array length does not match declared output count"
+            }
+
+            return DenominationPlan(
+                prepFeeZatoshi = encoded[0],
+                migrationFeeZatoshi = encoded[1],
+                totalInputZatoshi = encoded[2],
+                totalMigratableZatoshi = encoded[3],
+                orchardChange = encoded[4].takeIf { it >= 0 },
+                migrationOutputs = encoded.drop(6)
+            )
+        }
+    }
+}

--- a/backend-lib/src/main/rust/ironwood_migration.rs
+++ b/backend-lib/src/main/rust/ironwood_migration.rs
@@ -11,6 +11,13 @@
 //! see `.claude/context/ironwood-migration-port-plan.md` at the zodl repo
 //! root for the full design rationale.
 
+use anyhow::anyhow;
+use jni::JNIEnv;
+use jni::objects::JClass;
+use jni::sys::{jlong, jlongArray};
+
+use crate::utils::{catch_unwind, exception::unwrap_exc_or};
+
 pub(crate) const ZATOSHIS_PER_ZEC: u64 = 100_000_000;
 
 /// Upper bound on how many denomination outputs a single split plan may
@@ -120,6 +127,64 @@ pub(crate) fn plan_denominations(
         total_input_zatoshi,
         total_migratable_zatoshi,
     })
+}
+
+/// JNI entry point for [`plan_denominations`].
+///
+/// Pure arithmetic, no wallet DB access required, so unlike `proposeTransfer`/
+/// `proposeShielding` this takes the balance/fee inputs directly rather than
+/// an `account_uuid` + `db_data` pair.
+///
+/// Returns a `long[]` laid out as:
+/// `[prep_fee_zatoshi, migration_fee_zatoshi, total_input_zatoshi,
+///   total_migratable_zatoshi, orchard_change (-1 if none), output_count,
+///   output_0, output_1, ...]`
+///
+/// No protobuf message exists for this shape (`Proposal` doesn't fit), and
+/// adding new proto codegen to backend-lib for one small fixed-shape result
+/// isn't warranted yet - a packed primitive array is the established
+/// lightweight alternative for non-DB JNI calls in this codebase.
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_planOrchardDenominationSplit<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    total_input_zatoshi: jlong,
+    prep_fee_zatoshi: jlong,
+    migration_fee_zatoshi: jlong,
+    minimum_output_zatoshi: jlong,
+) -> jlongArray {
+    let res = catch_unwind(&mut env, |env| {
+        let _span = tracing::info_span!("RustBackend.planOrchardDenominationSplit").entered();
+
+        let to_u64 = |label: &str, value: jlong| -> anyhow::Result<u64> {
+            u64::try_from(value).map_err(|_| anyhow!("{label} must be non-negative"))
+        };
+
+        let plan = plan_denominations(
+            to_u64("total_input_zatoshi", total_input_zatoshi)?,
+            to_u64("prep_fee_zatoshi", prep_fee_zatoshi)?,
+            to_u64("migration_fee_zatoshi", migration_fee_zatoshi)?,
+            to_u64("minimum_output_zatoshi", minimum_output_zatoshi)?,
+        )
+        .map_err(|e| anyhow!("Error planning denomination split: {e}"))?;
+
+        let mut encoded: Vec<jlong> = vec![
+            plan.prep_fee_zatoshi as jlong,
+            plan.migration_fee_zatoshi as jlong,
+            plan.total_input_zatoshi as jlong,
+            plan.total_migratable_zatoshi as jlong,
+            plan.orchard_change.map(|v| v as jlong).unwrap_or(-1),
+            plan.migration_outputs.len() as jlong,
+        ];
+        encoded.extend(plan.migration_outputs.iter().map(|v| *v as jlong));
+
+        let array = env.new_long_array(encoded.len() as i32)?;
+        env.set_long_array_region(&array, 0, &encoded)?;
+        Ok(array.into_raw())
+    });
+    unwrap_exc_or(&mut env, res, std::ptr::null_mut())
 }
 
 #[cfg(test)]

--- a/backend-lib/src/main/rust/ironwood_migration.rs
+++ b/backend-lib/src/main/rust/ironwood_migration.rs
@@ -1,0 +1,198 @@
+//! Orchard -> Ironwood migration: denomination planning.
+//!
+//! Splits a wallet's spendable Orchard balance into round-ZEC-denominated
+//! outputs (1, 10, 100... ZEC) plus an optional sub-ZEC residual, so that a
+//! later Orchard -> Ironwood transfer moves one round-numbered note at a
+//! time instead of the whole balance in one visible pool-crossing transfer.
+//!
+//! This module intentionally contains only the planning arithmetic. Building,
+//! signing, and broadcasting the resulting transactions happens per-step on
+//! each guided app-open (no pre-signed batch, no background scheduling) -
+//! see `.claude/context/ironwood-migration-port-plan.md` at the zodl repo
+//! root for the full design rationale.
+
+pub(crate) const ZATOSHIS_PER_ZEC: u64 = 100_000_000;
+
+/// Upper bound on how many denomination outputs a single split plan may
+/// produce, to keep the resulting self-send transaction's output count
+/// (and fee) bounded.
+pub(crate) const MAX_DENOMINATION_OUTPUTS: usize = 64;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct DenominationPlan {
+    /// Round-ZEC-denominated output values, descending order of denomination.
+    pub migration_outputs: Vec<u64>,
+    /// Sub-ZEC residual kept as Orchard change rather than migrated, when it's
+    /// too small to be worth a dedicated migration output but still above the
+    /// minimum output threshold.
+    pub orchard_change: Option<u64>,
+    pub prep_fee_zatoshi: u64,
+    pub migration_fee_zatoshi: u64,
+    pub total_input_zatoshi: u64,
+    pub total_migratable_zatoshi: u64,
+}
+
+/// Plans how to split `total_input_zatoshi` of spendable Orchard balance into
+/// round-ZEC denomination outputs.
+///
+/// `prep_fee_zatoshi` is the fee for the denomination-split transaction
+/// itself; `migration_fee_zatoshi` and `minimum_output_zatoshi` determine
+/// whether a sub-ZEC residual becomes its own output, becomes Orchard change,
+/// or is folded into the prep fee as dust.
+pub(crate) fn plan_denominations(
+    total_input_zatoshi: u64,
+    prep_fee_zatoshi: u64,
+    migration_fee_zatoshi: u64,
+    minimum_output_zatoshi: u64,
+) -> Result<DenominationPlan, String> {
+    if total_input_zatoshi <= prep_fee_zatoshi {
+        return Ok(DenominationPlan {
+            migration_outputs: Vec::new(),
+            orchard_change: None,
+            prep_fee_zatoshi: total_input_zatoshi,
+            migration_fee_zatoshi,
+            total_input_zatoshi,
+            total_migratable_zatoshi: 0,
+        });
+    }
+
+    let available = total_input_zatoshi
+        .checked_sub(prep_fee_zatoshi)
+        .ok_or("Denomination prep fee underflow")?;
+    let whole_zec = available / ZATOSHIS_PER_ZEC;
+    let mut remainder = available % ZATOSHIS_PER_ZEC;
+    let mut outputs = Vec::new();
+
+    let mut denom = 1u64;
+    while denom <= whole_zec / 10 {
+        denom = denom.checked_mul(10).ok_or("Denomination overflow")?;
+    }
+
+    let mut remaining_whole = whole_zec;
+    while denom > 0 {
+        while remaining_whole >= denom {
+            outputs.push(
+                denom
+                    .checked_mul(ZATOSHIS_PER_ZEC)
+                    .ok_or("Denomination zatoshi overflow")?,
+            );
+            remaining_whole -= denom;
+        }
+        denom /= 10;
+    }
+
+    let migratable_residual_threshold = migration_fee_zatoshi
+        .checked_add(minimum_output_zatoshi)
+        .ok_or("Residual fee threshold overflow")?;
+    let orchard_change = if remainder > migratable_residual_threshold {
+        outputs.push(remainder);
+        None
+    } else if remainder >= minimum_output_zatoshi {
+        Some(remainder)
+    } else {
+        remainder = 0;
+        None
+    };
+
+    if outputs.len() > MAX_DENOMINATION_OUTPUTS {
+        return Err(format!(
+            "Migration plan would create {} prepared notes, above the {} note limit",
+            outputs.len(),
+            MAX_DENOMINATION_OUTPUTS
+        ));
+    }
+
+    let total_migratable_zatoshi = outputs.iter().try_fold(0u64, |acc, value| {
+        acc.checked_add(*value)
+            .ok_or("Migratable total overflow".to_string())
+    })?;
+
+    // When `remainder` is below minimum output it intentionally becomes extra
+    // transaction fee. Keep the variable assignment explicit so tests can
+    // lock the policy.
+    let _dust_remainder_added_to_fee = remainder < minimum_output_zatoshi;
+
+    Ok(DenominationPlan {
+        migration_outputs: outputs,
+        orchard_change,
+        prep_fee_zatoshi,
+        migration_fee_zatoshi,
+        total_input_zatoshi,
+        total_migratable_zatoshi,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MINIMUM_OUTPUT_FOR_TEST: u64 = 1;
+
+    #[test]
+    fn planner_noops_when_prep_fee_consumes_balance() {
+        let plan = plan_denominations(5_000, 10_000, 10_000, 1).unwrap();
+
+        assert!(plan.migration_outputs.is_empty());
+        assert_eq!(plan.total_migratable_zatoshi, 0);
+        assert_eq!(plan.prep_fee_zatoshi, 5_000);
+    }
+
+    #[test]
+    fn planner_creates_decimal_denominations_and_fee_positive_residual() {
+        let plan = plan_denominations(1_234_500_000, 0, 10_000, MINIMUM_OUTPUT_FOR_TEST).unwrap();
+
+        assert_eq!(
+            plan.migration_outputs,
+            vec![1_000_000_000, 100_000_000, 100_000_000, 34_500_000]
+        );
+        assert_eq!(plan.orchard_change, None);
+        assert_eq!(plan.total_migratable_zatoshi, 1_234_500_000);
+    }
+
+    #[test]
+    fn planner_keeps_non_fee_positive_residual_as_orchard_change() {
+        let plan = plan_denominations(100_010_000, 0, 10_000, MINIMUM_OUTPUT_FOR_TEST).unwrap();
+
+        assert_eq!(plan.migration_outputs, vec![100_000_000]);
+        assert_eq!(plan.orchard_change, Some(10_000));
+    }
+
+    #[test]
+    fn planner_reserves_prep_fee_before_decomposition() {
+        let plan = plan_denominations(1_000_000_000, 10_000, 10_000, 1).unwrap();
+
+        assert_eq!(
+            plan.migration_outputs,
+            vec![
+                100_000_000,
+                100_000_000,
+                100_000_000,
+                100_000_000,
+                100_000_000,
+                100_000_000,
+                100_000_000,
+                100_000_000,
+                100_000_000,
+                99_990_000,
+            ]
+        );
+    }
+
+    #[test]
+    fn planner_rejects_more_than_max_prepared_outputs() {
+        let err = plan_denominations(1_999_999_950_000_000, 0, 10_000, 1).unwrap_err();
+
+        assert!(err.contains("above the 64 note limit"));
+    }
+
+    #[test]
+    fn planner_dust_residual_below_minimum_output_is_folded_into_fee() {
+        // Residual below minimum_output_zatoshi (here: 50_000) becomes extra fee,
+        // not its own output and not Orchard change.
+        let plan = plan_denominations(100_000_999, 0, 10_000, 50_000).unwrap();
+
+        assert_eq!(plan.migration_outputs, vec![100_000_000]);
+        assert_eq!(plan.orchard_change, None);
+        assert_eq!(plan.total_migratable_zatoshi, 100_000_000);
+    }
+}

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -101,6 +101,7 @@ use crate::utils::{
 };
 
 mod eip681;
+mod ironwood_migration;
 mod tor;
 mod utils;
 mod voting;

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
@@ -1,5 +1,4 @@
-package cash.z.ecc.android.sdk
-/**
+/*
  * Kotlin interface for the Orchard → Ironwood migration SDK bridge.
  *
  * Boundary: SDK owns all business logic (split algorithm, anchor height selection,
@@ -9,6 +8,7 @@ package cash.z.ecc.android.sdk
  * Based on: Orchard Migration Flow — Implementation Proposal (Path A)
  * Sync: 2026-06-17
  */
+package cash.z.ecc.android.sdk
 
 // ─── Supporting types ─────────────────────────────────────────────────────────
 
@@ -33,7 +33,7 @@ data class NetworkPrivacyOptions(
  * Splitting into ~10 notes is the current target heuristic (20k ZEC cap per note).
  */
 data class NoteSplitProposal(
-    val outputNotes: List<Long>,  // amounts in zatoshi
+    val outputNotes: List<Long>, // amounts in zatoshi
     val fee: Long
 )
 
@@ -102,13 +102,17 @@ sealed class MigrationState {
     object ReadyToPropose : MigrationState()
 
     /** Migration schedule is committed and transfers are executing. */
-    data class InProgress(val progress: MigrationProgress) : MigrationState()
+    data class InProgress(
+        val progress: MigrationProgress
+    ) : MigrationState()
 
     /**
      * A transfer cannot proceed automatically. App must surface a non-error prompt
      * and call restartCurrentMigrationStep() after user acknowledges.
      */
-    data class RequiresAttention(val reason: AttentionReason) : MigrationState()
+    data class RequiresAttention(
+        val reason: AttentionReason
+    ) : MigrationState()
 
     /** All transfers confirmed on-chain. Orchard balance is zero. */
     object Complete : MigrationState()
@@ -116,7 +120,9 @@ sealed class MigrationState {
 
 sealed class AttentionReason {
     /** Input note was spent externally before the migration transfer was broadcast. */
-    data class InvalidTransfer(val transferId: String) : AttentionReason()
+    data class InvalidTransfer(
+        val transferId: String
+    ) : AttentionReason()
 
     /** Transaction anchor expired before broadcast (e.g. extended offline period). */
     object TransferExpired : AttentionReason()
@@ -133,10 +139,14 @@ sealed class AttentionReason {
  * do not collapse these into a generic error.
  */
 sealed class TransferResult {
-    data class Success(val txId: String) : TransferResult()
+    data class Success(
+        val txId: String
+    ) : TransferResult()
 
     /** Transient network failure. Retry in the next WorkManager window. */
-    data class NetworkError(val retryable: Boolean) : TransferResult()
+    data class NetworkError(
+        val retryable: Boolean
+    ) : TransferResult()
 
     /**
      * Input note is already spent. Sets MigrationState to RequiresAttention.
@@ -154,7 +164,6 @@ sealed class TransferResult {
 // ─── Main interface ───────────────────────────────────────────────────────────
 
 interface OrchardMigrationSdk {
-
     // ── State ────────────────────────────────────────────────────────────────
 
     /**

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
@@ -1,0 +1,285 @@
+package cash.z.ecc.android.sdk
+/**
+ * Kotlin interface for the Orchard → Ironwood migration SDK bridge.
+ *
+ * Boundary: SDK owns all business logic (split algorithm, anchor height selection,
+ * transaction signing, storage, invalidity detection). App owns UI, WorkManager
+ * scheduling, permissions, and notifications.
+ *
+ * Based on: Orchard Migration Flow — Implementation Proposal (Path A)
+ * Sync: 2026-06-17
+ */
+
+// ─── Supporting types ─────────────────────────────────────────────────────────
+
+/**
+ * Controls how migration transactions are broadcast.
+ *
+ * [useTor] — routes the broadcast through Tor when true.
+ * [submissionEndpoint] — null means use the same LWD server as sync.
+ *   Pass a secondary endpoint to de-correlate sync and submission servers
+ *   (privacy improvement: an observer cannot link sync traffic and broadcast traffic
+ *   to the same wallet).
+ */
+data class NetworkPrivacyOptions(
+    val useTor: Boolean,
+    val submissionEndpoint: String? = null
+)
+
+/**
+ * SDK-generated note split proposal. The SDK decides the number of output notes,
+ * their sizes, and randomisation — the app only shows this to the user for confirmation.
+ *
+ * Splitting into ~10 notes is the current target heuristic (20k ZEC cap per note).
+ */
+data class NoteSplitProposal(
+    val outputNotes: List<Long>,  // amounts in zatoshi
+    val fee: Long
+)
+
+/**
+ * A single scheduled migration transfer.
+ *
+ * [anchorHeight] is chosen from a shared network-wide 288-block bucket
+ * (block height divisible by 288, ≈ 6-hour intervals). This hides the wallet's
+ * last sync time from an observer. The anchor and the broadcast time are independent —
+ * the transaction can be broadcast at any point after [nextExecutableAfterHeight].
+ *
+ * [nextExecutableAfterHeight] is what the app uses to schedule the WorkManager task.
+ * The SDK sets this; the app does not compute it.
+ *
+ * [expiryHeight] — if the transaction is not broadcast before this height it becomes
+ * invalid and [OrchardMigrationSdk.restartCurrentMigrationStep] must be called.
+ */
+data class TransferProposal(
+    val id: String,
+    val amountZatoshi: Long,
+    val anchorHeight: Long,
+    val nextExecutableAfterHeight: Long,
+    val expiryHeight: Long
+)
+
+/**
+ * Full migration schedule returned by [OrchardMigrationSdk.proposeMigrationTransfers].
+ * Shown to the user for review before [OrchardMigrationSdk.signAndStoreMigrationSchedule]
+ * is called. After sign+store, individual transfers do not require per-send confirmation.
+ */
+data class MigrationSchedule(
+    val transfers: List<TransferProposal>,
+    val estimatedDurationHours: Int
+)
+
+/**
+ * Live migration progress used by the progress UI.
+ * [nextTransferReadyAtHeight] is null when all transfers are complete or migration
+ * has not started yet.
+ */
+data class MigrationProgress(
+    val completedTransfers: Int,
+    val totalTransfers: Int,
+    val remainingOrchardZatoshi: Long,
+    val nextTransferReadyAtHeight: Long?
+)
+
+/**
+ * Top-level migration state machine.
+ *
+ * NotStarted
+ *   → SplitPendingConfirmation  (if split needed, split tx submitted)
+ *   → ReadyToPropose            (split confirmed, or split not needed)
+ *   → InProgress                (schedule signed and stored)
+ *   → RequiresAttention         (transfer invalid/expired, user must act)
+ *   → Complete
+ */
+sealed class MigrationState {
+    /** No migration has been initiated. Show migration entry point. */
+    object NotStarted : MigrationState()
+
+    /** Note split transaction submitted, waiting for on-chain confirmation (~1 block). */
+    object SplitPendingConfirmation : MigrationState()
+
+    /** Split confirmed (or was not needed). Ready to call proposeMigrationTransfers(). */
+    object ReadyToPropose : MigrationState()
+
+    /** Migration schedule is committed and transfers are executing. */
+    data class InProgress(val progress: MigrationProgress) : MigrationState()
+
+    /**
+     * A transfer cannot proceed automatically. App must surface a non-error prompt
+     * and call restartCurrentMigrationStep() after user acknowledges.
+     */
+    data class RequiresAttention(val reason: AttentionReason) : MigrationState()
+
+    /** All transfers confirmed on-chain. Orchard balance is zero. */
+    object Complete : MigrationState()
+}
+
+sealed class AttentionReason {
+    /** Input note was spent externally before the migration transfer was broadcast. */
+    data class InvalidTransfer(val transferId: String) : AttentionReason()
+
+    /** Transaction anchor expired before broadcast (e.g. extended offline period). */
+    object TransferExpired : AttentionReason()
+
+    /**
+     * A transfer produced change back to Orchard. That change must be synced before
+     * the next transfer can spend it. App should trigger sync, then resume execution.
+     */
+    object SyncRequiredBeforeNext : AttentionReason()
+}
+
+/**
+ * Result of a broadcast attempt. The app maps each case to a specific UI/retry action —
+ * do not collapse these into a generic error.
+ */
+sealed class TransferResult {
+    data class Success(val txId: String) : TransferResult()
+
+    /** Transient network failure. Retry in the next WorkManager window. */
+    data class NetworkError(val retryable: Boolean) : TransferResult()
+
+    /**
+     * Input note is already spent. Sets MigrationState to RequiresAttention.
+     * App must call restartCurrentMigrationStep() for the remaining balance.
+     */
+    object InvalidNote : TransferResult()
+
+    /**
+     * Transaction anchor height has expired. Same handling as InvalidNote.
+     * Call restartCurrentMigrationStep().
+     */
+    object Expired : TransferResult()
+}
+
+// ─── Main interface ───────────────────────────────────────────────────────────
+
+interface OrchardMigrationSdk {
+
+    // ── State ────────────────────────────────────────────────────────────────
+
+    /**
+     * Current state of the migration. App calls this on every launch and after
+     * every SDK operation to decide which screen to show.
+     *
+     * Consider exposing as Flow<MigrationState> if the Rust bridge supports it —
+     * that removes the need for manual polling.
+     */
+    fun getMigrationState(): MigrationState
+
+    /** Convenience accessor for progress details when state is InProgress. */
+    fun getMigrationProgress(): MigrationProgress?
+
+    // ── Note splitting ───────────────────────────────────────────────────────
+
+    /**
+     * Returns true if the current Orchard notes must be split before migration.
+     * Note splitting is mandatory — do not proceed to proposeMigrationTransfers()
+     * without splitting first if this returns true.
+     */
+    fun isNoteSplitNeeded(): Boolean
+
+    /**
+     * SDK computes the optimal split (number of notes, sizes, randomisation).
+     * Returns a proposal for user review. Nothing is broadcast until submitNoteSplit().
+     */
+    suspend fun prepareNoteSplit(): NoteSplitProposal
+
+    /**
+     * Broadcasts the note-split transaction. State transitions to SplitPendingConfirmation.
+     * The split is a wallet-internal send (no external receiver).
+     *
+     * Open question: should this accept NetworkPrivacyOptions?
+     * The split is on-chain visible, so routing through Tor may be desirable for
+     * large balances. Defaulting to no Tor for simplicity for now.
+     */
+    suspend fun submitNoteSplit(proposal: NoteSplitProposal): TransferResult
+
+    // ── Migration proposal ───────────────────────────────────────────────────
+
+    /**
+     * Generates the full migration schedule. Call only when state is ReadyToPropose.
+     *
+     * SDK decides: number of transfers, randomised amounts, anchor heights
+     * (from 288-block buckets), and nextExecutableAfterHeight per transfer.
+     * App shows this to the user for one-time confirmation before signing.
+     */
+    suspend fun proposeMigrationTransfers(): MigrationSchedule
+
+    /**
+     * User has confirmed the schedule. SDK signs all transactions and stores them
+     * in the database via the existing transaction-resubmission infrastructure.
+     * State transitions to InProgress. Individual transfers no longer need per-send
+     * confirmation.
+     *
+     * After this call, app reads nextExecutableAfterHeight from each TransferProposal
+     * to schedule WorkManager tasks.
+     */
+    suspend fun signAndStoreMigrationSchedule(schedule: MigrationSchedule)
+
+    // ── Background execution ─────────────────────────────────────────────────
+
+    /**
+     * Returns true if a sync is needed before the next transfer can be executed.
+     * Happens when the previous transfer produced change back to Orchard — that
+     * change must be confirmed and synced before it can be spent.
+     *
+     * WorkManager task should check this before calling executeNextPendingTransfer().
+     * If true, task should exit and trigger a separate sync (not in the same session —
+     * sync and broadcast must be decoupled in time).
+     */
+    fun isSyncRequiredBeforeNextTransfer(): Boolean
+
+    /**
+     * Broadcasts the next pending transfer. App does not need to track which transfer
+     * is next — the SDK manages internal ordering.
+     *
+     * Returns null if there is nothing to execute (all done or none stored yet).
+     *
+     * Called from: WorkManager Worker (Android) / BGTaskScheduler task (iOS).
+     * Sync must NOT be triggered inside the same background session as this call.
+     *
+     * [options] — Tor and submission endpoint settings chosen by the user during
+     * the confirmation flow. Store and pass through from the committed schedule.
+     */
+    suspend fun executeNextPendingTransfer(options: NetworkPrivacyOptions): TransferResult?
+
+    // ── On-launch reconciliation ─────────────────────────────────────────────
+
+    /**
+     * True if one or more scheduled transfers are past their nextExecutableAfterHeight
+     * but have not been broadcast yet. App shows the fallback prompt on launch.
+     *
+     * This is the primary catch-up mechanism — do not rely on notification delivery.
+     */
+    fun hasOverdueTransfers(): Boolean
+
+    /**
+     * True if any stored transfer is in an invalid state (spent note or expired anchor).
+     * App shows the RequiresAttention screen. Call restartCurrentMigrationStep() after
+     * user acknowledges.
+     *
+     * Detection condition: orchardBalance > 0 AND no valid queued migration transaction.
+     */
+    fun hasInvalidTransfers(): Boolean
+
+    // ── Invalidity recovery ──────────────────────────────────────────────────
+
+    /**
+     * Called when state is RequiresAttention. SDK invalidates the broken transfer,
+     * re-evaluates the remaining unspent Orchard notes, and returns a new schedule
+     * for the remainder of the balance.
+     *
+     * The returned MigrationSchedule must go through the normal user confirmation
+     * flow → signAndStoreMigrationSchedule() — same as the first time.
+     */
+    suspend fun restartCurrentMigrationStep(): MigrationSchedule
+
+    // ── Lifecycle ────────────────────────────────────────────────────────────
+
+    /**
+     * Call on the first app open after the Ironwood network upgrade activates.
+     * Sets the minimum anchor height for all migration transactions. Must be called
+     * before any proposal or execution methods.
+     */
+    fun initializePostUpgrade()
+}

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
@@ -32,6 +32,7 @@ import cash.z.ecc.android.sdk.internal.exchange.UsdExchangeRateFetcher
 import cash.z.ecc.android.sdk.internal.ext.existsSuspend
 import cash.z.ecc.android.sdk.internal.ext.tryNull
 import cash.z.ecc.android.sdk.internal.jni.RustBackend
+import cash.z.ecc.android.sdk.internal.model.DenominationPlan
 import cash.z.ecc.android.sdk.internal.model.TorClient
 import cash.z.ecc.android.sdk.internal.model.TorDormantMode
 import cash.z.ecc.android.sdk.internal.model.TorHttp
@@ -717,6 +718,19 @@ class SdkSynchronizer private constructor(
                 throw throwable
             }
         }
+
+    override suspend fun planOrchardDenominationSplit(
+        totalInputZatoshi: Long,
+        prepFeeZatoshi: Long,
+        migrationFeeZatoshi: Long,
+        minimumOutputZatoshi: Long
+    ): DenominationPlan =
+        backend.planOrchardDenominationSplit(
+            totalInputZatoshi = totalInputZatoshi,
+            prepFeeZatoshi = prepFeeZatoshi,
+            migrationFeeZatoshi = migrationFeeZatoshi,
+            minimumOutputZatoshi = minimumOutputZatoshi
+        )
 
     internal suspend fun getWalletDbPathForVoting(): String =
         withContext(Dispatchers.IO) {

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
@@ -18,6 +18,7 @@ import cash.z.ecc.android.sdk.internal.Twig
 import cash.z.ecc.android.sdk.internal.block.CompactBlockDownloader
 import cash.z.ecc.android.sdk.internal.db.DatabaseCoordinator
 import cash.z.ecc.android.sdk.internal.exchange.UsdExchangeRateFetcher
+import cash.z.ecc.android.sdk.internal.model.DenominationPlan
 import cash.z.ecc.android.sdk.internal.model.TorClient
 import cash.z.ecc.android.sdk.internal.model.TreeState
 import cash.z.ecc.android.sdk.internal.model.ext.toBlockHeight
@@ -707,6 +708,22 @@ interface Synchronizer {
      * should first verify that [fullyScannedHeight] has reached at least [height].
      */
     suspend fun getTreeState(height: BlockHeight): ByteArray
+
+    /**
+     * Computes a plan for splitting a spendable Orchard balance into round-ZEC-denominated
+     * outputs ahead of an Orchard -> Ironwood migration transfer.
+     *
+     * @param totalInputZatoshi the spendable Orchard balance to split.
+     * @param prepFeeZatoshi the fee required to produce the denominated outputs.
+     * @param migrationFeeZatoshi the fee required for each individual migration transfer.
+     * @param minimumOutputZatoshi the smallest output value worth migrating on its own.
+     */
+    suspend fun planOrchardDenominationSplit(
+        totalInputZatoshi: Long,
+        prepFeeZatoshi: Long,
+        migrationFeeZatoshi: Long,
+        minimumOutputZatoshi: Long
+    ): DenominationPlan
 
     //
     // Error Handling

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackend.kt
@@ -3,6 +3,7 @@ package cash.z.ecc.android.sdk.internal
 import cash.z.ecc.android.sdk.exception.InitializeException
 import cash.z.ecc.android.sdk.exception.PcztException
 import cash.z.ecc.android.sdk.exception.RustLayerException
+import cash.z.ecc.android.sdk.internal.model.DenominationPlan
 import cash.z.ecc.android.sdk.internal.model.JniBlockMeta
 import cash.z.ecc.android.sdk.internal.model.RewindResult
 import cash.z.ecc.android.sdk.internal.model.ScanRange
@@ -64,6 +65,13 @@ internal interface TypesafeBackend {
         value: Long,
         memo: ByteArray? = null
     ): Proposal
+
+    suspend fun planOrchardDenominationSplit(
+        totalInputZatoshi: Long,
+        prepFeeZatoshi: Long,
+        migrationFeeZatoshi: Long,
+        minimumOutputZatoshi: Long
+    ): DenominationPlan
 
     suspend fun proposeShielding(
         account: Account,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImpl.kt
@@ -2,6 +2,7 @@ package cash.z.ecc.android.sdk.internal
 
 import cash.z.ecc.android.sdk.exception.InitializeException
 import cash.z.ecc.android.sdk.exception.RustLayerException
+import cash.z.ecc.android.sdk.internal.model.DenominationPlan
 import cash.z.ecc.android.sdk.internal.model.JniBlockMeta
 import cash.z.ecc.android.sdk.internal.model.JniSubtreeRoot
 import cash.z.ecc.android.sdk.internal.model.RewindResult
@@ -122,6 +123,19 @@ internal class TypesafeBackendImpl(
                 value,
                 memo
             )
+        )
+
+    override suspend fun planOrchardDenominationSplit(
+        totalInputZatoshi: Long,
+        prepFeeZatoshi: Long,
+        migrationFeeZatoshi: Long,
+        minimumOutputZatoshi: Long
+    ): DenominationPlan =
+        backend.planOrchardDenominationSplit(
+            totalInputZatoshi = totalInputZatoshi,
+            prepFeeZatoshi = prepFeeZatoshi,
+            migrationFeeZatoshi = migrationFeeZatoshi,
+            minimumOutputZatoshi = minimumOutputZatoshi
         )
 
     override suspend fun proposeShielding(


### PR DESCRIPTION
Adds the denomination-planning layer for the Orchard -> Ironwood migration (Approach B: guided on-open sending, no background automation). First of several PRs. Paused here — iOS is getting the full vertical slice (SDK -> app) built first; will resume Android once that's proven out.

- `plan_denominations()` pure-arithmetic planner, ported from Valar's vizor-wallet reference (kept in lockstep with the Swift SDK's copy)
- JNI binding returning a packed `jlongArray` (no new protobuf needed for this small fixed-shape result)
- `Backend`/`RustBackend`/`FakeRustBackend` wiring + Kotlin `DenominationPlan` data class

Transaction-building is not in scope yet (blocked on unstable Ironwood/nu6.3 crate APIs).

Verified: `./gradlew :backend-lib:compileDebugKotlin`, `ktlintFormat ktlint`, `detekt` (zero findings).