### PR TITLE
Depend on librustzcash feat/ironwood for Ironwood (NU6.3) tx-building support

### DIFF
--- a/backend-lib/.cargo/config.toml
+++ b/backend-lib/.cargo/config.toml
@@ -1,0 +1,5 @@
+# Ironwood (NU6.3) pre-release transaction-building support is gated behind this
+# unstable cfg in zcash/librustzcash's feat/ironwood branch (see Cargo.toml [patch.crates-io]
+# and ironwood-migration-execution.md). Remove once Ironwood stabilizes.
+[build]
+rustflags = ["--cfg", "zcash_unstable=\"nu6.3\""]

--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -1453,6 +1453,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "equihash"
+version = "0.3.0"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
+dependencies = [
+ "blake2b_simd",
+ "corez",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1484,6 +1493,14 @@ name = "f4jumble"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+dependencies = [
+ "blake2b_simd",
+]
+
+[[package]]
+name = "f4jumble"
+version = "0.1.1"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1582,6 +1599,18 @@ name = "fluid-let"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "749cff877dc1af878a0b31a41dd221a753634401ea0ef2f87b62d3171522485a"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin",
+]
 
 [[package]]
 name = "fnv"
@@ -1855,6 +1884,26 @@ name = "halo2_gadgets"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45824ce0dd12e91ec0c68ebae2a7ed8ae19b70946624c849add59f1d1a62a143"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "ff",
+ "group",
+ "halo2_poseidon",
+ "halo2_proofs",
+ "lazy_static",
+ "pasta_curves",
+ "rand 0.8.6",
+ "sinsemilla",
+ "subtle",
+ "uint",
+]
+
+[[package]]
+name = "halo2_gadgets"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb2a697cad929f706b7987fe804ad57d43622cd37463ba7e4d662a926fdcfea3"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -2180,7 +2229,7 @@ checksum = "c378a3c5c44b985233906c966bd82a4f775a83aa4e1bde1635961c2eb8673d7b"
 dependencies = [
  "anyhow",
  "ff",
- "halo2_gadgets",
+ "halo2_gadgets 0.4.0",
  "hex",
  "pasta_curves",
  "rayon",
@@ -2591,6 +2640,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "ndk-sys"
 version = "0.5.0+25.2.9519653"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2825,7 +2883,42 @@ dependencies = [
  "fpe",
  "getset",
  "group",
- "halo2_gadgets",
+ "halo2_gadgets 0.4.0",
+ "halo2_poseidon",
+ "halo2_proofs",
+ "hex",
+ "incrementalmerkletree",
+ "lazy_static",
+ "memuse",
+ "nonempty",
+ "pasta_curves",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
+ "reddsa",
+ "serde",
+ "sinsemilla",
+ "subtle",
+ "tracing",
+ "visibility",
+ "zcash_note_encryption",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "orchard"
+version = "0.15.0-pre.0"
+source = "git+https://github.com/zcash/orchard?rev=2f322a220d2750c3fa752132f51594b8358f653f#2f322a220d2750c3fa752132f51594b8358f653f"
+dependencies = [
+ "aes",
+ "bitvec",
+ "blake2b_simd",
+ "corez",
+ "ff",
+ "fpe",
+ "getset",
+ "group",
+ "halo2_gadgets 0.5.0",
  "halo2_poseidon",
  "halo2_proofs",
  "hex",
@@ -2989,7 +3082,7 @@ dependencies = [
  "getset",
  "jubjub",
  "nonempty",
- "orchard",
+ "orchard 0.13.1",
  "pasta_curves",
  "postcard",
  "rand_core 0.6.4",
@@ -2999,10 +3092,38 @@ dependencies = [
  "serde",
  "serde_with",
  "zcash_note_encryption",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_primitives 0.27.1",
+ "zcash_protocol 0.8.0",
  "zcash_script",
- "zcash_transparent",
+ "zcash_transparent 0.7.0",
+]
+
+[[package]]
+name = "pczt"
+version = "0.7.0"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
+dependencies = [
+ "blake2b_simd",
+ "bls12_381",
+ "document-features",
+ "ff",
+ "getset",
+ "jubjub",
+ "nonempty",
+ "orchard 0.15.0-pre.0",
+ "pasta_curves",
+ "postcard",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "secp256k1",
+ "serde",
+ "serde_with",
+ "zcash_note_encryption",
+ "zcash_primitives 0.28.0",
+ "zcash_protocol 0.9.0",
+ "zcash_script",
+ "zcash_transparent 0.8.0",
 ]
 
 [[package]]
@@ -4290,6 +4411,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -6022,7 +6146,7 @@ checksum = "870b893a2c53ec015d46fd3a33cf91715a9a968d34531208144f48e46398321c"
 dependencies = [
  "anyhow",
  "ff",
- "halo2_gadgets",
+ "halo2_gadgets 0.4.0",
  "imt-tree",
  "incrementalmerkletree",
  "lazy_static",
@@ -6056,13 +6180,13 @@ dependencies = [
  "blake2b_simd",
  "ff",
  "group",
- "halo2_gadgets",
+ "halo2_gadgets 0.4.0",
  "halo2_poseidon",
  "halo2_proofs",
  "incrementalmerkletree",
  "itertools 0.14.0",
  "lazy_static",
- "orchard",
+ "orchard 0.13.1",
  "pasta_curves",
  "rand 0.8.6",
  "sinsemilla",
@@ -6801,9 +6925,9 @@ dependencies = [
  "libc",
  "log-panics",
  "nonempty",
- "orchard",
+ "orchard 0.15.0-pre.0",
  "paranoid-android",
- "pczt",
+ "pczt 0.7.0",
  "prost",
  "rand 0.8.6",
  "rayon",
@@ -6819,15 +6943,15 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "xz2",
- "zcash_address",
+ "zcash_address 0.12.0",
  "zcash_client_backend",
  "zcash_client_sqlite",
  "zcash_note_encryption",
- "zcash_primitives",
+ "zcash_primitives 0.28.0",
  "zcash_proofs",
- "zcash_protocol",
+ "zcash_protocol 0.9.0",
  "zcash_script",
- "zcash_transparent",
+ "zcash_transparent 0.8.0",
  "zcash_voting",
  "zip32",
 ]
@@ -6841,16 +6965,28 @@ dependencies = [
  "bech32",
  "bs58",
  "corez",
- "f4jumble",
- "zcash_encoding",
- "zcash_protocol",
+ "f4jumble 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.8.0",
+]
+
+[[package]]
+name = "zcash_address"
+version = "0.12.0"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
+dependencies = [
+ "bech32",
+ "bs58",
+ "corez",
+ "f4jumble 0.1.1 (git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6)",
+ "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6)",
+ "zcash_protocol 0.9.0",
 ]
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d052d002ffd18bf4f129ab161e0a584c96b3578d9b9e88cd2dafef7df7db408"
+version = "0.23.0"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
 dependencies = [
  "arti-client",
  "base64",
@@ -6859,9 +6995,9 @@ dependencies = [
  "bls12_381",
  "bs58",
  "byteorder",
- "crossbeam-channel",
  "document-features",
  "dynosaur",
+ "flume",
  "fs-mistrust",
  "futures-util",
  "getset",
@@ -6873,9 +7009,9 @@ dependencies = [
  "incrementalmerkletree",
  "memuse",
  "nonempty",
- "orchard",
+ "orchard 0.15.0-pre.0",
  "pasta_curves",
- "pczt",
+ "pczt 0.7.0",
  "percent-encoding",
  "postcard",
  "prost",
@@ -6903,23 +7039,22 @@ dependencies = [
  "trait-variant",
  "webpki-roots",
  "which",
- "zcash_address",
- "zcash_encoding",
- "zcash_keys",
+ "zcash_address 0.12.0",
+ "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6)",
+ "zcash_keys 0.14.0",
  "zcash_note_encryption",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_primitives 0.28.0",
+ "zcash_protocol 0.9.0",
  "zcash_script",
- "zcash_transparent",
+ "zcash_transparent 0.8.0",
  "zip32",
  "zip321",
 ]
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cfbaeaa5b2320720be03e0cc360b471b61f29437c09c9d1412f2030e5dec714"
+version = "0.21.1"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
 dependencies = [
  "bip32",
  "bitflags",
@@ -6932,7 +7067,7 @@ dependencies = [
  "jubjub",
  "maybe-rayon",
  "nonempty",
- "orchard",
+ "orchard 0.15.0-pre.0",
  "prost",
  "rand 0.8.6",
  "rand_core 0.6.4",
@@ -6951,14 +7086,14 @@ dependencies = [
  "time",
  "tracing",
  "uuid",
- "zcash_address",
+ "zcash_address 0.12.0",
  "zcash_client_backend",
- "zcash_encoding",
- "zcash_keys",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6)",
+ "zcash_keys 0.14.0",
+ "zcash_primitives 0.28.0",
+ "zcash_protocol 0.9.0",
  "zcash_script",
- "zcash_transparent",
+ "zcash_transparent 0.8.0",
  "zip32",
 ]
 
@@ -6974,10 +7109,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_encoding"
+version = "0.4.0"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
+dependencies = [
+ "corez",
+ "hex",
+ "nonempty",
+]
+
+[[package]]
 name = "zcash_keys"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b340e2bc20698c4d784d920dcda1f270d076bef2b0726b732ca9ca7574d61241"
+dependencies = [
+ "bech32",
+ "blake2b_simd",
+ "bls12_381",
+ "bs58",
+ "corez",
+ "document-features",
+ "group",
+ "memuse",
+ "nonempty",
+ "orchard 0.13.1",
+ "rand_core 0.6.4",
+ "sapling-crypto",
+ "secrecy",
+ "subtle",
+ "tracing",
+ "zcash_address 0.11.0",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.8.0",
+ "zcash_transparent 0.7.0",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_keys"
+version = "0.14.0"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
 dependencies = [
  "bech32",
  "bip32",
@@ -6990,16 +7162,16 @@ dependencies = [
  "group",
  "memuse",
  "nonempty",
- "orchard",
+ "orchard 0.15.0-pre.0",
  "rand_core 0.6.4",
  "sapling-crypto",
  "secrecy",
  "subtle",
  "tracing",
- "zcash_address",
- "zcash_encoding",
- "zcash_protocol",
- "zcash_transparent",
+ "zcash_address 0.12.0",
+ "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6)",
+ "zcash_protocol 0.9.0",
+ "zcash_transparent 0.8.0",
  "zip32",
 ]
 
@@ -7027,31 +7199,59 @@ dependencies = [
  "corez",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash",
+ "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff",
  "hex",
  "incrementalmerkletree",
  "jubjub",
  "memuse",
  "nonempty",
- "orchard",
+ "orchard 0.13.1",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "sha2 0.10.9",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_note_encryption",
+ "zcash_protocol 0.8.0",
+ "zcash_script",
+ "zcash_transparent 0.7.0",
+]
+
+[[package]]
+name = "zcash_primitives"
+version = "0.28.0"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
+dependencies = [
+ "blake2b_simd",
+ "block-buffer 0.11.0-rc.3",
+ "corez",
+ "crypto-common 0.2.0-rc.1",
+ "document-features",
+ "equihash 0.3.0 (git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6)",
+ "ff",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "memuse",
+ "nonempty",
+ "orchard 0.15.0-pre.0",
  "rand_core 0.6.4",
  "redjubjub",
  "sapling-crypto",
  "secp256k1",
  "sha2 0.10.9",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6)",
  "zcash_note_encryption",
- "zcash_protocol",
+ "zcash_protocol 0.9.0",
  "zcash_script",
- "zcash_transparent",
+ "zcash_transparent 0.8.0",
 ]
 
 [[package]]
 name = "zcash_proofs"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c6749aeaf49a56874d915482bc03e4afb9f6e561ed476b7c906e6d9de3ef74"
+version = "0.28.0"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7066,7 +7266,7 @@ dependencies = [
  "sapling-crypto",
  "tracing",
  "xdg",
- "zcash_primitives",
+ "zcash_primitives 0.28.0",
 ]
 
 [[package]]
@@ -7079,7 +7279,19 @@ dependencies = [
  "document-features",
  "hex",
  "memuse",
- "zcash_encoding",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zcash_protocol"
+version = "0.9.0"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
+dependencies = [
+ "corez",
+ "document-features",
+ "hex",
+ "memuse",
+ "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6)",
 ]
 
 [[package]]
@@ -7125,9 +7337,33 @@ dependencies = [
  "secp256k1",
  "sha2 0.10.9",
  "subtle",
- "zcash_address",
- "zcash_encoding",
- "zcash_protocol",
+ "zcash_address 0.11.0",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.8.0",
+ "zcash_script",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_transparent"
+version = "0.8.0"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
+dependencies = [
+ "bip32",
+ "bs58",
+ "corez",
+ "document-features",
+ "getset",
+ "hex",
+ "nonempty",
+ "ripemd 0.1.3",
+ "secp256k1",
+ "sha2 0.10.9",
+ "subtle",
+ "zcash_address 0.12.0",
+ "zcash_encoding 0.4.0 (git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6)",
+ "zcash_protocol 0.9.0",
  "zcash_script",
  "zcash_spec",
  "zip32",
@@ -7144,7 +7380,7 @@ dependencies = [
  "bytes",
  "ff",
  "group",
- "halo2_gadgets",
+ "halo2_gadgets 0.4.0",
  "halo2_proofs",
  "hex",
  "http",
@@ -7155,9 +7391,9 @@ dependencies = [
  "imt-tree",
  "incrementalmerkletree",
  "nonempty",
- "orchard",
+ "orchard 0.13.1",
  "pasta_curves",
- "pczt",
+ "pczt 0.6.0",
  "pir-client",
  "pir-types",
  "rand 0.8.6",
@@ -7173,9 +7409,9 @@ dependencies = [
  "vote-commitment-tree",
  "vote-commitment-tree-client",
  "voting-circuits",
- "zcash_keys",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_keys 0.13.0",
+ "zcash_primitives 0.27.1",
+ "zcash_protocol 0.8.0",
  "zip32",
 ]
 
@@ -7250,15 +7486,14 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2159ebf6e48565b2fc74a4beae8d906f06657ca61c0db21a0361f15a075feee"
+version = "0.8.0"
+source = "git+https://github.com/zcash/librustzcash?rev=676e8dd64f0b166ee3dcfaadafcc374e536693f6#676e8dd64f0b166ee3dcfaadafcc374e536693f6"
 dependencies = [
  "base64",
  "nom",
  "percent-encoding",
- "zcash_address",
- "zcash_protocol",
+ "zcash_address 0.12.0",
+ "zcash_protocol 0.9.0",
 ]
 
 [[package]]

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -14,15 +14,21 @@ rust-version = "1.92"
 # Enables JNI helpers that are only used by Android instrumentation tests.
 # This feature must not be enabled for production native builds.
 android-test-fixtures = []
+# Deferred while on the Ironwood (NU6.3) pre-release deps — see the zcash_voting
+# entry under [dependencies] and ironwood-migration-execution.md. Off by default.
+voting = ["dep:zcash_voting"]
 
 [dependencies]
 # Zcash dependencies
-orchard = { version = "=0.13.1", features = ["unstable-voting-circuits"] }
-pczt = { version = "0.6", features = ["prover", "orchard", "sapling"] }
+# Ironwood (NU6.3): tracks the same git rev as [patch.crates-io] below directly,
+# since its version (0.15.0-pre.0) can't satisfy a "=0.13.1" crates-io requirement.
+# "unstable-voting-circuits" dropped since it's only needed by the deferred voting feature.
+orchard = { git = "https://github.com/zcash/orchard", rev = "2f322a220d2750c3fa752132f51594b8358f653f" }
+pczt = { version = "0.7", features = ["prover", "orchard", "sapling"] }
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
-transparent = { package = "zcash_transparent", version = "0.7", default-features = false }
-zcash_address = "0.11"
-zcash_client_backend = { version = "0.22", features = [
+transparent = { package = "zcash_transparent", version = "0.8", default-features = false }
+zcash_address = "0.12"
+zcash_client_backend = { version = "0.23", features = [
     "orchard",
     "lightwalletd-tonic-tls-webpki-roots",
     "tor",
@@ -30,11 +36,11 @@ zcash_client_backend = { version = "0.22", features = [
     "unstable",
     "pczt",
 ] }
-zcash_client_sqlite = { version = "0.20.2", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
+zcash_client_sqlite = { version = "0.21", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
 zcash_note_encryption = "0.4.1"
-zcash_primitives = "0.27"
-zcash_proofs = "0.27"
-zcash_protocol = "0.8"
+zcash_primitives = "0.28"
+zcash_proofs = "0.28"
+zcash_protocol = "0.9"
 zcash_script = "0.4"
 zip32 = "0.2"
 eip681 = "0.1.0"
@@ -105,10 +111,30 @@ xz2 = { version = "0.1", features = ["static"] }
 # Expected PIR/tree-sync networking transitives include `pir-client`, `pir-types`,
 # `valar-ypir`, `valar-spiral-rs`, `vote-commitment-tree-client`, and
 # `hyper-rustls`.
-zcash_voting = { version = "0.10.1", default-features = false, features = [
+#
+# Deferred while on the Ironwood (NU6.3) pre-release deps below: zcash_voting's
+# orchard pin can't satisfy the Ironwood pre-release version under semver. Open
+# question for Kris/upstream — see ironwood-migration-execution.md. `voting`
+# feature is off by default until resolved.
+zcash_voting = { version = "0.10.1", default-features = false, optional = true, features = [
     "client-pir",
     "client-tree-sync",
 ] }
+
+# Ironwood (NU6.3) pre-release support: pinned to zcash/librustzcash's feat/ironwood
+# branch instead of crates.io. This is the official org's active integration branch,
+# not a third-party fork — see ironwood-migration-execution.md for why. Unpin once
+# these land on crates.io as published pre-releases.
+[patch.crates-io]
+zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "676e8dd64f0b166ee3dcfaadafcc374e536693f6" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "676e8dd64f0b166ee3dcfaadafcc374e536693f6" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "676e8dd64f0b166ee3dcfaadafcc374e536693f6" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "676e8dd64f0b166ee3dcfaadafcc374e536693f6" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "676e8dd64f0b166ee3dcfaadafcc374e536693f6" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "676e8dd64f0b166ee3dcfaadafcc374e536693f6" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "676e8dd64f0b166ee3dcfaadafcc374e536693f6" }
+pczt = { git = "https://github.com/zcash/librustzcash", rev = "676e8dd64f0b166ee3dcfaadafcc374e536693f6" }
+orchard = { git = "https://github.com/zcash/orchard", rev = "2f322a220d2750c3fa752132f51594b8358f653f" }
 
 ## Uncomment this to test librustzcash changes locally
 #[patch.crates-io]

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -104,6 +104,8 @@ mod eip681;
 mod ironwood_migration;
 mod tor;
 mod utils;
+// Deferred while on Ironwood (NU6.3) pre-release deps — see Cargo.toml [features] voting.
+#[cfg(feature = "voting")]
 mod voting;
 
 #[cfg(debug_assertions)]
@@ -1360,7 +1362,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_rewindToH
         let mut db_data = wallet_db(env, network, db_data)?;
 
         let height = BlockHeight::try_from(height)?;
-        let rewind_result = db_data.rewind_to_height(height);
+        let rewind_result = db_data.truncate_to_height(height);
 
         Ok(encode_rewind_result(env, height, rewind_result)?.into_raw())
     });
@@ -1966,6 +1968,11 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_putUtxo<'
                 script_pubkey,
             },
             Some(BlockHeight::from(height as u32)),
+            // This FFI call doesn't carry account context (same as before this API
+            // gained these fields) — left unset, consistent with prior behavior.
+            None,
+            None,
+            None,
         )
         .ok_or_else(|| anyhow!("UTXO is not P2PKH or P2SH"))?;
 
@@ -2393,7 +2400,13 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_createPcz
             )
             .map_err(|e| anyhow!("Error creating PCZT from single-step proposal: {}", e))?;
 
-            Ok(utils::rust_bytes_to_java(env, &pczt.serialize())?.into_raw())
+            Ok(utils::rust_bytes_to_java(
+                env,
+                &pczt
+                    .serialize()
+                    .map_err(|e| anyhow!("Error serializing PCZT: {:?}", e))?,
+            )?
+            .into_raw())
         } else {
             Err(anyhow!(
                 "Multi-step proposals are not yet supported for PCZT generation."
@@ -2440,7 +2453,13 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_redactPcz
             })
             .finish();
 
-        Ok(utils::rust_bytes_to_java(env, &pczt_with_proofs.serialize())?.into_raw())
+        Ok(utils::rust_bytes_to_java(
+            env,
+            &pczt_with_proofs
+                .serialize()
+                .map_err(|e| anyhow!("Error serializing PCZT with proofs: {:?}", e))?,
+        )?
+        .into_raw())
     });
     unwrap_exc_or(&mut env, res, ptr::null_mut())
 }
@@ -2491,7 +2510,12 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_addProofs
 
         if prover.requires_orchard_proof() {
             prover = prover
-                .create_orchard_proof(&orchard::circuit::ProvingKey::build())
+                .create_orchard_proof(&orchard::circuit::ProvingKey::build(
+                    // Matches the PCZT extractor's own default for regular Orchard-pool
+                    // proving (see pczt's tx_extractor::orchard::verify_bundle); PostNu6_3
+                    // is reserved for the separate create_ironwood_proof path.
+                    orchard::circuit::OrchardCircuitVersion::FixedPostNu6_2,
+                ))
                 .map_err(|e| anyhow!("Failed to create Orchard proof for PCZT: {:?}", e))?;
         }
         assert!(!prover.requires_orchard_proof());
@@ -2509,7 +2533,13 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_addProofs
 
         let pczt_with_proofs = prover.finish();
 
-        Ok(utils::rust_bytes_to_java(env, &pczt_with_proofs.serialize())?.into_raw())
+        Ok(utils::rust_bytes_to_java(
+            env,
+            &pczt_with_proofs
+                .serialize()
+                .map_err(|e| anyhow!("Error serializing PCZT with proofs: {:?}", e))?,
+        )?
+        .into_raw())
     });
     unwrap_exc_or(&mut env, res, ptr::null_mut())
 }
@@ -2555,7 +2585,11 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_extractAn
             &mut db_data,
             pczt,
             Some((&spend_vk, &output_vk)),
-            Some(&orchard::circuit::VerifyingKey::build()),
+            Some(&orchard::circuit::VerifyingKey::build(
+                // Regular Orchard-pool extraction, not Ironwood — see comment on the
+                // create_orchard_proof call site above.
+                orchard::circuit::OrchardCircuitVersion::FixedPostNu6_2,
+            )),
         )
         .map_err(|e| anyhow!("Failed to extract transaction from PCZT: {:?}", e))?;
 

--- a/backend-lib/src/main/rust/tor.rs
+++ b/backend-lib/src/main/rust/tor.rs
@@ -17,6 +17,7 @@ use zcash_client_backend::{
     tor::{Client, DormantMode},
     wallet::WalletTransparentOutput,
 };
+use zcash_client_sqlite::AccountUuid;
 use zcash_protocol::{
     TxId,
     consensus::{self, BlockHeight},
@@ -174,7 +175,7 @@ impl LwdConn {
         address: TransparentAddress,
         start: Option<BlockHeight>,
         limit: Option<u32>,
-        mut f: impl FnMut(WalletTransparentOutput) -> anyhow::Result<()>,
+        mut f: impl FnMut(WalletTransparentOutput<AccountUuid>) -> anyhow::Result<()>,
     ) -> anyhow::Result<()> {
         let request = service::GetAddressUtxosArg {
             addresses: vec![address.encode(params)],
@@ -197,6 +198,11 @@ impl LwdConn {
                         Script(script::Code(result.script)),
                     ),
                     Some(BlockHeight::from(u32::try_from(result.height)?)),
+                    // This UTXO discovery call doesn't carry account context (same as
+                    // before this API gained these fields) — left unset.
+                    None,
+                    None,
+                    None,
                 )
                 .ok_or(anyhow!(
                     "Received UTXO that doesn't correspond to a valid P2PKH or P2SH address"


### PR DESCRIPTION
## Summary

- Wires `backend-lib`'s `Cargo.toml` `[patch.crates-io]` + new `.cargo/config.toml` to `zcash/librustzcash`'s official `feat/ironwood` branch (pinned by commit sha) and the matching `zcash/orchard` rev, with the `--cfg zcash_unstable="nu6.3"` flag enabled. This is what gates `Builder::add_ironwood_output()`/`BuildConfig::Standard.ironwood_anchor` — the actual mechanism Orchard -> Ironwood migration transactions will be built with (confirmed by reading Valar's vizor-wallet reference implementation directly; mirrors the iOS SDK's #1792).
- Required bumping baseline crate versions ahead of the Ironwood patch, since Android's pins predated the same bumps already applied on iOS: `pczt` 0.6 -> 0.7, `zcash_client_backend` 0.22 -> 0.23, `zcash_client_sqlite` 0.20.2 -> 0.21, `zcash_primitives`/`zcash_proofs` 0.27 -> 0.28, `zcash_protocol` 0.8 -> 0.9, `zcash_transparent` 0.7 -> 0.8.
- `zcash_voting` is made optional behind a new off-by-default `voting` Cargo feature (`mod voting` gated accordingly). Its `orchard = "0.13.1"` pin can't satisfy the Ironwood pre-release (`0.15.0-pre.0`) under semver — same open question for upstream/Kris as on iOS, tracked in `ironwood-migration-execution.md`.
- Fixes the resulting upstream API drift in `src/main/rust/lib.rs` and `src/main/rust/tor.rs`: `rewind_to_height` -> `truncate_to_height` rename, `WalletTransparentOutput::from_parts` gained three `Option` args (left unset, consistent with prior behavior at these call sites), `Pczt::serialize()` now returns a `Result`, and both `orchard::circuit::ProvingKey::build()` and `VerifyingKey::build()` now require an `OrchardCircuitVersion` (using `FixedPostNu6_2` to match the PCZT extractor's own default for regular Orchard-pool proving).
- `.cargo/config.toml` is force-added since `.cargo/` is gitignored in this repo as a "generated files" entry — it isn't generated here, it's required for the build's `nu6.3` cfg flag.

Stacked on #2008 — depends on its denomination-split planning work merging first.

This is dependency wiring only; no new transaction-building logic yet (that's the next PR in the migration series).

## Test plan

- [x] `cargo check` (from `backend-lib/`) — zero errors, zero dependency-graph conflicts
- [ ] `./gradlew build`
- [ ] Instrumentation tests