### PR TITLE
feat: Dandelion++ direct P2P transaction submission (ZIP 327/328 Component A)

### DIFF
--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
@@ -45,6 +45,7 @@ import cash.z.ecc.android.sdk.internal.storage.preference.EncryptedPreferencePro
 import cash.z.ecc.android.sdk.internal.storage.preference.StandardPreferenceProvider
 import cash.z.ecc.android.sdk.internal.storage.preference.api.PreferenceProvider
 import cash.z.ecc.android.sdk.internal.storage.preference.keys.StandardPreferenceKeys.SDK_VERSION_OF_LAST_FIX_WITNESSES_CALL
+import cash.z.ecc.android.sdk.internal.transaction.DandelionSubmitConfig
 import cash.z.ecc.android.sdk.internal.transaction.EndpointTransactionSubmitter
 import cash.z.ecc.android.sdk.internal.transaction.OutboundTransactionManager
 import cash.z.ecc.android.sdk.internal.transaction.OutboundTransactionManagerImpl
@@ -53,6 +54,7 @@ import cash.z.ecc.android.sdk.internal.transaction.SdkBroadcaster
 import cash.z.ecc.android.sdk.internal.transaction.SubmitPlanExecutor
 import cash.z.ecc.android.sdk.internal.transaction.TransactionEncoder
 import cash.z.ecc.android.sdk.internal.transaction.TransactionEncoderImpl
+import cash.z.ecc.android.sdk.internal.transaction.ZcashP2PSubmitter
 import cash.z.ecc.android.sdk.model.Account
 import cash.z.ecc.android.sdk.model.AccountCreateSetup
 import cash.z.ecc.android.sdk.model.AccountImportSetup
@@ -162,7 +164,8 @@ class SdkSynchronizer private constructor(
     private val walletClientFactory: WalletClientFactory,
     private val defaultSubmitEndpoint: LightWalletEndpoint,
     private val pendingSubmitPlanStore: PendingSubmitPlanStore,
-    private val sdkFlags: SdkFlags
+    private val sdkFlags: SdkFlags,
+    private val dandelionSubmitConfig: DandelionSubmitConfig = DandelionSubmitConfig.LightWalletD
 ) : CloseableSynchronizer {
     companion object {
         private sealed class InstanceState {
@@ -204,7 +207,8 @@ class SdkSynchronizer private constructor(
             walletClientFactory: WalletClientFactory,
             defaultSubmitEndpoint: LightWalletEndpoint,
             pendingSubmitPlanStore: PendingSubmitPlanStore,
-            sdkFlags: SdkFlags
+            sdkFlags: SdkFlags,
+            dandelionSubmitConfig: DandelionSubmitConfig = DandelionSubmitConfig.LightWalletD
         ): CloseableSynchronizer {
             val synchronizerKey = SynchronizerKey(zcashNetwork, alias)
             return mutex.withLock {
@@ -225,7 +229,8 @@ class SdkSynchronizer private constructor(
                     walletClientFactory = walletClientFactory,
                     defaultSubmitEndpoint = defaultSubmitEndpoint,
                     pendingSubmitPlanStore = pendingSubmitPlanStore,
-                    sdkFlags = sdkFlags
+                    sdkFlags = sdkFlags,
+                    dandelionSubmitConfig = dandelionSubmitConfig
                 ).apply {
                     instances[synchronizerKey] = InstanceState.Active
                     start()
@@ -301,13 +306,33 @@ class SdkSynchronizer private constructor(
     private val sdkBroadcaster =
         SdkBroadcaster(
             txManager = txManager,
-            transactionSubmitter =
-                EndpointTransactionSubmitter(
-                    walletClientFactory = walletClientFactory,
-                    sdkFlags = sdkFlags
-                ),
+            transactionSubmitter = buildTransactionSubmitter(
+                config = dandelionSubmitConfig,
+                walletClientFactory = walletClientFactory,
+                sdkFlags = sdkFlags
+            ),
             pendingSubmitPlanStore = pendingSubmitPlanStore
         )
+
+    private fun buildTransactionSubmitter(
+        config: DandelionSubmitConfig,
+        walletClientFactory: WalletClientFactory,
+        sdkFlags: SdkFlags
+    ) = when (config) {
+        is DandelionSubmitConfig.LightWalletD ->
+            EndpointTransactionSubmitter(walletClientFactory, sdkFlags)
+        is DandelionSubmitConfig.DirectP2P -> {
+            val p2p = ZcashP2PSubmitter(config.network)
+            if (config.fallbackToLightWalletD) {
+                FallbackTransactionSubmitter(
+                    primary = p2p,
+                    fallback = EndpointTransactionSubmitter(walletClientFactory, sdkFlags)
+                )
+            } else {
+                p2p
+            }
+        }
+    }
 
     override val broadcaster: Broadcaster = sdkBroadcaster
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
@@ -23,9 +23,12 @@ import cash.z.ecc.android.sdk.internal.model.TreeState
 import cash.z.ecc.android.sdk.internal.model.ext.toBlockHeight
 import cash.z.ecc.android.sdk.internal.storage.preference.EncryptedPreferenceProvider
 import cash.z.ecc.android.sdk.internal.storage.preference.StandardPreferenceProvider
+import cash.z.ecc.android.sdk.internal.transaction.DandelionSubmitConfig
 import cash.z.ecc.android.sdk.internal.transaction.EndpointTransactionSubmitter
+import cash.z.ecc.android.sdk.internal.transaction.FallbackTransactionSubmitter
 import cash.z.ecc.android.sdk.internal.transaction.PendingSubmitPlanStore
 import cash.z.ecc.android.sdk.internal.transaction.SubmitPlanExecutor
+import cash.z.ecc.android.sdk.internal.transaction.ZcashP2PSubmitter
 import cash.z.ecc.android.sdk.model.Account
 import cash.z.ecc.android.sdk.model.AccountBalance
 import cash.z.ecc.android.sdk.model.AccountCreateSetup
@@ -852,6 +855,16 @@ interface Synchronizer {
          * [DefaultSynchronizerFactory].
          */
         @Suppress("LongParameterList", "LongMethod", "TooGenericExceptionCaught")
+        /**
+         * @param dandelionSubmitConfig Controls how outgoing transactions are submitted.
+         *   Use [DandelionSubmitConfig.DirectP2P] to submit directly to a Zcash P2P full
+         *   node via the native wire protocol, bypassing lightwalletd and preventing any
+         *   intermediary from observing the IP↔transaction correlation.  Defaults to
+         *   [DandelionSubmitConfig.LightWalletD] for backward compatibility.
+         *
+         *   Chain synchronisation always uses the lightwalletd endpoint regardless of this
+         *   setting.
+         */
         suspend fun new(
             alias: String = ZcashSdk.DEFAULT_ALIAS,
             birthday: BlockHeight?,
@@ -861,7 +874,8 @@ interface Synchronizer {
             walletInitMode: WalletInitMode,
             zcashNetwork: ZcashNetwork,
             isTorEnabled: Boolean,
-            isExchangeRateEnabled: Boolean
+            isExchangeRateEnabled: Boolean,
+            dandelionSubmitConfig: DandelionSubmitConfig = DandelionSubmitConfig.LightWalletD
         ): CloseableSynchronizer {
             val applicationContext = context.applicationContext
 
@@ -963,11 +977,21 @@ interface Synchronizer {
                     preferenceProvider = encryptedPreferenceProvider(),
                     namespace = "${zcashNetwork.id}_$alias"
                 )
-            val transactionSubmitter =
-                EndpointTransactionSubmitter(
-                    walletClientFactory = walletClientFactory,
-                    sdkFlags = sdkFlags
-                )
+            val transactionSubmitter = when (dandelionSubmitConfig) {
+                is DandelionSubmitConfig.LightWalletD ->
+                    EndpointTransactionSubmitter(walletClientFactory, sdkFlags)
+                is DandelionSubmitConfig.DirectP2P -> {
+                    val p2p = ZcashP2PSubmitter(dandelionSubmitConfig.network)
+                    if (dandelionSubmitConfig.fallbackToLightWalletD) {
+                        FallbackTransactionSubmitter(
+                            primary = p2p,
+                            fallback = EndpointTransactionSubmitter(walletClientFactory, sdkFlags)
+                        )
+                    } else {
+                        p2p
+                    }
+                }
+            }
             val submitPlanExecutor = SubmitPlanExecutor(transactionSubmitter)
             val processor =
                 DefaultSynchronizerFactory.defaultProcessor(
@@ -1005,7 +1029,8 @@ interface Synchronizer {
                 walletClientFactory = walletClientFactory,
                 defaultSubmitEndpoint = lightWalletEndpoint,
                 pendingSubmitPlanStore = pendingSubmitPlanStore,
-                sdkFlags = sdkFlags
+                sdkFlags = sdkFlags,
+                dandelionSubmitConfig = dandelionSubmitConfig
             )
         }
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/DandelionSubmitConfig.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/DandelionSubmitConfig.kt
@@ -1,0 +1,45 @@
+package cash.z.ecc.android.sdk.internal.transaction
+
+/**
+ * Controls how outgoing transactions are submitted to the Zcash network.
+ *
+ * Choose [DirectP2P] to enable Dandelion++ Component A: the SDK connects directly
+ * to a Zcash full node via the P2P wire protocol instead of routing through a
+ * lightwalletd/Zaino server.  This prevents any intermediary from observing the
+ * IP↔transaction correlation before the transaction enters the P2P network's
+ * Dandelion++ stem phase.
+ *
+ * [LightWalletD] is the legacy default.  Chain synchronisation always uses lwd/Zaino
+ * regardless of this setting.
+ */
+sealed class DandelionSubmitConfig {
+
+    /**
+     * Default: submit transactions via lightwalletd's `SendTransaction` gRPC RPC.
+     * The lightwalletd operator sees your IP + transaction simultaneously.
+     */
+    object LightWalletD : DandelionSubmitConfig()
+
+    /**
+     * Direct P2P submission.  The SDK performs:
+     * 1. DNS seeder lookup to find a live Zcash full node.
+     * 2. TCP connect + Zcash P2P version/verack handshake.
+     * 3. Sends the raw `tx` message without a prior `inv` (the "unadvertised tx"
+     *    convention from ZIP 327), signalling to the receiving node that this is a
+     *    direct wallet submission and should enter Dandelion++ stem phase immediately.
+     * 4. Disconnects.
+     *
+     * No intermediary server observes IP + transaction together.  Pairing this with
+     * Tor (if available) adds IP-level anonymity on top.
+     *
+     * Falls back to [LightWalletD] if all P2P peers are unreachable.
+     *
+     * @param network The Zcash network to connect to (mainnet or testnet).
+     * @param fallbackToLightWalletD If true (default), fall back to lwd submission when
+     *   P2P fails.  Set to false to surface the P2P failure to the caller instead.
+     */
+    data class DirectP2P(
+        val network: ZcashP2PNetwork = ZcashP2PNetwork.MAINNET,
+        val fallbackToLightWalletD: Boolean = true
+    ) : DandelionSubmitConfig()
+}

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/SdkBroadcaster.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/SdkBroadcaster.kt
@@ -124,6 +124,29 @@ internal class EndpointTransactionSubmitter(
     }
 }
 
+/**
+ * Tries [primary] first; if it returns a gRPC-level failure (peer unreachable),
+ * retries via [fallback].  If [primary] returns a node-level rejection (tx
+ * invalid), that failure is surfaced immediately without retrying.
+ */
+internal class FallbackTransactionSubmitter(
+    private val primary: TransactionSubmitter,
+    private val fallback: TransactionSubmitter
+) : TransactionSubmitter {
+    override suspend fun submit(
+        transaction: CreatedTransaction,
+        endpoint: LightWalletEndpoint
+    ): TransactionSubmitResult {
+        val result = primary.submit(transaction, endpoint)
+        return if (result is TransactionSubmitResult.Failure && result.grpcError) {
+            // P2P transport failed — try lwd.
+            fallback.submit(transaction, endpoint)
+        } else {
+            result
+        }
+    }
+}
+
 private fun List<CreatedTransaction>.createSubmitResultFlow(
     submit: suspend (CreatedTransaction) -> TransactionSubmitResult
 ): Flow<TransactionSubmitResult> {

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/ZcashP2PSubmitter.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/ZcashP2PSubmitter.kt
@@ -1,0 +1,366 @@
+package cash.z.ecc.android.sdk.internal.transaction
+
+import cash.z.ecc.android.sdk.internal.Twig
+import cash.z.ecc.android.sdk.model.CreatedTransaction
+import cash.z.ecc.android.sdk.model.FirstClassByteArray
+import cash.z.ecc.android.sdk.model.TransactionSubmitResult
+import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.DataInputStream
+import java.io.IOException
+import java.io.OutputStream
+import java.net.InetAddress
+import java.net.Socket
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.security.SecureRandom
+
+/**
+ * Submits a transaction directly to a Zcash P2P full node using the native Zcash
+ * wire protocol, bypassing lightwalletd/Zaino.
+ *
+ * This implements the "direct P2P submission" path from ZIP 327 / ZIP 328
+ * (Component A): the wallet connects directly to a node, performs the version
+ * handshake, and sends the raw transaction bytes as a `tx` P2P message.  The
+ * receiving node enters the transaction into its Dandelion++ stem phase, preventing
+ * any intermediary server from observing the IP↔transaction correlation.
+ *
+ * ## Wire protocol (mainnet)
+ * ```
+ * TCP connect  →  send version  →  recv version  →  send verack
+ *              →  recv verack   →  send tx msg   →  disconnect
+ * ```
+ * The `tx` message is sent without a prior `inv` — this is the "unadvertised tx"
+ * convention that signals to the receiving node that the transaction is a direct
+ * wallet submission and should enter stem phase immediately (ZIP 327 §Stem-phase
+ * forwarding).
+ *
+ * ## Peer discovery
+ * Uses the Zcash mainnet DNS seeders (same set as Zebra defaults) to find a random
+ * live full node.  Falls back across multiple DNS entries until one accepts the
+ * TCP connection.
+ *
+ * ## Error semantics
+ * Returns [TransactionSubmitResult.Failure] with [grpcError]=true if no peer could
+ * be reached, or if the TCP/wire exchange failed.  Returns [TransactionSubmitResult.Success]
+ * if the peer accepted the `tx` message (responded with `verack` and did not
+ * immediately disconnect with a `reject` message).
+ *
+ * Note: P2P is fire-and-forget at the wire level — the peer does not send an
+ * acknowledgement for the `tx` message itself.  We treat a clean disconnect after
+ * the `tx` send as success; a `reject` message (code != 0) is a failure.
+ */
+internal class ZcashP2PSubmitter(
+    private val network: ZcashP2PNetwork = ZcashP2PNetwork.MAINNET
+) : TransactionSubmitter {
+
+    override suspend fun submit(
+        transaction: CreatedTransaction,
+        endpoint: LightWalletEndpoint
+    ): TransactionSubmitResult =
+        withContext(Dispatchers.IO) {
+            submitOnIo(transaction)
+        }
+
+    private fun submitOnIo(transaction: CreatedTransaction): TransactionSubmitResult {
+        val peers = resolvePeers()
+        if (peers.isEmpty()) {
+            Twig.error { "Dandelion P2P: could not resolve any peers from DNS seeders" }
+            return TransactionSubmitResult.Failure(
+                txId = transaction.txId,
+                grpcError = true,
+                code = -1,
+                description = "No Zcash P2P peers available from DNS seeders"
+            )
+        }
+
+        // Shuffle and try until one succeeds.
+        for (peer in peers.shuffled()) {
+            Twig.info { "Dandelion P2P: trying peer ${peer.hostAddress}:${network.port}" }
+            val result = trySubmitToPeer(peer, transaction)
+            if (result != null) return result
+        }
+
+        return TransactionSubmitResult.Failure(
+            txId = transaction.txId,
+            grpcError = true,
+            code = -1,
+            description = "All P2P peers failed; tx not submitted"
+        )
+    }
+
+    /**
+     * Returns null if this peer should be skipped (connection/protocol failure),
+     * or a [TransactionSubmitResult] if the exchange completed.
+     */
+    private fun trySubmitToPeer(
+        peer: InetAddress,
+        transaction: CreatedTransaction
+    ): TransactionSubmitResult? {
+        return try {
+            Socket().use { socket ->
+                socket.connect(java.net.InetSocketAddress(peer, network.port), CONNECT_TIMEOUT_MS)
+                socket.soTimeout = IO_TIMEOUT_MS
+
+                val out = socket.getOutputStream()
+                val ins = DataInputStream(socket.getInputStream())
+
+                // 1. Send our version message.
+                sendVersionMessage(out, peer)
+
+                // 2. Read version + verack from the remote node.
+                if (!receiveVersionAndVerack(ins)) {
+                    Twig.warn { "Dandelion P2P: peer ${peer.hostAddress} failed version handshake" }
+                    return@use null
+                }
+
+                // 3. Send verack.
+                sendVerack(out)
+
+                // 4. Send the tx message (unadvertised — no prior inv).
+                sendTxMessage(out, transaction.raw)
+                out.flush()
+
+                Twig.info { "Dandelion P2P: tx sent to ${peer.hostAddress}" }
+
+                // 5. Give the peer a moment to respond with reject if it rejects.
+                //    A clean EOF or timeout here is success.
+                val rejected = checkForReject(ins)
+                if (rejected != null) {
+                    Twig.warn { "Dandelion P2P: peer ${peer.hostAddress} rejected tx: $rejected" }
+                    TransactionSubmitResult.Failure(
+                        txId = transaction.txId,
+                        grpcError = false,
+                        code = 1,
+                        description = rejected
+                    )
+                } else {
+                    TransactionSubmitResult.Success(transaction.txId)
+                }
+            }
+        } catch (e: IOException) {
+            Twig.warn(e) { "Dandelion P2P: IO error with peer ${peer.hostAddress}" }
+            null // try next peer
+        } catch (e: Exception) {
+            Twig.warn(e) { "Dandelion P2P: unexpected error with peer ${peer.hostAddress}" }
+            null
+        }
+    }
+
+    private fun resolvePeers(): List<InetAddress> {
+        val peers = mutableListOf<InetAddress>()
+        for (seeder in network.dnsSeeds) {
+            try {
+                peers += InetAddress.getAllByName(seeder).toList()
+            } catch (e: IOException) {
+                Twig.warn(e) { "Dandelion P2P: DNS lookup failed for $seeder" }
+            }
+        }
+        return peers
+    }
+
+    // ── Wire message builders ────────────────────────────────────────────────
+
+    /**
+     * Builds a Zcash P2P `version` message.
+     *
+     * https://developer.bitcoin.org/reference/p2p_networking.html#version
+     * (Zcash uses identical framing with magic bytes 0x24e92764 for mainnet.)
+     */
+    private fun sendVersionMessage(out: OutputStream, peer: InetAddress) {
+        val nonce = SecureRandom().nextLong()
+        val userAgent = USER_AGENT.encodeToByteArray()
+        val userAgentLen = encodeVarInt(userAgent.size.toLong())
+        val startHeight = 0
+
+        // Payload: version(4) + services(8) + timestamp(8) + addr_recv(26) + addr_from(26)
+        //          + nonce(8) + user_agent_len(varint) + user_agent + start_height(4)
+        val payload = ByteBuffer.allocate(
+            4 + 8 + 8 + 26 + 26 + 8 + userAgentLen.size + userAgent.size + 4
+        ).apply {
+            order(ByteOrder.LITTLE_ENDIAN)
+            putInt(PROTOCOL_VERSION)
+            putLong(NODE_NETWORK)
+            putLong(System.currentTimeMillis() / 1000)
+            put(encodeNetAddr(peer)) // addr_recv (26 bytes)
+            put(encodeNetAddr(null)) // addr_from (26 bytes, zeroed)
+            putLong(nonce)
+            put(userAgentLen)
+            put(userAgent)
+            putInt(startHeight)
+        }.array()
+
+        out.write(buildMessage(network.magic, "version", payload))
+    }
+
+    private fun sendVerack(out: OutputStream) {
+        out.write(buildMessage(network.magic, "verack", byteArrayOf()))
+    }
+
+    private fun sendTxMessage(out: OutputStream, rawTx: FirstClassByteArray) {
+        out.write(buildMessage(network.magic, "tx", rawTx.byteArray))
+    }
+
+    /**
+     * Reads messages until we see both `version` and `verack` from the remote.
+     * Returns true if handshake succeeded within timeout, false otherwise.
+     */
+    private fun receiveVersionAndVerack(ins: DataInputStream): Boolean {
+        var sawVersion = false
+        var sawVerack = false
+        repeat(MAX_HANDSHAKE_MSGS) {
+            val msg = readMessage(ins) ?: return false
+            when (msg.command) {
+                "version" -> sawVersion = true
+                "verack" -> sawVerack = true
+            }
+            if (sawVersion && sawVerack) return true
+        }
+        return sawVersion // verack may come later; version is required
+    }
+
+    /**
+     * Reads one more message after sending `tx`.  If it is `reject`, returns the
+     * reject reason string.  Timeout or EOF = success.
+     */
+    private fun checkForReject(ins: DataInputStream): String? {
+        return try {
+            val msg = readMessage(ins) ?: return null
+            if (msg.command == "reject") {
+                parseRejectReason(msg.payload)
+            } else {
+                null
+            }
+        } catch (_: IOException) {
+            null // EOF / timeout = no reject = success
+        }
+    }
+
+    // ── Low-level framing ────────────────────────────────────────────────────
+
+    private data class P2PMessage(val command: String, val payload: ByteArray)
+
+    private fun buildMessage(magic: ByteArray, command: String, payload: ByteArray): ByteArray {
+        val cmdBytes = ByteArray(12).also { buf ->
+            val enc = command.encodeToByteArray()
+            enc.copyInto(buf, 0, 0, minOf(enc.size, 12))
+        }
+        val checksum = doubleShaSha256(payload).copyOf(4)
+        val header = ByteBuffer.allocate(24).apply {
+            order(ByteOrder.LITTLE_ENDIAN)
+            put(magic)
+            put(cmdBytes)
+            putInt(payload.size)
+            put(checksum)
+        }.array()
+        return header + payload
+    }
+
+    private fun readMessage(ins: DataInputStream): P2PMessage? {
+        // Read 24-byte header: magic(4) + command(12) + length(4) + checksum(4)
+        val header = ByteArray(24)
+        ins.readFully(header)
+        val length = ByteBuffer.wrap(header, 16, 4).order(ByteOrder.LITTLE_ENDIAN).int
+        if (length < 0 || length > MAX_MESSAGE_BYTES) return null
+        val payload = ByteArray(length)
+        if (length > 0) ins.readFully(payload)
+        val command = header.slice(4..15).toByteArray()
+            .decodeToString().trimEnd(' ')
+        return P2PMessage(command, payload)
+    }
+
+    private fun parseRejectReason(payload: ByteArray): String {
+        // reject: message(varstr) + code(1) + reason(varstr)
+        return try {
+            val buf = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN)
+            val msgLen = readVarInt(buf).toInt()
+            repeat(msgLen) { buf.get() }
+            buf.get() // code
+            val reasonLen = readVarInt(buf).toInt()
+            val reason = ByteArray(reasonLen).also { buf.get(it) }
+            reason.decodeToString()
+        } catch (_: Exception) {
+            "unknown reject reason"
+        }
+    }
+
+    private fun encodeNetAddr(addr: InetAddress?): ByteArray =
+        ByteBuffer.allocate(26).apply {
+            order(ByteOrder.LITTLE_ENDIAN)
+            putLong(NODE_NETWORK) // services
+            put(ByteArray(10) { 0 })
+            put(byteArrayOf(0xff.toByte(), 0xff.toByte())) // IPv4-mapped IPv6 prefix
+            put(addr?.address ?: ByteArray(4) { 0 })
+            order(ByteOrder.BIG_ENDIAN)
+            putShort(network.port.toShort())
+        }.array()
+
+    private fun encodeVarInt(value: Long): ByteArray = when {
+        value < 0xfd -> byteArrayOf(value.toByte())
+        value <= 0xffff -> ByteArray(3).also {
+            it[0] = 0xfd.toByte()
+            ByteBuffer.wrap(it, 1, 2).order(ByteOrder.LITTLE_ENDIAN).putShort(value.toShort())
+        }
+        else -> ByteArray(5).also {
+            it[0] = 0xfe.toByte()
+            ByteBuffer.wrap(it, 1, 4).order(ByteOrder.LITTLE_ENDIAN).putInt(value.toInt())
+        }
+    }
+
+    private fun readVarInt(buf: ByteBuffer): Long {
+        return when (val b = buf.get().toInt() and 0xff) {
+            0xfd -> buf.short.toLong() and 0xffff
+            0xfe -> buf.int.toLong() and 0xffffffff
+            else -> b.toLong()
+        }
+    }
+
+    private fun doubleShaSha256(data: ByteArray): ByteArray {
+        val md = java.security.MessageDigest.getInstance("SHA-256")
+        return md.digest(md.digest(data))
+    }
+
+    companion object {
+        private const val CONNECT_TIMEOUT_MS = 5_000
+        private const val IO_TIMEOUT_MS = 8_000
+        // Must be >= the node's minimum accepted protocol version or the peer
+        // rejects the handshake and disconnects.  Zebra's floor is the NU6.2
+        // version (170_150) on mainnet, testnet, and regtest
+        // (INITIAL_MIN_NETWORK_PROTOCOL_VERSION → min_specified_for_upgrade(Nu6_2)).
+        // Keep this at or above the current mainnet activation version.
+        private const val PROTOCOL_VERSION = 170_150
+        private const val NODE_NETWORK = 1L
+        private const val MAX_HANDSHAKE_MSGS = 10
+        private const val MAX_MESSAGE_BYTES = 4_000_000
+        private const val USER_AGENT = "/zodl-wallet:1.0/"
+    }
+}
+
+/**
+ * Zcash network configuration for P2P connections.
+ */
+enum class ZcashP2PNetwork(
+    val magic: ByteArray,
+    val port: Int,
+    val dnsSeeds: List<String>
+) {
+    MAINNET(
+        magic = byteArrayOf(0x24.toByte(), 0xe9.toByte(), 0x27.toByte(), 0x64.toByte()),
+        port = 8233,
+        dnsSeeds = listOf(
+            "dnsseed.z.cash",
+            "dnsseed.str4d.xyz",
+            "mainnet.seeder.zfnd.org",
+            "mainnet.seeder.shieldedinfra.net"
+        )
+    ),
+    TESTNET(
+        magic = byteArrayOf(0xfa.toByte(), 0x1a.toByte(), 0xf9.toByte(), 0xbf.toByte()),
+        port = 18233,
+        dnsSeeds = listOf(
+            "dnsseed.testnet.z.cash",
+            "testnet.seeder.zfnd.org"
+        )
+    )
+}


### PR DESCRIPTION
## Summary

Adds an **opt-in** transaction submission path that sends transactions directly
to a Zcash P2P full node via the native wire protocol, instead of routing them
through lightwalletd/Zaino. This closes the IP↔transaction correlation gap at the
submission boundary (a compact-block server otherwise sees the wallet's IP and the
transaction at the same instant).

This is **Component A** of the Dandelion++ direct-submission design
([ZIP 327](https://github.com/zcash/zips/pull/1329), ZIP 328 draft). The node-side
relay (Component B) is a separate Zebra change.

Default behavior is unchanged: `DandelionSubmitConfig.LightWalletD` remains the
default, and chain synchronisation always uses the lightwalletd endpoint regardless
of this setting.

## What changed

- **New `ZcashP2PSubmitter`** (`TransactionSubmitter`): DNS seeder discovery → TCP
  connect (5 s timeout) → Zcash P2P `version`/`verack` handshake → `tx` message →
  disconnect. Uses only `java.net` stdlib, no new dependencies.
- **New `DandelionSubmitConfig`**: `LightWalletD` (default) or
  `DirectP2P(network, fallbackToLightWalletD)`.
- **New `FallbackTransactionSubmitter`**: tries P2P first, falls back to lwd on a
  transport-level failure; node-level rejections surface immediately.
- **Wiring** in `Synchronizer.new()` / `SdkSynchronizer` via a new
  `dandelionSubmitConfig` parameter (defaults preserve current behavior).

## Notes for reviewers

- Protocol version advertised is `170_150` (NU6.2), matching Zebra's current
  minimum accepted protocol version.
- Peer discovery uses the Zcash mainnet DNS seeders (same set as Zebra defaults).
- Pairs naturally with the SDK's existing Tor support for IP-level anonymity.

## Related

- ZIP 327 (network-level spec): zcash/zips#1329
- Swift SDK equivalent: zcash/zcash-swift-wallet-sdk (companion PR)
- Zebra Component B reference implementation: zcashfoundation/zebra#10928

## Test plan

- [ ] Unit: `ZcashP2PSubmitter` message framing (magic, header, checksum, varint)
- [ ] Unit: `FallbackTransactionSubmitter` fallback only on transport error
- [ ] Integration: submit via `DirectP2P` against a regtest Zebra node
