### PR TITLE
Fix race condition in Sapling params download (PRO-97)

### DIFF
--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/SaplingParamToolConcurrencyTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/SaplingParamToolConcurrencyTest.kt
@@ -1,0 +1,139 @@
+package cash.z.ecc.android.sdk.internal
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import cash.z.ecc.android.sdk.internal.ext.existsSuspend
+import cash.z.ecc.android.sdk.internal.ext.getSha1Hash
+import cash.z.ecc.android.sdk.test.getAppContext
+import cash.z.ecc.fixture.SaplingParamsFixture
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import kotlin.test.assertTrue
+
+/**
+ * Regression test for PRO-97 (`TransactionNotCreatedException: parameter file size is not
+ * correct`). Root cause was a missing lock around [SaplingParamTool.fetchParams]: concurrent
+ * callers raced on the same static temporary file name (`_sapling-output.params`), and one
+ * caller's success/failure cleanup could delete or clobber another's in-flight download,
+ * transiently leaving the final param file missing or invalid. Fixed by serializing
+ * [SaplingParamTool.fetchParams] with `fetchParamsMutex`.
+ *
+ * Ignored for the same reason as [SaplingParamToolIntegrationTest]: it hits the real network
+ * (download.z.cash) and is prone to CI flakiness. Run manually when touching params-fetch logic.
+ */
+@Ignore(
+    "Hits the real network (download.z.cash) with several concurrent downloads per round, same CI " +
+        "flakiness risk as SaplingParamToolIntegrationTest. Run manually when touching params-fetch " +
+        "concurrency."
+)
+@RunWith(AndroidJUnit4::class)
+class SaplingParamToolConcurrencyTest {
+    // Number of concurrent coroutines racing to fetch the very same param file in one round.
+    private val concurrencyLevel = 4
+
+    // Number of rounds repeated, since this is a TOCTOU-style race and a single attempt might not
+    // trigger it.
+    private val rounds = 3
+
+    private val outputSaplingParams =
+        SaplingParamsFixture.new(
+            SaplingParamsFixture.DESTINATION_DIRECTORY,
+            SaplingParamsFixture.OUTPUT_FILE_NAME,
+            SaplingParamsFixture.OUTPUT_FILE_MAX_SIZE,
+            SaplingParamsFixture.OUTPUT_FILE_HASH
+        )
+
+    @Before
+    fun setup() {
+        runBlocking {
+            SaplingParamsFixture.clearAllFilesFromDirectory(SaplingParamsFixture.DESTINATION_DIRECTORY)
+            SaplingParamsFixture.clearAllFilesFromDirectory(SaplingParamsFixture.DESTINATION_DIRECTORY_LEGACY)
+        }
+    }
+
+    @Test
+    @LargeTest
+    fun concurrent_fetch_params_same_file_race_test() =
+        runBlocking {
+            val saplingParamTool = SaplingParamTool.new(getAppContext())
+
+            val outcomesPerRound = mutableListOf<List<Result<Unit>>>()
+            val finalStatePerRound = mutableListOf<Triple<Boolean, Boolean, String>>()
+
+            repeat(rounds) { round ->
+                // Fresh directory state for every round.
+                SaplingParamsFixture.clearAllFilesFromDirectory(SaplingParamsFixture.DESTINATION_DIRECTORY)
+
+                val results: List<Result<Unit>> =
+                    coroutineScope {
+                        List(concurrencyLevel) {
+                            async {
+                                runCatching {
+                                    saplingParamTool.fetchParams(outputSaplingParams)
+                                }
+                            }
+                        }.awaitAll()
+                    }
+                outcomesPerRound += results
+
+                val finalFile =
+                    File(
+                        SaplingParamsFixture.DESTINATION_DIRECTORY,
+                        SaplingParamsFixture.OUTPUT_FILE_NAME
+                    )
+                val exists = finalFile.existsSuspend()
+                val hashValid =
+                    exists &&
+                        runCatching { finalFile.getSha1Hash() == SaplingParamsFixture.OUTPUT_FILE_HASH }
+                            .getOrDefault(false)
+                val sizeReported = if (exists) finalFile.length().toString() else "N/A"
+
+                finalStatePerRound += Triple(exists, hashValid, sizeReported)
+
+                val successCount = results.count { it.isSuccess }
+                val failureTypes = results.mapNotNull { it.exceptionOrNull()?.let { e -> e::class.simpleName } }
+
+                println(
+                    "PRO97_RACE_ROUND[$round]: successes=$successCount/${results.size} " +
+                        "failures=$failureTypes finalFileExists=$exists finalFileHashValid=$hashValid " +
+                        "finalFileSize=$sizeReported"
+                )
+            }
+
+            // Summarize everything at the end for easy grepping from logcat/test output.
+            outcomesPerRound.forEachIndexed { round, results ->
+                results.forEachIndexed { idx, result ->
+                    result.onFailure { e ->
+                        println(
+                            "PRO97_RACE_ROUND[$round]_TASK[$idx]_EXCEPTION: ${e::class.qualifiedName}: " +
+                                "${e.message}"
+                        )
+                    }
+                }
+            }
+
+            val roundsWithInvalidFinalState =
+                finalStatePerRound.withIndex().filter { (_, state) ->
+                    val (exists, hashValid, _) = state
+                    !exists || !hashValid
+                }
+
+            println(
+                "PRO97_RACE_SUMMARY: roundsWithInvalidFinalState=${roundsWithInvalidFinalState.map { it.index }} " +
+                    "totalRounds=$rounds concurrencyLevel=$concurrencyLevel"
+            )
+
+            assertTrue(
+                roundsWithInvalidFinalState.isEmpty(),
+                "Param file ended up missing/invalid after concurrent fetchParams() in round(s) " +
+                    "${roundsWithInvalidFinalState.map { it.index }} - see PRO97_RACE_ROUND logs above."
+            )
+        }
+}

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/SaplingParamToolConcurrencyTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/SaplingParamToolConcurrencyTest.kt
@@ -68,56 +68,12 @@ class SaplingParamToolConcurrencyTest {
             val finalStatePerRound = mutableListOf<Triple<Boolean, Boolean, String>>()
 
             repeat(rounds) { round ->
-                // Fresh directory state for every round.
-                SaplingParamsFixture.clearAllFilesFromDirectory(SaplingParamsFixture.DESTINATION_DIRECTORY)
-
-                val results: List<Result<Unit>> =
-                    coroutineScope {
-                        List(concurrencyLevel) {
-                            async {
-                                runCatching {
-                                    saplingParamTool.fetchParams(outputSaplingParams)
-                                }
-                            }
-                        }.awaitAll()
-                    }
+                val (results, finalState) = runConcurrentFetchRound(round, saplingParamTool)
                 outcomesPerRound += results
-
-                val finalFile =
-                    File(
-                        SaplingParamsFixture.DESTINATION_DIRECTORY,
-                        SaplingParamsFixture.OUTPUT_FILE_NAME
-                    )
-                val exists = finalFile.existsSuspend()
-                val hashValid =
-                    exists &&
-                        runCatching { finalFile.getSha1Hash() == SaplingParamsFixture.OUTPUT_FILE_HASH }
-                            .getOrDefault(false)
-                val sizeReported = if (exists) finalFile.length().toString() else "N/A"
-
-                finalStatePerRound += Triple(exists, hashValid, sizeReported)
-
-                val successCount = results.count { it.isSuccess }
-                val failureTypes = results.mapNotNull { it.exceptionOrNull()?.let { e -> e::class.simpleName } }
-
-                println(
-                    "PRO97_RACE_ROUND[$round]: successes=$successCount/${results.size} " +
-                        "failures=$failureTypes finalFileExists=$exists finalFileHashValid=$hashValid " +
-                        "finalFileSize=$sizeReported"
-                )
+                finalStatePerRound += finalState
             }
 
-            // Summarize everything at the end for easy grepping from logcat/test output.
-            outcomesPerRound.forEachIndexed { round, results ->
-                results.forEachIndexed { idx, result ->
-                    result.onFailure { e ->
-                        println(
-                            "PRO97_RACE_ROUND[$round]_TASK[$idx]_EXCEPTION: ${e::class.qualifiedName}: " +
-                                "${e.message}"
-                        )
-                    }
-                }
-            }
+            logRoundExceptions(outcomesPerRound)
 
             val roundsWithInvalidFinalState =
                 finalStatePerRound.withIndex().filter { (_, state) ->
@@ -136,4 +92,60 @@ class SaplingParamToolConcurrencyTest {
                     "${roundsWithInvalidFinalState.map { it.index }} - see PRO97_RACE_ROUND logs above."
             )
         }
+
+    // Runs one round of [concurrencyLevel] concurrent fetchParams() calls against a freshly-cleared
+    // directory, and returns the per-task outcomes plus the final on-disk state (exists, hashValid, size).
+    private suspend fun runConcurrentFetchRound(
+        round: Int,
+        saplingParamTool: SaplingParamTool
+    ): Pair<List<Result<Unit>>, Triple<Boolean, Boolean, String>> {
+        SaplingParamsFixture.clearAllFilesFromDirectory(SaplingParamsFixture.DESTINATION_DIRECTORY)
+
+        val results: List<Result<Unit>> =
+            coroutineScope {
+                List(concurrencyLevel) {
+                    async {
+                        runCatching {
+                            saplingParamTool.fetchParams(outputSaplingParams)
+                        }
+                    }
+                }.awaitAll()
+            }
+
+        val finalFile =
+            File(
+                SaplingParamsFixture.DESTINATION_DIRECTORY,
+                SaplingParamsFixture.OUTPUT_FILE_NAME
+            )
+        val exists = finalFile.existsSuspend()
+        val hashValid =
+            exists &&
+                runCatching { finalFile.getSha1Hash() == SaplingParamsFixture.OUTPUT_FILE_HASH }
+                    .getOrDefault(false)
+        val sizeReported = if (exists) finalFile.length().toString() else "N/A"
+
+        val successCount = results.count { it.isSuccess }
+        val failureTypes = results.mapNotNull { it.exceptionOrNull()?.let { e -> e::class.simpleName } }
+        println(
+            "PRO97_RACE_ROUND[$round]: successes=$successCount/${results.size} " +
+                "failures=$failureTypes finalFileExists=$exists finalFileHashValid=$hashValid " +
+                "finalFileSize=$sizeReported"
+        )
+
+        return results to Triple(exists, hashValid, sizeReported)
+    }
+
+    // Summarizes every round's failures at the end for easy grepping from logcat/test output.
+    private fun logRoundExceptions(outcomesPerRound: List<List<Result<Unit>>>) {
+        outcomesPerRound.forEachIndexed { round, results ->
+            results.forEachIndexed { idx, result ->
+                result.onFailure { e ->
+                    println(
+                        "PRO97_RACE_ROUND[$round]_TASK[$idx]_EXCEPTION: ${e::class.qualifiedName}: " +
+                            "${e.message}"
+                    )
+                }
+            }
+        }
+    }
 }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/SaplingParamTool.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/SaplingParamTool.kt
@@ -77,6 +77,9 @@ internal class SaplingParamTool(
 
         private val checkFilesMutex = Mutex()
 
+        // Guards fetchParams() so concurrent callers can't race on the shared temporary file path
+        private val fetchParamsMutex = Mutex()
+
         /**
          * Initialization of needed properties. This is necessary entry point for other operations from {@code
          * SaplingParamTool}. This type of implementation also simplifies its testing.
@@ -255,71 +258,73 @@ internal class SaplingParamTool(
         TransactionEncoderException.FetchParamsException::class
     )
     internal suspend fun fetchParams(paramsToFetch: SaplingParameters) {
-        val url = URL("$CLOUD_PARAM_DIR_URL${paramsToFetch.fileName}")
-        Twig.debug { "Sapling params fetch URL: $url" }
-        val temporaryFile =
-            File(
-                paramsToFetch.destinationDirectory,
-                "$TEMPORARY_FILE_NAME_PREFIX${paramsToFetch.fileName}"
-            )
+        fetchParamsMutex.withLock {
+            val url = URL("$CLOUD_PARAM_DIR_URL${paramsToFetch.fileName}")
+            Twig.debug { "Sapling params fetch URL: $url" }
+            val temporaryFile =
+                File(
+                    paramsToFetch.destinationDirectory,
+                    "$TEMPORARY_FILE_NAME_PREFIX${paramsToFetch.fileName}"
+                )
 
-        withContext(Dispatchers.IO) {
-            runCatching {
-                Channels.newChannel(url.openStream()).use { readableByteChannel ->
-                    temporaryFile.outputStream().use { fileOutputStream ->
-                        fileOutputStream.channel.use { fileChannel ->
-                            // Transfers bytes from stream to file from position 0 to end position or to max
-                            // file size limit. This eliminates the risk of downloading potentially large files
-                            // from a malicious server. We need to make a check of the file hash then.
-                            fileChannel.transferFrom(readableByteChannel, 0, paramsToFetch.fileMaxSizeBytes)
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    Channels.newChannel(url.openStream()).use { readableByteChannel ->
+                        temporaryFile.outputStream().use { fileOutputStream ->
+                            fileOutputStream.channel.use { fileChannel ->
+                                // Transfers bytes from stream to file from position 0 to end position or to max
+                                // file size limit. This eliminates the risk of downloading potentially large files
+                                // from a malicious server. We need to make a check of the file hash then.
+                                fileChannel.transferFrom(readableByteChannel, 0, paramsToFetch.fileMaxSizeBytes)
+                            }
                         }
                     }
-                }
-            }.onFailure { exception ->
-                // IllegalArgumentException - If the preconditions on the parameters do not hold
-                // NonReadableChannelException - If the source channel was not opened for reading
-                // NonWritableChannelException - If this channel was not opened for writing
-                // ClosedChannelException - If either this channel or the source channel is closed
-                // AsynchronousCloseException - If another thread closes either channel while the transfer is
-                // in progress
-                // ClosedByInterruptException - If another thread interrupts the current thread while the
-                // transfer is in progress, thereby closing both channels and setting the current thread's
-                // interrupt status
-                // IOException - If some other I/O error occurs
-                finalizeAndReportError(
-                    temporaryFile,
-                    exception =
-                        TransactionEncoderException.FetchParamsException(
-                            paramsToFetch,
-                            "Error while fetching ${paramsToFetch.fileName}, caused by $exception."
+                }.onFailure { exception ->
+                    // IllegalArgumentException - If the preconditions on the parameters do not hold
+                    // NonReadableChannelException - If the source channel was not opened for reading
+                    // NonWritableChannelException - If this channel was not opened for writing
+                    // ClosedChannelException - If either this channel or the source channel is closed
+                    // AsynchronousCloseException - If another thread closes either channel while the transfer is
+                    // in progress
+                    // ClosedByInterruptException - If another thread interrupts the current thread while the
+                    // transfer is in progress, thereby closing both channels and setting the current thread's
+                    // interrupt status
+                    // IOException - If some other I/O error occurs
+                    finalizeAndReportError(
+                        temporaryFile,
+                        exception =
+                            TransactionEncoderException.FetchParamsException(
+                                paramsToFetch,
+                                "Error while fetching ${paramsToFetch.fileName}, caused by $exception."
+                            )
+                    )
+                }.onSuccess {
+                    Twig.debug {
+                        "Fetch and write of the temporary ${temporaryFile.name} succeeded. Validating and moving " +
+                            "it to the final destination."
+                    }
+                    if (!isFileHashValid(temporaryFile, paramsToFetch.fileHash)) {
+                        finalizeAndReportError(
+                            temporaryFile,
+                            exception =
+                                TransactionEncoderException.ValidateParamsException(
+                                    paramsToFetch,
+                                    "Failed while validating fetched param file: ${paramsToFetch.fileName}."
+                                )
                         )
-                )
-            }.onSuccess {
-                Twig.debug {
-                    "Fetch and write of the temporary ${temporaryFile.name} succeeded. Validating and moving it to " +
-                        "the final destination."
-                }
-                if (!isFileHashValid(temporaryFile, paramsToFetch.fileHash)) {
-                    finalizeAndReportError(
-                        temporaryFile,
-                        exception =
-                            TransactionEncoderException.ValidateParamsException(
-                                paramsToFetch,
-                                "Failed while validating fetched param file: ${paramsToFetch.fileName}."
-                            )
-                    )
-                }
-                val resultFile = File(paramsToFetch.destinationDirectory, paramsToFetch.fileName)
-                if (!renameParametersFile(temporaryFile, resultFile)) {
-                    finalizeAndReportError(
-                        temporaryFile,
-                        resultFile,
-                        exception =
-                            TransactionEncoderException.ValidateParamsException(
-                                paramsToFetch,
-                                "Failed while renaming result param file: ${paramsToFetch.fileName}."
-                            )
-                    )
+                    }
+                    val resultFile = File(paramsToFetch.destinationDirectory, paramsToFetch.fileName)
+                    if (!renameParametersFile(temporaryFile, resultFile)) {
+                        finalizeAndReportError(
+                            temporaryFile,
+                            resultFile,
+                            exception =
+                                TransactionEncoderException.ValidateParamsException(
+                                    paramsToFetch,
+                                    "Failed while renaming result param file: ${paramsToFetch.fileName}."
+                                )
+                        )
+                    }
                 }
             }
         }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/SaplingParamTool.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/SaplingParamTool.kt
@@ -259,6 +259,13 @@ internal class SaplingParamTool(
     )
     internal suspend fun fetchParams(paramsToFetch: SaplingParameters) {
         fetchParamsMutex.withLock {
+            val resultFile = File(paramsToFetch.destinationDirectory, paramsToFetch.fileName)
+            if (resultFile.existsSuspend()) {
+                // A concurrent caller already fetched this file while we were waiting for the lock.
+                Twig.debug { "Param file ${paramsToFetch.fileName} was fetched by a concurrent caller. Skipping." }
+                return@withLock
+            }
+
             val url = URL("$CLOUD_PARAM_DIR_URL${paramsToFetch.fileName}")
             Twig.debug { "Sapling params fetch URL: $url" }
             val temporaryFile =
@@ -313,7 +320,6 @@ internal class SaplingParamTool(
                                 )
                         )
                     }
-                    val resultFile = File(paramsToFetch.destinationDirectory, paramsToFetch.fileName)
                     if (!renameParametersFile(temporaryFile, resultFile)) {
                         finalizeAndReportError(
                             temporaryFile,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/SaplingParamTool.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/SaplingParamTool.kt
@@ -275,64 +275,82 @@ internal class SaplingParamTool(
                 )
 
             withContext(Dispatchers.IO) {
-                runCatching {
-                    Channels.newChannel(url.openStream()).use { readableByteChannel ->
-                        temporaryFile.outputStream().use { fileOutputStream ->
-                            fileOutputStream.channel.use { fileChannel ->
-                                // Transfers bytes from stream to file from position 0 to end position or to max
-                                // file size limit. This eliminates the risk of downloading potentially large files
-                                // from a malicious server. We need to make a check of the file hash then.
-                                fileChannel.transferFrom(readableByteChannel, 0, paramsToFetch.fileMaxSizeBytes)
-                            }
-                        }
-                    }
-                }.onFailure { exception ->
-                    // IllegalArgumentException - If the preconditions on the parameters do not hold
-                    // NonReadableChannelException - If the source channel was not opened for reading
-                    // NonWritableChannelException - If this channel was not opened for writing
-                    // ClosedChannelException - If either this channel or the source channel is closed
-                    // AsynchronousCloseException - If another thread closes either channel while the transfer is
-                    // in progress
-                    // ClosedByInterruptException - If another thread interrupts the current thread while the
-                    // transfer is in progress, thereby closing both channels and setting the current thread's
-                    // interrupt status
-                    // IOException - If some other I/O error occurs
-                    finalizeAndReportError(
-                        temporaryFile,
-                        exception =
-                            TransactionEncoderException.FetchParamsException(
-                                paramsToFetch,
-                                "Error while fetching ${paramsToFetch.fileName}, caused by $exception."
-                            )
-                    )
-                }.onSuccess {
-                    Twig.debug {
-                        "Fetch and write of the temporary ${temporaryFile.name} succeeded. Validating and moving " +
-                            "it to the final destination."
-                    }
-                    if (!isFileHashValid(temporaryFile, paramsToFetch.fileHash)) {
+                downloadToFile(url, temporaryFile, paramsToFetch.fileMaxSizeBytes)
+                    .onFailure { exception ->
                         finalizeAndReportError(
                             temporaryFile,
                             exception =
-                                TransactionEncoderException.ValidateParamsException(
+                                TransactionEncoderException.FetchParamsException(
                                     paramsToFetch,
-                                    "Failed while validating fetched param file: ${paramsToFetch.fileName}."
+                                    "Error while fetching ${paramsToFetch.fileName}, caused by $exception."
                                 )
                         )
+                    }.onSuccess {
+                        validateAndStore(paramsToFetch, temporaryFile, resultFile)
                     }
-                    if (!renameParametersFile(temporaryFile, resultFile)) {
-                        finalizeAndReportError(
-                            temporaryFile,
-                            resultFile,
-                            exception =
-                                TransactionEncoderException.ValidateParamsException(
-                                    paramsToFetch,
-                                    "Failed while renaming result param file: ${paramsToFetch.fileName}."
-                                )
-                        )
+            }
+        }
+    }
+
+    /**
+     * Transfers bytes from [url] to [temporaryFile], from position 0 up to [maxSizeBytes]. This eliminates the
+     * risk of downloading a potentially large file from a malicious server.
+     *
+     * Failures surfaced here (non-exhaustive): [IllegalArgumentException] - preconditions on the parameters don't
+     * hold; [java.nio.channels.NonReadableChannelException]/[java.nio.channels.NonWritableChannelException] -
+     * source/destination channel opened for the wrong direction; [java.nio.channels.ClosedChannelException]/
+     * [java.nio.channels.AsynchronousCloseException]/[java.nio.channels.ClosedByInterruptException] - a channel
+     * was closed concurrently or the transfer was interrupted; [IOException] - any other I/O error.
+     */
+    private suspend fun downloadToFile(
+        url: URL,
+        temporaryFile: File,
+        maxSizeBytes: Long
+    ): Result<Unit> =
+        runCatching {
+            Channels.newChannel(url.openStream()).use { readableByteChannel ->
+                temporaryFile.outputStream().use { fileOutputStream ->
+                    fileOutputStream.channel.use { fileChannel ->
+                        fileChannel.transferFrom(readableByteChannel, 0, maxSizeBytes)
                     }
                 }
             }
+        }.map { }
+
+    /**
+     * Validates the hash of the successfully downloaded [temporaryFile] and renames it to [resultFile], reporting
+     * and cleaning up on any failure.
+     */
+    @Throws(TransactionEncoderException.ValidateParamsException::class)
+    private suspend fun validateAndStore(
+        paramsToFetch: SaplingParameters,
+        temporaryFile: File,
+        resultFile: File
+    ) {
+        Twig.debug {
+            "Fetch and write of the temporary ${temporaryFile.name} succeeded. Validating and moving it to the " +
+                "final destination."
+        }
+        if (!isFileHashValid(temporaryFile, paramsToFetch.fileHash)) {
+            finalizeAndReportError(
+                temporaryFile,
+                exception =
+                    TransactionEncoderException.ValidateParamsException(
+                        paramsToFetch,
+                        "Failed while validating fetched param file: ${paramsToFetch.fileName}."
+                    )
+            )
+        }
+        if (!renameParametersFile(temporaryFile, resultFile)) {
+            finalizeAndReportError(
+                temporaryFile,
+                resultFile,
+                exception =
+                    TransactionEncoderException.ValidateParamsException(
+                        paramsToFetch,
+                        "Failed while renaming result param file: ${paramsToFetch.fileName}."
+                    )
+            )
         }
     }
 


### PR DESCRIPTION
## Summary
- `SaplingParamTool.fetchParams()` had no synchronization guarding it. Concurrent invocations for the same param file (e.g. two overlapping transaction submissions) raced on the same static temporary file path (`_sapling-spend.params` / `_sapling-output.params`), so one caller's success-path rename or failure-path cleanup could delete or clobber another caller's in-flight download.
- This produced a transiently missing or invalid param file at the exact moment the file was needed, matching the `TransactionNotCreatedException: parameter file size is not correct` errors reported in [PRO-97](https://linear.app/zodl/issue/PRO-97/parameter-file-size-is-not-correct-please-clean-your-zcash-parameters).
- Fix: serialize `fetchParams()` with a dedicated `fetchParamsMutex` (mirrors the existing `checkFilesMutex` pattern already used for the legacy-folder migration). No change to temp file naming, `ensureParams()`'s existence check, or the download/validation logic itself.

## Test plan
- [x] Added `SaplingParamToolConcurrencyTest` (androidTest, `@Ignore`d like `SaplingParamToolIntegrationTest` due to real-network CI flakiness — run manually) that fires several concurrent `fetchParams()` calls at the same param file across multiple rounds and asserts the final file is always present with a valid hash.
- [x] Before the fix: reliably reproduced missing/invalid param files across ~3/16 rounds on two separate devices (physical + emulator).
- [x] After the fix: 0/16 rounds reproduced the issue across the same two devices; all concurrent calls now serialize and succeed.
- [x] Existing `SaplingParamToolBasicTest` suite passes unchanged on both devices (no regression).