### PR TITLE
MOB-1403: Cold start performance optimizations

### DIFF
--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -2174,9 +2174,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "imt-tree"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c378a3c5c44b985233906c966bd82a4f775a83aa4e1bde1635961c2eb8673d7b"
+checksum = "1d0a4887bb71d68b3d0c5db9d42bb76df38b0dff4d261b863dada6383b6c2012"
 dependencies = [
  "anyhow",
  "ff",
@@ -3112,9 +3112,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pir-client"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f18409a3bbbc58985c0ba79ec464c65e6ebab19cc1a82c5d4e184c3484520100"
+checksum = "edef04868dc19983199d26c205129b86fd95e2856e3f7a7c096438e7debafb69"
 dependencies = [
  "anyhow",
  "ff",
@@ -3131,9 +3131,9 @@ dependencies = [
 
 [[package]]
 name = "pir-types"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd3d6025cac852a7b3b81d6d07d6e21cc03bb3d5873fc13144a74c56f325b9d"
+checksum = "27fca477d53f99bc04e449bb984231bb383c41ddc24a0304ecea48563c17e25b"
 dependencies = [
  "anyhow",
  "ff",
@@ -6016,9 +6016,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vote-commitment-tree"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870b893a2c53ec015d46fd3a33cf91715a9a968d34531208144f48e46398321c"
+checksum = "8cac5881d522e752d764520d78b7a2fb674eaab4e394fabd1b976cf5f1a7a26c"
 dependencies = [
  "anyhow",
  "ff",
@@ -6033,9 +6033,9 @@ dependencies = [
 
 [[package]]
 name = "vote-commitment-tree-client"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03af018a5afbd7e58f2b233c96e64cc581d56cf12dd7daedd337cf6eaa10f80e"
+checksum = "ba358e900080169be7be851f4aab556b1c1e2ca3d195d71ad2ef5a71abd00f81"
 dependencies = [
  "base64",
  "ff",
@@ -6049,9 +6049,9 @@ dependencies = [
 
 [[package]]
 name = "voting-circuits"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a5b61b6f99af50df900d839b9440fa36709166449c7fa831169391bc5f44bc"
+checksum = "37d8bd9964ce4aef9152a66ad8950af529de4bbbd875bfd9e5d95534abc50df9"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -6785,7 +6785,7 @@ dependencies = [
 
 [[package]]
 name = "zcash-android-wallet-sdk"
-version = "2.5.1"
+version = "2.6.4"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -7135,9 +7135,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23827ed8aa8fe8bd1bdda0f72cfffca36fe1d8fafde82e72b0f5561a7aae845"
+checksum = "0a0f6ac52e66228393eab773dcec0eacbb6e1c768e0b6e0675d89d3a78ef53f1"
 dependencies = [
  "anyhow",
  "blake2b_simd",

--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -2174,9 +2174,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "imt-tree"
-version = "0.2.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0a4887bb71d68b3d0c5db9d42bb76df38b0dff4d261b863dada6383b6c2012"
+checksum = "c378a3c5c44b985233906c966bd82a4f775a83aa4e1bde1635961c2eb8673d7b"
 dependencies = [
  "anyhow",
  "ff",
@@ -3112,9 +3112,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pir-client"
-version = "0.3.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edef04868dc19983199d26c205129b86fd95e2856e3f7a7c096438e7debafb69"
+checksum = "f18409a3bbbc58985c0ba79ec464c65e6ebab19cc1a82c5d4e184c3484520100"
 dependencies = [
  "anyhow",
  "ff",
@@ -3131,9 +3131,9 @@ dependencies = [
 
 [[package]]
 name = "pir-types"
-version = "0.2.0"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27fca477d53f99bc04e449bb984231bb383c41ddc24a0304ecea48563c17e25b"
+checksum = "2fd3d6025cac852a7b3b81d6d07d6e21cc03bb3d5873fc13144a74c56f325b9d"
 dependencies = [
  "anyhow",
  "ff",
@@ -6016,9 +6016,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vote-commitment-tree"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cac5881d522e752d764520d78b7a2fb674eaab4e394fabd1b976cf5f1a7a26c"
+checksum = "870b893a2c53ec015d46fd3a33cf91715a9a968d34531208144f48e46398321c"
 dependencies = [
  "anyhow",
  "ff",
@@ -6033,9 +6033,9 @@ dependencies = [
 
 [[package]]
 name = "vote-commitment-tree-client"
-version = "0.5.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba358e900080169be7be851f4aab556b1c1e2ca3d195d71ad2ef5a71abd00f81"
+checksum = "03af018a5afbd7e58f2b233c96e64cc581d56cf12dd7daedd337cf6eaa10f80e"
 dependencies = [
  "base64",
  "ff",
@@ -6049,9 +6049,9 @@ dependencies = [
 
 [[package]]
 name = "voting-circuits"
-version = "0.8.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d8bd9964ce4aef9152a66ad8950af529de4bbbd875bfd9e5d95534abc50df9"
+checksum = "30a5b61b6f99af50df900d839b9440fa36709166449c7fa831169391bc5f44bc"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -6785,7 +6785,7 @@ dependencies = [
 
 [[package]]
 name = "zcash-android-wallet-sdk"
-version = "2.6.4"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -7135,9 +7135,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "0.11.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0f6ac52e66228393eab773dcec0eacbb6e1c768e0b6e0675d89d3a78ef53f1"
+checksum = "f23827ed8aa8fe8bd1bdda0f72cfffca36fe1d8fafde82e72b0f5561a7aae845"
 dependencies = [
  "anyhow",
  "blake2b_simd",

--- a/backend-lib/build.gradle.kts
+++ b/backend-lib/build.gradle.kts
@@ -201,6 +201,7 @@ dependencies {
 
     // Tests
     testImplementation(libs.kotlin.test)
+    testImplementation(libs.kotlinx.coroutines.test)
 
     androidTestImplementation(libs.androidx.multidex)
     androidTestImplementation(libs.androidx.test.runner)

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/CombinedWalletClientImpl.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/CombinedWalletClientImpl.kt
@@ -15,6 +15,7 @@ import co.electriccoin.lightwallet.client.model.ShieldedProtocolEnum
 import co.electriccoin.lightwallet.client.model.SubtreeRootUnsafe
 import co.electriccoin.lightwallet.client.model.UninitializedTorClientException
 import co.electriccoin.lightwallet.client.util.use
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
@@ -25,16 +26,12 @@ import kotlinx.coroutines.withContext
 @Suppress("TooManyFunctions")
 class CombinedWalletClientImpl private constructor(
     private val lightWalletClient: LightWalletClient,
-    private val torClientProvider: (suspend () -> TorClient?)?,
+    private val isolatedTorClient: LazyTorClient?,
     private val endpoint: LightWalletEndpoint,
 ) : CombinedWalletClient {
     private val cache = mutableMapOf<ServiceMode, PartialTorWalletClient>()
 
     private val semaphore = Mutex()
-
-    // Lazily-acquired isolated Tor client. Only ever accessed from within [create], which
-    // always runs under [semaphore] (via [execute]), so no additional synchronization is needed.
-    private var isolatedTorClient: TorClient? = null
 
     override suspend fun dispose() {
         semaphore.withLock {
@@ -171,6 +168,11 @@ class CombinedWalletClientImpl private constructor(
             Response.Failure.OverTor(cause = e)
         }
 
+    /**
+     * Executes [block] against the client appropriate for [serviceMode] under [semaphore]. For
+     * [ServiceMode.Direct], the shared [lightWalletClient] is used directly. For Tor-mode requests, the
+     * Tor client is resolved lazily inside the Tor branches, backed by [LazyTorClient]'s cache.
+     */
     @Suppress("TooGenericExceptionCaught")
     private suspend inline fun <T> execute(
         serviceMode: ServiceMode,
@@ -183,7 +185,7 @@ class CombinedWalletClientImpl private constructor(
                 }
 
                 ServiceMode.UniqueTor -> {
-                    create().use { block(it) }
+                    createTorWalletClient().use { block(it) }
                 }
 
                 ServiceMode.DefaultTor,
@@ -202,21 +204,23 @@ class CombinedWalletClientImpl private constructor(
         withContext(Dispatchers.Default) { cache.remove(serviceMode) }
 
     private suspend fun getOrCreate(serviceMode: ServiceMode) =
-        withContext(Dispatchers.Default) { cache.getOrPut(serviceMode) { create() } }
+        withContext(Dispatchers.Default) { cache.getOrPut(serviceMode) { createTorWalletClient() } }
 
-    @Suppress("TooGenericExceptionCaught")
-    private suspend fun create(): PartialTorWalletClient {
+    @Suppress("TooGenericExceptionCaught", "ThrowsCount")
+    private suspend fun createTorWalletClient(): PartialTorWalletClient {
         val tor =
-            isolatedTorClient
-                ?: try {
-                    torClientProvider?.invoke()?.also { isolatedTorClient = it }
-                } catch (e: Exception) {
-                    throw UninitializedTorClientException(e)
-                }
-                ?: throw UninitializedTorClientException(NullPointerException("torClient is null"))
+            try {
+                isolatedTorClient?.getOrCreate()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                throw UninitializedTorClientException(e)
+            } ?: throw UninitializedTorClientException(NullPointerException("torClient is null"))
 
         return try {
             tor.createWalletClient("https://${endpoint.host}:${endpoint.port}")
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             throw UninitializedTorClientException(e)
         }
@@ -226,11 +230,11 @@ class CombinedWalletClientImpl private constructor(
         suspend fun new(
             endpoint: LightWalletEndpoint,
             lightWalletClient: LightWalletClient,
-            torClientProvider: (suspend () -> TorClient?)?
+            isolatedTorClient: LazyTorClient?
         ) = CombinedWalletClientImpl(
             endpoint = endpoint,
             lightWalletClient = lightWalletClient,
-            torClientProvider = torClientProvider
+            isolatedTorClient = isolatedTorClient
         )
     }
 }

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/CombinedWalletClientImpl.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/CombinedWalletClientImpl.kt
@@ -25,17 +25,21 @@ import kotlinx.coroutines.withContext
 @Suppress("TooManyFunctions")
 class CombinedWalletClientImpl private constructor(
     private val lightWalletClient: LightWalletClient,
-    private val torClient: TorClient?,
+    private val torClientProvider: (suspend () -> TorClient?)?,
     private val endpoint: LightWalletEndpoint,
 ) : CombinedWalletClient {
     private val cache = mutableMapOf<ServiceMode, PartialTorWalletClient>()
 
     private val semaphore = Mutex()
 
+    // Lazily-acquired isolated Tor client. Only ever accessed from within [create], which
+    // always runs under [semaphore] (via [execute]), so no additional synchronization is needed.
+    private var isolatedTorClient: TorClient? = null
+
     override suspend fun dispose() {
         semaphore.withLock {
             lightWalletClient.dispose()
-            torClient?.dispose()
+            isolatedTorClient?.dispose()
             cache.forEach { (_, client) -> client.dispose() }
             cache.clear()
         }
@@ -202,10 +206,17 @@ class CombinedWalletClientImpl private constructor(
 
     @Suppress("TooGenericExceptionCaught")
     private suspend fun create(): PartialTorWalletClient {
-        if (torClient == null) throw UninitializedTorClientException(NullPointerException("torClient is null"))
+        val tor =
+            isolatedTorClient
+                ?: try {
+                    torClientProvider?.invoke()?.also { isolatedTorClient = it }
+                } catch (e: Exception) {
+                    throw UninitializedTorClientException(e)
+                }
+                ?: throw UninitializedTorClientException(NullPointerException("torClient is null"))
 
         return try {
-            torClient.createWalletClient("https://${endpoint.host}:${endpoint.port}")
+            tor.createWalletClient("https://${endpoint.host}:${endpoint.port}")
         } catch (e: Exception) {
             throw UninitializedTorClientException(e)
         }
@@ -215,11 +226,11 @@ class CombinedWalletClientImpl private constructor(
         suspend fun new(
             endpoint: LightWalletEndpoint,
             lightWalletClient: LightWalletClient,
-            torClient: TorClient?
+            torClientProvider: (suspend () -> TorClient?)?
         ) = CombinedWalletClientImpl(
             endpoint = endpoint,
             lightWalletClient = lightWalletClient,
-            torClient = torClient
+            torClientProvider = torClientProvider
         )
     }
 }

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/LazyTorClient.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/LazyTorClient.kt
@@ -1,0 +1,44 @@
+package cash.z.ecc.android.sdk.internal.model
+
+import co.electriccoin.lightwallet.client.util.Disposable
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * A lazily-initialized, shared holder for a base [TorClient].
+ *
+ * Creating a [TorClient] starts a Tor runtime, which is a relatively expensive operation (on the
+ * order of a second). This holder defers that cost until the [TorClient] is actually needed (e.g.
+ * for an exchange rate fetch, or a caller-requested Tor [io.ktor.client.HttpClient]) rather than
+ * paying it eagerly while constructing a [cash.z.ecc.android.sdk.Synchronizer].
+ *
+ * The created [TorClient] is cached and shared between all callers of [getOrCreate], so the
+ * expensive runtime creation happens at most once, and [dispose] frees it at most once.
+ */
+class LazyTorClient(
+    private val factory: suspend () -> TorClient
+) : Disposable {
+    private val mutex = Mutex()
+    private var instance: TorClient? = null
+
+    /**
+     * Returns the shared base [TorClient], creating it via [factory] on first call.
+     */
+    suspend fun getOrCreate(): TorClient = mutex.withLock { instance ?: factory().also { instance = it } }
+
+    /**
+     * Runs [action] against the underlying [TorClient] only if it has already been created,
+     * without forcing creation as a side effect. Useful for best-effort operations, such as
+     * toggling dormant mode, that are meaningless before the client exists.
+     */
+    suspend fun ifCreated(action: suspend (TorClient) -> Unit) {
+        val current = mutex.withLock { instance }
+        current?.let { action(it) }
+    }
+
+    override suspend fun dispose() =
+        mutex.withLock {
+            instance?.dispose()
+            instance = null
+        }
+}

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/LazyTorClient.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/LazyTorClient.kt
@@ -14,17 +14,28 @@ import kotlinx.coroutines.sync.withLock
  *
  * The created [TorClient] is cached and shared between all callers of [getOrCreate], so the
  * expensive runtime creation happens at most once, and [dispose] frees it at most once.
+ *
+ * Once [dispose] has been called, this holder is permanently disposed: [getOrCreate] will throw
+ * [IllegalStateException] rather than creating a new [TorClient].
  */
 class LazyTorClient(
     private val factory: suspend () -> TorClient
 ) : Disposable {
     private val mutex = Mutex()
     private var instance: TorClient? = null
+    private var disposed = false
 
     /**
      * Returns the shared base [TorClient], creating it via [factory] on first call.
+     *
+     * @throws IllegalStateException if this holder has already been [dispose]d.
      */
-    suspend fun getOrCreate(): TorClient = mutex.withLock { instance ?: factory().also { instance = it } }
+    suspend fun getOrCreate(): TorClient =
+        mutex.withLock {
+            check(!disposed) { "LazyTorClient is disposed" }
+
+            instance ?: factory().also { instance = it }
+        }
 
     /**
      * Runs [action] against the underlying [TorClient] only if it has already been created,
@@ -40,5 +51,6 @@ class LazyTorClient(
         mutex.withLock {
             instance?.dispose()
             instance = null
+            disposed = true
         }
 }

--- a/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/model/LazyTorClientTest.kt
+++ b/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/model/LazyTorClientTest.kt
@@ -1,0 +1,45 @@
+package cash.z.ecc.android.sdk.internal.model
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class LazyTorClientTest {
+    @Test
+    fun getOrCreate_after_dispose_throws() =
+        runTest {
+            val lazyTorClient = LazyTorClient { error("factory should not be invoked once disposed") }
+
+            lazyTorClient.dispose()
+
+            assertFailsWith<IllegalStateException> { lazyTorClient.getOrCreate() }
+        }
+
+    @Test
+    fun dispose_is_idempotent() =
+        runTest {
+            val lazyTorClient = LazyTorClient { error("factory should not be invoked once disposed") }
+
+            lazyTorClient.dispose()
+            lazyTorClient.dispose()
+
+            assertFailsWith<IllegalStateException> { lazyTorClient.getOrCreate() }
+        }
+
+    @Test
+    fun getOrCreate_failure_does_not_cache_and_factory_is_retried() =
+        runTest {
+            var factoryCallCount = 0
+            val lazyTorClient =
+                LazyTorClient {
+                    factoryCallCount++
+                    error("boom $factoryCallCount")
+                }
+
+            assertFailsWith<IllegalStateException> { lazyTorClient.getOrCreate() }
+            assertFailsWith<IllegalStateException> { lazyTorClient.getOrCreate() }
+
+            assertEquals(2, factoryCallCount)
+        }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -139,3 +139,6 @@ BIP39_VERSION=1.0.9
 
 # This shouldn't be changed, as Android doesn't support targets beyond Java 8
 ANDROID_JVM_TARGET=1.8
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/integration/service/ChangeServiceTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/integration/service/ChangeServiceTest.kt
@@ -7,6 +7,7 @@ import cash.z.ecc.android.sdk.annotation.TestPurpose
 import cash.z.ecc.android.sdk.internal.Twig
 import cash.z.ecc.android.sdk.internal.block.CompactBlockDownloader
 import cash.z.ecc.android.sdk.internal.jni.FakeRustBackend
+import cash.z.ecc.android.sdk.internal.model.LazyTorClient
 import cash.z.ecc.android.sdk.internal.model.TorClient
 import cash.z.ecc.android.sdk.internal.repository.CompactBlockRepository
 import cash.z.ecc.android.sdk.model.ZcashNetwork
@@ -61,7 +62,7 @@ class ChangeServiceTest : ScopedTest() {
 
     private suspend fun initMocks() {
         val torDir = createTempDirectory("tor-client-").toFile()
-        val torClient = TorClient.new(torDir, FakeRustBackend(0, mutableListOf()))
+        val torClient = LazyTorClient { TorClient.new(torDir, FakeRustBackend(0, mutableListOf())) }
         val factory = WalletClientFactory(context = context, torClient = torClient)
         service = factory.create(lightWalletEndpoint)
         mockCloseable = MockitoAnnotations.openMocks(this)

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
@@ -32,7 +32,7 @@ import cash.z.ecc.android.sdk.internal.exchange.UsdExchangeRateFetcher
 import cash.z.ecc.android.sdk.internal.ext.existsSuspend
 import cash.z.ecc.android.sdk.internal.ext.tryNull
 import cash.z.ecc.android.sdk.internal.jni.RustBackend
-import cash.z.ecc.android.sdk.internal.model.TorClient
+import cash.z.ecc.android.sdk.internal.model.LazyTorClient
 import cash.z.ecc.android.sdk.internal.model.TorDormantMode
 import cash.z.ecc.android.sdk.internal.model.TorHttp
 import cash.z.ecc.android.sdk.internal.model.TreeState
@@ -157,7 +157,7 @@ class SdkSynchronizer private constructor(
     private val fetchFastestServers: FastestServerFetcher,
     private val fetchExchangeChangeUsd: UsdExchangeRateFetcher?,
     private val preferenceProvider: PreferenceProvider,
-    private val torClient: TorClient?,
+    private val lazyTorClient: LazyTorClient?,
     private val walletClient: CombinedWalletClient,
     private val walletClientFactory: WalletClientFactory,
     private val defaultSubmitEndpoint: LightWalletEndpoint,
@@ -199,7 +199,7 @@ class SdkSynchronizer private constructor(
             fastestServerFetcher: FastestServerFetcher,
             fetchExchangeChangeUsd: UsdExchangeRateFetcher?,
             preferenceProvider: PreferenceProvider,
-            torClient: TorClient?,
+            lazyTorClient: LazyTorClient?,
             walletClient: CombinedWalletClient,
             walletClientFactory: WalletClientFactory,
             defaultSubmitEndpoint: LightWalletEndpoint,
@@ -220,7 +220,7 @@ class SdkSynchronizer private constructor(
                     fetchFastestServers = fastestServerFetcher,
                     fetchExchangeChangeUsd = fetchExchangeChangeUsd,
                     preferenceProvider = preferenceProvider,
-                    torClient = torClient,
+                    lazyTorClient = lazyTorClient,
                     walletClient = walletClient,
                     walletClientFactory = walletClientFactory,
                     defaultSubmitEndpoint = defaultSubmitEndpoint,
@@ -472,12 +472,11 @@ class SdkSynchronizer private constructor(
     override fun close() {
         // Note that stopping will continue asynchronously.  Race conditions with starting a new synchronizer are
         // avoided with a delay during startup.
-
         val shutdownJob =
             coroutineScope.launch {
                 Twig.info { "Stopping synchronizer $synchronizerKey…" }
                 processor.stop()
-                torClient?.dispose()
+                lazyTorClient?.dispose()
                 walletClient.dispose()
                 fetchExchangeChangeUsd?.dispose()
             }
@@ -503,7 +502,7 @@ class SdkSynchronizer private constructor(
                 coroutineScope.launch {
                     Twig.info { "Stopping synchronizer $synchronizerKey…" }
                     processor.stop()
-                    torClient?.dispose()
+                    lazyTorClient?.dispose()
                     walletClient.dispose()
                     fetchExchangeChangeUsd?.dispose()
                 }
@@ -563,6 +562,9 @@ class SdkSynchronizer private constructor(
         return storage.getRecipients(transactionOverview.txId)
     }
 
+    override suspend fun getRecipients(): Map<TransactionId, List<TransactionRecipient>> =
+        storage.getAllRecipients()
+
     override suspend fun getTransactionOutputs(transactionOverview: TransactionOverview): List<TransactionOutput> =
         storage.getOutputProperties(transactionOverview.txId).toList().map {
             TransactionOutput(
@@ -572,6 +574,19 @@ class SdkSynchronizer private constructor(
                     ZcashProtocol.ORCHARD -> TransactionPool.ORCHARD
                 }
             )
+        }
+
+    override suspend fun getTransactionOutputs(): Map<TransactionId, List<TransactionOutput>> =
+        storage.getAllOutputProperties().mapValues { (_, outputProperties) ->
+            outputProperties.map {
+                TransactionOutput(
+                    when (it.protocol) {
+                        ZcashProtocol.TRANSPARENT -> TransactionPool.TRANSPARENT
+                        ZcashProtocol.SAPLING -> TransactionPool.SAPLING
+                        ZcashProtocol.ORCHARD -> TransactionPool.ORCHARD
+                    }
+                )
+            }
         }
 
     override suspend fun getTransactions(accountUuid: AccountUuid): Flow<List<TransactionOverview>> =
@@ -631,11 +646,13 @@ class SdkSynchronizer private constructor(
     }
 
     override fun onBackground() {
-        coroutineScope.launch { torClient?.setDormant(TorDormantMode.SOFT) }
+        // Only put an already-created Tor client to sleep; there's no reason to force lazy Tor runtime
+        // creation just to immediately mark it dormant.
+        coroutineScope.launch { lazyTorClient?.ifCreated { it.setDormant(TorDormantMode.SOFT) } }
     }
 
     override fun onForeground() {
-        coroutineScope.launch { torClient?.setDormant(TorDormantMode.NORMAL) }
+        coroutineScope.launch { lazyTorClient?.ifCreated { it.setDormant(TorDormantMode.NORMAL) } }
     }
 
     //
@@ -668,7 +685,7 @@ class SdkSynchronizer private constructor(
         config: HttpClientConfig<HttpClientEngineConfig>.() -> Unit
     ): HttpClient =
         if (sdkFlags.isTorEnabled || sdkFlags.isExchangeRateEnabled) {
-            if (torClient == null) {
+            if (lazyTorClient == null) {
                 throw TorInitializationErrorException(
                     NullPointerException("Tor has not been initialized during synchronizer setup")
                 )
@@ -676,7 +693,7 @@ class SdkSynchronizer private constructor(
 
             val isolatedTor =
                 try {
-                    torClient.isolatedTorClient()
+                    lazyTorClient.getOrCreate().isolatedTorClient()
                 } catch (e: Exception) {
                     throw TorInitializationErrorException(e)
                 }
@@ -1002,7 +1019,7 @@ class SdkSynchronizer private constructor(
         )
 
     override val initializationError =
-        if (torClient == null && sdkFlags.isTorEnabled) {
+        if (lazyTorClient == null && sdkFlags.isTorEnabled) {
             Synchronizer.InitializationError.TOR_NOT_AVAILABLE
         } else {
             null

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
@@ -567,26 +567,12 @@ class SdkSynchronizer private constructor(
 
     override suspend fun getTransactionOutputs(transactionOverview: TransactionOverview): List<TransactionOutput> =
         storage.getOutputProperties(transactionOverview.txId).toList().map {
-            TransactionOutput(
-                when (it.protocol) {
-                    ZcashProtocol.TRANSPARENT -> TransactionPool.TRANSPARENT
-                    ZcashProtocol.SAPLING -> TransactionPool.SAPLING
-                    ZcashProtocol.ORCHARD -> TransactionPool.ORCHARD
-                }
-            )
+            TransactionOutput(it.protocol.toTransactionPool())
         }
 
     override suspend fun getTransactionOutputs(): Map<TransactionId, List<TransactionOutput>> =
         storage.getAllOutputProperties().mapValues { (_, outputProperties) ->
-            outputProperties.map {
-                TransactionOutput(
-                    when (it.protocol) {
-                        ZcashProtocol.TRANSPARENT -> TransactionPool.TRANSPARENT
-                        ZcashProtocol.SAPLING -> TransactionPool.SAPLING
-                        ZcashProtocol.ORCHARD -> TransactionPool.ORCHARD
-                    }
-                )
-            }
+            outputProperties.map { TransactionOutput(it.protocol.toTransactionPool()) }
         }
 
     override suspend fun getTransactions(accountUuid: AccountUuid): Flow<List<TransactionOverview>> =
@@ -645,9 +631,11 @@ class SdkSynchronizer private constructor(
         }
     }
 
+    /**
+     * Only puts an already-created Tor client to sleep; there's no reason to force lazy Tor runtime
+     * creation just to immediately mark it dormant.
+     */
     override fun onBackground() {
-        // Only put an already-created Tor client to sleep; there's no reason to force lazy Tor runtime
-        // creation just to immediately mark it dormant.
         coroutineScope.launch { lazyTorClient?.ifCreated { it.setDormant(TorDormantMode.SOFT) } }
     }
 
@@ -1018,6 +1006,12 @@ class SdkSynchronizer private constructor(
             null
         )
 
+    /**
+     * [lazyTorClient] is only ever `null` when [SdkFlags.isTorEnabled] is also `false` (see how [lazyTorClient]
+     * is constructed in [Synchronizer.Companion.new]), so this condition is never actually met: Tor client
+     * creation is lazy, and its failure is no longer observable at construction time. See
+     * [Synchronizer.InitializationError.TOR_NOT_AVAILABLE].
+     */
     override val initializationError =
         if (lazyTorClient == null && sdkFlags.isTorEnabled) {
             Synchronizer.InitializationError.TOR_NOT_AVAILABLE
@@ -1344,6 +1338,13 @@ class SdkSynchronizer private constructor(
                 absolutePath
             }
 }
+
+private fun ZcashProtocol.toTransactionPool(): TransactionPool =
+    when (this) {
+        ZcashProtocol.TRANSPARENT -> TransactionPool.TRANSPARENT
+        ZcashProtocol.SAPLING -> TransactionPool.SAPLING
+        ZcashProtocol.ORCHARD -> TransactionPool.ORCHARD
+    }
 
 /**
  * Provides a way of constructing a synchronizer where dependencies are injected in.

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
@@ -63,6 +63,7 @@ import co.electriccoin.lightwallet.client.model.Response
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.HttpClientEngineConfig
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -192,6 +193,11 @@ interface Synchronizer {
 
     /**
      * Emits error states of the synchronizer.
+     *
+     * Since Tor client creation is now lazy (see [InitializationError.TOR_NOT_AVAILABLE]), this is not
+     * currently produced at construction time; Tor bootstrap failures instead surface per-call, e.g. as
+     * [TorInitializationErrorException] from [getTorHttpClient] or as `Response.Failure.OverTor` from
+     * Tor-mode network calls.
      */
     val initializationError: InitializationError?
 
@@ -625,6 +631,10 @@ interface Synchronizer {
      * Batched alternative to [getRecipients] that returns the recipients for ALL transactions in a single query,
      * grouped by [TransactionId]. Prefer this over calling [getRecipients] in a loop for every transaction, e.g.
      * when building a transaction list for the UI.
+     *
+     * The map only contains entries for transactions that have at least one non-change recipient; a
+     * transaction with only change outputs (or no outputs) is absent from the map rather than being present
+     * with an empty list.
      */
     suspend fun getRecipients(): Map<TransactionId, List<TransactionRecipient>>
 
@@ -655,6 +665,10 @@ interface Synchronizer {
      * Batched alternative to [getTransactionOutputs] that returns the transaction outputs for ALL transactions
      * in a single query, grouped by [TransactionId]. Prefer this over calling [getTransactionOutputs] in a loop
      * for every transaction, e.g. when building a transaction list for the UI.
+     *
+     * The map only contains entries for transactions that have at least one non-change output; a transaction
+     * with only change outputs (or no outputs) is absent from the map rather than being present with an empty
+     * list.
      */
     suspend fun getTransactionOutputs(): Map<TransactionId, List<TransactionOutput>>
 
@@ -828,6 +842,12 @@ interface Synchronizer {
          *
          * Typically this means that [SdkFlags.isTorEnabled] is set to true but Tor instantiation
          * failed.
+         *
+         * Tor client creation is lazy (deferred to first use, via `LazyTorClient`) rather than happening
+         * eagerly during [Synchronizer.Companion.new], so this error is no longer produced at
+         * construction time. Tor bootstrap failures now surface per-call instead, e.g. as
+         * [TorInitializationErrorException] from [getTorHttpClient] or as `Response.Failure.OverTor` from
+         * Tor-mode network calls. This case is kept for source/binary compatibility.
          */
         TOR_NOT_AVAILABLE,
     }
@@ -850,6 +870,12 @@ interface Synchronizer {
 
         /**
          * Primary method that SDK clients will use to construct a synchronizer.
+         *
+         * The construction of a [Synchronizer] is split into independent branches that run concurrently
+         * on background threads, then joined. The critical path to an emitting DB (backend native-load →
+         * repository/initDataDb) no longer serializes behind the network client (gRPC walletClient),
+         * checkpoint load, or preference disk I/O — all of which are only needed for syncing, not for
+         * reading stored balances/transactions.
          *
          * @param zcashNetwork the network to use.
          *
@@ -907,13 +933,10 @@ interface Synchronizer {
 
             validateAlias(alias)
 
-            // The construction of a Synchronizer is split into independent branches that run
-            // concurrently on background threads, then joined. The critical path to an emitting DB
-            // (backend native-load → repository/initDataDb) no longer serializes behind the network
-            // client (gRPC walletClient), checkpoint load, or preference disk I/O — all of which are
-            // only needed for syncing, not for reading stored balances/transactions.
             return coroutineScope {
-                // Bundled checkpoint load (asset read) — independent of everything else.
+                /**
+                 * Bundled checkpoint load (asset read) — independent of everything else.
+                 */
                 val checkpointDeferred =
                     async(Dispatchers.Default) {
                         CheckpointTool.loadNearest(
@@ -924,11 +947,12 @@ interface Synchronizer {
                     }
 
                 val coordinator = DatabaseCoordinator.getInstance(context)
-                // The pending transaction database no longer exists, so we can delete the file
                 coordinator.deletePendingTransactionDatabase(zcashNetwork, alias)
 
-                // Native library load (~one-time per process) + Rust backend construction. This is the
-                // long pole of the DB-read critical path; everything Rust/DB-related awaits it.
+                /**
+                 * Native library load (~one-time per process) + Rust backend construction. This is the
+                 * long pole of the DB-read critical path; everything Rust/DB-related awaits it.
+                 */
                 val backendDeferred =
                     async(Dispatchers.Default) {
                         val saplingParamTool = SaplingParamTool.new(applicationContext)
@@ -942,16 +966,18 @@ interface Synchronizer {
                         saplingParamTool to backend
                     }
 
-                // Tor is only needed for on-demand/background work (sync-path Tor-mode RPCs, exchange rate
-                // fetch, getTorHttpClient), never on the cold-start critical path, so its creation (the ~1s
-                // Tor runtime creation cost) is always deferred to first use via LazyTorClient, regardless of
-                // whether isTorEnabled and/or isExchangeRateEnabled is set. Because the factory only awaits
-                // the backend when Tor is actually first used (much later), the walletClient below can be
-                // built concurrently with the backend rather than waiting for it.
+                /**
+                 * Tor is only needed for on-demand/background work (sync-path Tor-mode RPCs, exchange rate
+                 * fetch, getTorHttpClient), never on the cold-start critical path, so its creation (the ~1s
+                 * Tor runtime creation cost) is always deferred to first use via [LazyTorClient], regardless of
+                 * whether isTorEnabled and/or isExchangeRateEnabled is set. Because the factory only awaits
+                 * the backend when Tor is actually first used (much later), the walletClient below can be
+                 * built concurrently with the backend rather than waiting for it.
+                 */
                 val lazyTorClient =
                     if (sdkFlags.isTorEnabled || sdkFlags.isExchangeRateEnabled) {
                         LazyTorClient {
-                            val torDir = Files.getTorDir(context)
+                            val torDir = Files.getTorDir(applicationContext)
                             TorClient.new(torDir, backendDeferred.await().second.backend)
                         }
                     } else {
@@ -962,7 +988,7 @@ interface Synchronizer {
                     if (sdkFlags.isExchangeRateEnabled) {
                         lazyTorClient?.let { holder ->
                             UsdExchangeRateFetcher(
-                                isolatedTorClientProvider = { holder.getOrCreate().isolatedTorClient() }
+                                isolatedTorClient = LazyTorClient { holder.getOrCreate().isolatedTorClient() }
                             )
                         }
                     } else {
@@ -975,13 +1001,17 @@ interface Synchronizer {
                         torClient = lazyTorClient?.takeIf { sdkFlags.isTorEnabled }
                     )
 
-                // gRPC lightwalletd client (does not touch the Rust backend) — built concurrently.
+                /**
+                 * gRPC lightwalletd client (does not touch the Rust backend) — built concurrently.
+                 */
                 val walletClientDeferred =
                     async(Dispatchers.Default) {
                         walletClientFactory.create(endpoint = lightWalletEndpoint)
                     }
 
-                // Preference stores (disk I/O) — independent of backend and network.
+                /**
+                 * Preference stores (disk I/O) — independent of backend and network.
+                 */
                 val prefsDeferred =
                     async(Dispatchers.Default) {
                         val preferenceProvider = StandardPreferenceProvider(context)()
@@ -1000,8 +1030,10 @@ interface Synchronizer {
                     DefaultSynchronizerFactory
                         .defaultCompactBlockRepository(coordinator.fsBlockDbRoot(zcashNetwork, alias), backend)
 
-                // Downloader wraps the concurrently-built walletClient; built once and reused by both
-                // the (rarely used) init-state network fetch and the processor.
+                /**
+                 * Downloader wraps the concurrently-built walletClient; built once and reused by both
+                 * the (rarely used) init-state network fetch and the processor.
+                 */
                 val downloaderDeferred =
                     async(Dispatchers.Default) {
                         DefaultSynchronizerFactory.defaultDownloader(walletClientDeferred.await(), blockStore)
@@ -1027,30 +1059,35 @@ interface Synchronizer {
 
                 val encoder = DefaultSynchronizerFactory.defaultEncoder(backend, saplingParamFetcher, repository)
 
+                /**
+                 * From here on, [walletClient] is disposed on failure since ownership only transfers to the
+                 * returned [SdkSynchronizer] once construction succeeds; on any earlier failure there would be
+                 * nobody left to dispose it via `close()`.
+                 */
                 val walletClient = walletClientDeferred.await()
-                val downloader = downloaderDeferred.await()
-                val txManager = DefaultSynchronizerFactory.defaultTxManager(encoder, walletClient, sdkFlags)
-                val (preferenceProvider, pendingSubmitPlanStore) = prefsDeferred.await()
-                val transactionSubmitter =
-                    EndpointTransactionSubmitter(
-                        walletClientFactory = walletClientFactory,
-                        sdkFlags = sdkFlags
-                    )
-                val submitPlanExecutor = SubmitPlanExecutor(transactionSubmitter)
-                val processor =
-                    DefaultSynchronizerFactory.defaultProcessor(
-                        backend = backend,
-                        birthdayHeight = birthday ?: zcashNetwork.saplingActivationHeight,
-                        downloader = downloader,
-                        repository = repository,
-                        txManager = txManager,
-                        sdkFlags = sdkFlags,
-                        saplingParamFetcher = saplingParamFetcher,
-                        pendingSubmitPlanStore = pendingSubmitPlanStore,
-                        submitPlanExecutor = submitPlanExecutor
-                    )
+                try {
+                    val downloader = downloaderDeferred.await()
+                    val txManager = DefaultSynchronizerFactory.defaultTxManager(encoder, walletClient, sdkFlags)
+                    val (preferenceProvider, pendingSubmitPlanStore) = prefsDeferred.await()
+                    val transactionSubmitter =
+                        EndpointTransactionSubmitter(
+                            walletClientFactory = walletClientFactory,
+                            sdkFlags = sdkFlags
+                        )
+                    val submitPlanExecutor = SubmitPlanExecutor(transactionSubmitter)
+                    val processor =
+                        DefaultSynchronizerFactory.defaultProcessor(
+                            backend = backend,
+                            birthdayHeight = birthday ?: zcashNetwork.saplingActivationHeight,
+                            downloader = downloader,
+                            repository = repository,
+                            txManager = txManager,
+                            sdkFlags = sdkFlags,
+                            saplingParamFetcher = saplingParamFetcher,
+                            pendingSubmitPlanStore = pendingSubmitPlanStore,
+                            submitPlanExecutor = submitPlanExecutor
+                        )
 
-                val synchronizer =
                     SdkSynchronizer.new(
                         context = context.applicationContext,
                         zcashNetwork = zcashNetwork,
@@ -1075,7 +1112,13 @@ interface Synchronizer {
                         pendingSubmitPlanStore = pendingSubmitPlanStore,
                         sdkFlags = sdkFlags
                     )
-                synchronizer
+                } catch (e: CancellationException) {
+                    walletClient.dispose()
+                    throw e
+                } catch (e: Exception) {
+                    walletClient.dispose()
+                    throw e
+                }
             }
         }
 
@@ -1205,6 +1248,13 @@ internal data class WalletInitializationState(
     val recoverUntil: BlockHeight?
 )
 
+/**
+ * Resolves the [TreeState]/recover-until pair to use for wallet initialization, based on [walletInitMode].
+ *
+ * [WalletInitMode.ExistingWallet] is the normal cold-start case and never needs the network client, so it
+ * does not invoke [downloaderProvider]. This lets DB init (repository/initDataDb) proceed without waiting
+ * for the concurrently-built walletClient/downloader.
+ */
 internal suspend fun resolveWalletInitializationState(
     downloaderProvider: suspend () -> CompactBlockDownloader,
     fallbackTreeState: TreeState,
@@ -1230,9 +1280,6 @@ internal suspend fun resolveWalletInitializationState(
         )
     }
 
-    // ExistingWallet is the normal cold-start case and never needs the network client, so it does
-    // not invoke [downloaderProvider]. This lets DB init (repository/initDataDb) proceed without
-    // waiting for the concurrently-built walletClient/downloader.
     is WalletInitMode.ExistingWallet -> {
         WalletInitializationState(
             treeState = fallbackTreeState,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
@@ -18,6 +18,7 @@ import cash.z.ecc.android.sdk.internal.Twig
 import cash.z.ecc.android.sdk.internal.block.CompactBlockDownloader
 import cash.z.ecc.android.sdk.internal.db.DatabaseCoordinator
 import cash.z.ecc.android.sdk.internal.exchange.UsdExchangeRateFetcher
+import cash.z.ecc.android.sdk.internal.model.LazyTorClient
 import cash.z.ecc.android.sdk.internal.model.TorClient
 import cash.z.ecc.android.sdk.internal.model.TreeState
 import cash.z.ecc.android.sdk.internal.model.ext.toBlockHeight
@@ -617,6 +618,13 @@ interface Synchronizer {
     fun getRecipients(transactionOverview: TransactionOverview): Flow<TransactionRecipient>
 
     /**
+     * Batched alternative to [getRecipients] that returns the recipients for ALL transactions in a single query,
+     * grouped by [TransactionId]. Prefer this over calling [getRecipients] in a loop for every transaction, e.g.
+     * when building a transaction list for the UI.
+     */
+    suspend fun getRecipients(): Map<TransactionId, List<TransactionRecipient>>
+
+    /**
      * Checks and provides file path to the existing data database file for the given input parameters or throws
      * [InitializeException.MissingDatabaseException] if the database does not exist yet.
      *
@@ -638,6 +646,13 @@ interface Synchronizer {
      * Returns a list of all transaction outputs for a transaction.
      */
     suspend fun getTransactionOutputs(transactionOverview: TransactionOverview): List<TransactionOutput>
+
+    /**
+     * Batched alternative to [getTransactionOutputs] that returns the transaction outputs for ALL transactions
+     * in a single query, grouped by [TransactionId]. Prefer this over calling [getTransactionOutputs] in a loop
+     * for every transaction, e.g. when building a transaction list for the UI.
+     */
+    suspend fun getTransactionOutputs(): Map<TransactionId, List<TransactionOutput>>
 
     /**
      * Returns all transactions belonging to the given account UUID
@@ -901,25 +916,24 @@ interface Synchronizer {
                     .defaultCompactBlockRepository(coordinator.fsBlockDbRoot(zcashNetwork, alias), backend)
 
             val torDir = Files.getTorDir(context)
-            val torClient =
+
+            // Tor is only needed for on-demand/background work (sync-path Tor-mode RPCs, exchange rate
+            // fetch, getTorHttpClient), never on the cold-start critical path, so its creation (the ~1s
+            // Tor runtime creation cost) is always deferred to first use via LazyTorClient, regardless of
+            // whether isTorEnabled and/or isExchangeRateEnabled is set.
+            val lazyTorClient =
                 if (sdkFlags.isTorEnabled || sdkFlags.isExchangeRateEnabled) {
-                    try {
-                        TorClient.new(torDir, backend.backend)
-                    } catch (e: Exception) {
-                        Twig.error(e) { "Error instantiating Tor Client" }
-                        null
-                    }
+                    LazyTorClient { TorClient.new(torDir, backend.backend) }
                 } else {
                     null
                 }
 
-            val exchangeRateIsolatedTorClient =
+            val fetchExchangeChangeUsd =
                 if (sdkFlags.isExchangeRateEnabled) {
-                    try {
-                        torClient?.isolatedTorClient()
-                    } catch (e: Exception) {
-                        Twig.error(e) { "Error instantiating an isolated Tor Client" }
-                        null
+                    lazyTorClient?.let { holder ->
+                        UsdExchangeRateFetcher(
+                            isolatedTorClientProvider = { holder.getOrCreate().isolatedTorClient() }
+                        )
                     }
                 } else {
                     null
@@ -928,7 +942,7 @@ interface Synchronizer {
             val walletClientFactory =
                 WalletClientFactory(
                     context = applicationContext,
-                    torClient = torClient.takeIf { sdkFlags.isTorEnabled }
+                    torClient = lazyTorClient?.takeIf { sdkFlags.isTorEnabled }
                 )
 
             val walletClient = walletClientFactory.create(endpoint = lightWalletEndpoint)
@@ -997,10 +1011,9 @@ interface Synchronizer {
                         walletClientFactory = walletClientFactory,
                         sdkFlags = sdkFlags
                     ),
-                fetchExchangeChangeUsd =
-                    exchangeRateIsolatedTorClient?.let { UsdExchangeRateFetcher(isolatedTorClient = it) },
+                fetchExchangeChangeUsd = fetchExchangeChangeUsd,
                 preferenceProvider = preferenceProvider,
-                torClient = torClient,
+                lazyTorClient = lazyTorClient,
                 walletClient = walletClient,
                 walletClientFactory = walletClientFactory,
                 defaultSubmitEndpoint = lightWalletEndpoint,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
@@ -18,6 +18,7 @@ import cash.z.ecc.android.sdk.internal.Twig
 import cash.z.ecc.android.sdk.internal.block.CompactBlockDownloader
 import cash.z.ecc.android.sdk.internal.db.DatabaseCoordinator
 import cash.z.ecc.android.sdk.internal.exchange.UsdExchangeRateFetcher
+import cash.z.ecc.android.sdk.internal.jni.RustBackend
 import cash.z.ecc.android.sdk.internal.model.LazyTorClient
 import cash.z.ecc.android.sdk.internal.model.TorClient
 import cash.z.ecc.android.sdk.internal.model.TreeState
@@ -62,6 +63,9 @@ import co.electriccoin.lightwallet.client.model.Response
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.HttpClientEngineConfig
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.runBlocking
@@ -830,6 +834,21 @@ interface Synchronizer {
 
     companion object {
         /**
+         * Eagerly loads the native Rust library used by the SDK.
+         *
+         * Loading the native library ([System.loadLibrary]) is a one-time, process-wide cost that
+         * otherwise happens on the cold-start critical path inside [new] (as part of building the
+         * backend). Clients can call this early — e.g. from `Application.onCreate` or during a splash/
+         * authentication screen — so the cost overlaps that idle time and [new] returns faster.
+         *
+         * This is idempotent and safe to call multiple times and concurrently with [new]; the load
+         * happens at most once.
+         */
+        suspend fun preloadNativeLibrary() {
+            RustBackend.loadLibrary()
+        }
+
+        /**
          * Primary method that SDK clients will use to construct a synchronizer.
          *
          * @param zcashNetwork the network to use.
@@ -888,138 +907,176 @@ interface Synchronizer {
 
             validateAlias(alias)
 
-            val saplingParamTool = SaplingParamTool.new(applicationContext)
-
-            val loadedCheckpoint =
-                CheckpointTool.loadNearest(
-                    context = applicationContext,
-                    network = zcashNetwork,
-                    birthdayHeight = birthday ?: zcashNetwork.saplingActivationHeight
-                )
-
-            val coordinator = DatabaseCoordinator.getInstance(context)
-            // The pending transaction database no longer exists, so we can delete the file
-            coordinator.deletePendingTransactionDatabase(zcashNetwork, alias)
-
-            val backend =
-                DefaultSynchronizerFactory.defaultBackend(
-                    zcashNetwork,
-                    alias,
-                    saplingParamTool,
-                    coordinator
-                )
-
-            val saplingParamFetcher = SaplingParamFetcher(saplingParamTool, backend)
-
-            val blockStore =
-                DefaultSynchronizerFactory
-                    .defaultCompactBlockRepository(coordinator.fsBlockDbRoot(zcashNetwork, alias), backend)
-
-            val torDir = Files.getTorDir(context)
-
-            // Tor is only needed for on-demand/background work (sync-path Tor-mode RPCs, exchange rate
-            // fetch, getTorHttpClient), never on the cold-start critical path, so its creation (the ~1s
-            // Tor runtime creation cost) is always deferred to first use via LazyTorClient, regardless of
-            // whether isTorEnabled and/or isExchangeRateEnabled is set.
-            val lazyTorClient =
-                if (sdkFlags.isTorEnabled || sdkFlags.isExchangeRateEnabled) {
-                    LazyTorClient { TorClient.new(torDir, backend.backend) }
-                } else {
-                    null
-                }
-
-            val fetchExchangeChangeUsd =
-                if (sdkFlags.isExchangeRateEnabled) {
-                    lazyTorClient?.let { holder ->
-                        UsdExchangeRateFetcher(
-                            isolatedTorClientProvider = { holder.getOrCreate().isolatedTorClient() }
+            // The construction of a Synchronizer is split into independent branches that run
+            // concurrently on background threads, then joined. The critical path to an emitting DB
+            // (backend native-load → repository/initDataDb) no longer serializes behind the network
+            // client (gRPC walletClient), checkpoint load, or preference disk I/O — all of which are
+            // only needed for syncing, not for reading stored balances/transactions.
+            return coroutineScope {
+                // Bundled checkpoint load (asset read) — independent of everything else.
+                val checkpointDeferred =
+                    async(Dispatchers.Default) {
+                        CheckpointTool.loadNearest(
+                            context = applicationContext,
+                            network = zcashNetwork,
+                            birthdayHeight = birthday ?: zcashNetwork.saplingActivationHeight
                         )
                     }
-                } else {
-                    null
-                }
 
-            val walletClientFactory =
-                WalletClientFactory(
-                    context = applicationContext,
-                    torClient = lazyTorClient?.takeIf { sdkFlags.isTorEnabled }
-                )
+                val coordinator = DatabaseCoordinator.getInstance(context)
+                // The pending transaction database no longer exists, so we can delete the file
+                coordinator.deletePendingTransactionDatabase(zcashNetwork, alias)
 
-            val walletClient = walletClientFactory.create(endpoint = lightWalletEndpoint)
-            val downloader = DefaultSynchronizerFactory.defaultDownloader(walletClient, blockStore)
+                // Native library load (~one-time per process) + Rust backend construction. This is the
+                // long pole of the DB-read critical path; everything Rust/DB-related awaits it.
+                val backendDeferred =
+                    async(Dispatchers.Default) {
+                        val saplingParamTool = SaplingParamTool.new(applicationContext)
+                        val backend =
+                            DefaultSynchronizerFactory.defaultBackend(
+                                zcashNetwork,
+                                alias,
+                                saplingParamTool,
+                                coordinator
+                            )
+                        saplingParamTool to backend
+                    }
 
-            val initializationState =
-                resolveWalletInitializationState(
-                    downloader = downloader,
-                    fallbackTreeState = loadedCheckpoint.treeState(),
-                    sdkFlags = sdkFlags,
-                    walletInitMode = walletInitMode
-                )
+                // Tor is only needed for on-demand/background work (sync-path Tor-mode RPCs, exchange rate
+                // fetch, getTorHttpClient), never on the cold-start critical path, so its creation (the ~1s
+                // Tor runtime creation cost) is always deferred to first use via LazyTorClient, regardless of
+                // whether isTorEnabled and/or isExchangeRateEnabled is set. Because the factory only awaits
+                // the backend when Tor is actually first used (much later), the walletClient below can be
+                // built concurrently with the backend rather than waiting for it.
+                val lazyTorClient =
+                    if (sdkFlags.isTorEnabled || sdkFlags.isExchangeRateEnabled) {
+                        LazyTorClient {
+                            val torDir = Files.getTorDir(context)
+                            TorClient.new(torDir, backendDeferred.await().second.backend)
+                        }
+                    } else {
+                        null
+                    }
 
-            val repository =
-                DefaultSynchronizerFactory.defaultDerivedDataRepository(
-                    context = applicationContext,
-                    rustBackend = backend,
-                    databaseFile = coordinator.dataDbFile(zcashNetwork, alias),
-                    treeState = initializationState.treeState,
-                    recoverUntil = initializationState.recoverUntil,
-                    setup = setup,
-                )
+                val fetchExchangeChangeUsd =
+                    if (sdkFlags.isExchangeRateEnabled) {
+                        lazyTorClient?.let { holder ->
+                            UsdExchangeRateFetcher(
+                                isolatedTorClientProvider = { holder.getOrCreate().isolatedTorClient() }
+                            )
+                        }
+                    } else {
+                        null
+                    }
 
-            val encoder = DefaultSynchronizerFactory.defaultEncoder(backend, saplingParamFetcher, repository)
+                val walletClientFactory =
+                    WalletClientFactory(
+                        context = applicationContext,
+                        torClient = lazyTorClient?.takeIf { sdkFlags.isTorEnabled }
+                    )
 
-            val txManager = DefaultSynchronizerFactory.defaultTxManager(encoder, walletClient, sdkFlags)
-            val standardPreferenceProvider = StandardPreferenceProvider(context)
-            val preferenceProvider = standardPreferenceProvider()
-            val encryptedPreferenceProvider = EncryptedPreferenceProvider(applicationContext)
-            val pendingSubmitPlanStore =
-                PendingSubmitPlanStore(
-                    preferenceProvider = encryptedPreferenceProvider(),
-                    namespace = "${zcashNetwork.id}_$alias"
-                )
-            val transactionSubmitter =
-                EndpointTransactionSubmitter(
-                    walletClientFactory = walletClientFactory,
-                    sdkFlags = sdkFlags
-                )
-            val submitPlanExecutor = SubmitPlanExecutor(transactionSubmitter)
-            val processor =
-                DefaultSynchronizerFactory.defaultProcessor(
-                    backend = backend,
-                    birthdayHeight = birthday ?: zcashNetwork.saplingActivationHeight,
-                    downloader = downloader,
-                    repository = repository,
-                    txManager = txManager,
-                    sdkFlags = sdkFlags,
-                    saplingParamFetcher = saplingParamFetcher,
-                    pendingSubmitPlanStore = pendingSubmitPlanStore,
-                    submitPlanExecutor = submitPlanExecutor
-                )
+                // gRPC lightwalletd client (does not touch the Rust backend) — built concurrently.
+                val walletClientDeferred =
+                    async(Dispatchers.Default) {
+                        walletClientFactory.create(endpoint = lightWalletEndpoint)
+                    }
 
-            return SdkSynchronizer.new(
-                context = context.applicationContext,
-                zcashNetwork = zcashNetwork,
-                alias = alias,
-                repository = repository,
-                txManager = txManager,
-                processor = processor,
-                backend = backend,
-                fastestServerFetcher =
-                    FastestServerFetcher(
-                        backend = backend,
-                        network = processor.network,
+                // Preference stores (disk I/O) — independent of backend and network.
+                val prefsDeferred =
+                    async(Dispatchers.Default) {
+                        val preferenceProvider = StandardPreferenceProvider(context)()
+                        val encryptedPreferenceProvider = EncryptedPreferenceProvider(applicationContext)
+                        val pendingSubmitPlanStore =
+                            PendingSubmitPlanStore(
+                                preferenceProvider = encryptedPreferenceProvider(),
+                                namespace = "${zcashNetwork.id}_$alias"
+                            )
+                        preferenceProvider to pendingSubmitPlanStore
+                    }
+
+                val (saplingParamTool, backend) = backendDeferred.await()
+                val saplingParamFetcher = SaplingParamFetcher(saplingParamTool, backend)
+                val blockStore =
+                    DefaultSynchronizerFactory
+                        .defaultCompactBlockRepository(coordinator.fsBlockDbRoot(zcashNetwork, alias), backend)
+
+                // Downloader wraps the concurrently-built walletClient; built once and reused by both
+                // the (rarely used) init-state network fetch and the processor.
+                val downloaderDeferred =
+                    async(Dispatchers.Default) {
+                        DefaultSynchronizerFactory.defaultDownloader(walletClientDeferred.await(), blockStore)
+                    }
+
+                val initializationState =
+                    resolveWalletInitializationState(
+                        downloaderProvider = { downloaderDeferred.await() },
+                        fallbackTreeState = checkpointDeferred.await().treeState(),
+                        sdkFlags = sdkFlags,
+                        walletInitMode = walletInitMode
+                    )
+
+                val repository =
+                    DefaultSynchronizerFactory.defaultDerivedDataRepository(
+                        context = applicationContext,
+                        rustBackend = backend,
+                        databaseFile = coordinator.dataDbFile(zcashNetwork, alias),
+                        treeState = initializationState.treeState,
+                        recoverUntil = initializationState.recoverUntil,
+                        setup = setup,
+                    )
+
+                val encoder = DefaultSynchronizerFactory.defaultEncoder(backend, saplingParamFetcher, repository)
+
+                val walletClient = walletClientDeferred.await()
+                val downloader = downloaderDeferred.await()
+                val txManager = DefaultSynchronizerFactory.defaultTxManager(encoder, walletClient, sdkFlags)
+                val (preferenceProvider, pendingSubmitPlanStore) = prefsDeferred.await()
+                val transactionSubmitter =
+                    EndpointTransactionSubmitter(
                         walletClientFactory = walletClientFactory,
                         sdkFlags = sdkFlags
-                    ),
-                fetchExchangeChangeUsd = fetchExchangeChangeUsd,
-                preferenceProvider = preferenceProvider,
-                lazyTorClient = lazyTorClient,
-                walletClient = walletClient,
-                walletClientFactory = walletClientFactory,
-                defaultSubmitEndpoint = lightWalletEndpoint,
-                pendingSubmitPlanStore = pendingSubmitPlanStore,
-                sdkFlags = sdkFlags
-            )
+                    )
+                val submitPlanExecutor = SubmitPlanExecutor(transactionSubmitter)
+                val processor =
+                    DefaultSynchronizerFactory.defaultProcessor(
+                        backend = backend,
+                        birthdayHeight = birthday ?: zcashNetwork.saplingActivationHeight,
+                        downloader = downloader,
+                        repository = repository,
+                        txManager = txManager,
+                        sdkFlags = sdkFlags,
+                        saplingParamFetcher = saplingParamFetcher,
+                        pendingSubmitPlanStore = pendingSubmitPlanStore,
+                        submitPlanExecutor = submitPlanExecutor
+                    )
+
+                val synchronizer =
+                    SdkSynchronizer.new(
+                        context = context.applicationContext,
+                        zcashNetwork = zcashNetwork,
+                        alias = alias,
+                        repository = repository,
+                        txManager = txManager,
+                        processor = processor,
+                        backend = backend,
+                        fastestServerFetcher =
+                            FastestServerFetcher(
+                                backend = backend,
+                                network = processor.network,
+                                walletClientFactory = walletClientFactory,
+                                sdkFlags = sdkFlags
+                            ),
+                        fetchExchangeChangeUsd = fetchExchangeChangeUsd,
+                        preferenceProvider = preferenceProvider,
+                        lazyTorClient = lazyTorClient,
+                        walletClient = walletClient,
+                        walletClientFactory = walletClientFactory,
+                        defaultSubmitEndpoint = lightWalletEndpoint,
+                        pendingSubmitPlanStore = pendingSubmitPlanStore,
+                        sdkFlags = sdkFlags
+                    )
+                synchronizer
+            }
         }
 
         /**
@@ -1149,7 +1206,7 @@ internal data class WalletInitializationState(
 )
 
 internal suspend fun resolveWalletInitializationState(
-    downloader: CompactBlockDownloader,
+    downloaderProvider: suspend () -> CompactBlockDownloader,
     fallbackTreeState: TreeState,
     sdkFlags: SdkFlags,
     walletInitMode: WalletInitMode,
@@ -1158,14 +1215,14 @@ internal suspend fun resolveWalletInitializationState(
     is RestoreWallet -> {
         WalletInitializationState(
             treeState = fallbackTreeState,
-            recoverUntil = downloader.fetchRecoverUntil(sdkFlags)
+            recoverUntil = downloaderProvider().fetchRecoverUntil(sdkFlags)
         )
     }
 
     is WalletInitMode.NewWallet -> {
         WalletInitializationState(
             treeState =
-                downloader.fetchNewWalletTreeState(
+                downloaderProvider().fetchNewWalletTreeState(
                     sdkFlags,
                     newWalletTreeStateTimeout
                 ) ?: fallbackTreeState,
@@ -1173,6 +1230,9 @@ internal suspend fun resolveWalletInitializationState(
         )
     }
 
+    // ExistingWallet is the normal cold-start case and never needs the network client, so it does
+    // not invoke [downloaderProvider]. This lets DB init (repository/initDataDb) proceed without
+    // waiting for the concurrently-built walletClient/downloader.
     is WalletInitMode.ExistingWallet -> {
         WalletInitializationState(
             treeState = fallbackTreeState,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/DbDerivedDataRepository.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/DbDerivedDataRepository.kt
@@ -59,13 +59,7 @@ internal class DbDerivedDataRepository(
             .getOutputProperties(transactionId.value)
 
     override suspend fun getAllOutputProperties(): Map<TransactionId, List<OutputProperties>> =
-        derivedDataDb.txOutputsView
-            .getAllOutputProperties()
-            .toList()
-            .groupBy(
-                keySelector = { (transactionId, _) -> TransactionId(transactionId) },
-                valueTransform = { (_, outputProperties) -> outputProperties }
-            )
+        derivedDataDb.txOutputsView.getAllOutputProperties().groupByTransactionId()
 
     override fun getTransactionsByMemoSubstring(query: String): Flow<List<TransactionId>> =
         flow {
@@ -82,13 +76,7 @@ internal class DbDerivedDataRepository(
         derivedDataDb.txOutputsView.getRecipients(transactionId.value)
 
     override suspend fun getAllRecipients(): Map<TransactionId, List<TransactionRecipient>> =
-        derivedDataDb.txOutputsView
-            .getAllRecipients()
-            .toList()
-            .groupBy(
-                keySelector = { (transactionId, _) -> TransactionId(transactionId) },
-                valueTransform = { (_, recipient) -> recipient }
-            )
+        derivedDataDb.txOutputsView.getAllRecipients().groupByTransactionId()
 
     override suspend fun debugQuery(query: String): String = derivedDataDb.debugQuery(query)
 
@@ -101,3 +89,13 @@ internal class DbDerivedDataRepository(
 
     override suspend fun isClosed(): Boolean = derivedDataDb.isClosed()
 }
+
+/**
+ * Collects this [Flow] of (transaction ID, value) pairs, emitted grouped by transaction ID, e.g. by
+ * [TxOutputsView.getAllOutputProperties] or [TxOutputsView.getAllRecipients].
+ */
+private suspend fun <T> Flow<Pair<FirstClassByteArray, T>>.groupByTransactionId(): Map<TransactionId, List<T>> =
+    toList().groupBy(
+        keySelector = { (transactionId, _) -> TransactionId(transactionId) },
+        valueTransform = { (_, value) -> value }
+    )

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/DbDerivedDataRepository.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/DbDerivedDataRepository.kt
@@ -3,6 +3,7 @@ package cash.z.ecc.android.sdk.internal.db.derived
 import cash.z.ecc.android.sdk.internal.model.DbBlock
 import cash.z.ecc.android.sdk.internal.model.DbTransactionOverview
 import cash.z.ecc.android.sdk.internal.model.EncodedTransaction
+import cash.z.ecc.android.sdk.internal.model.OutputProperties
 import cash.z.ecc.android.sdk.internal.repository.DerivedDataRepository
 import cash.z.ecc.android.sdk.model.AccountUuid
 import cash.z.ecc.android.sdk.model.BlockHeight
@@ -57,6 +58,15 @@ internal class DbDerivedDataRepository(
         derivedDataDb.txOutputsView
             .getOutputProperties(transactionId.value)
 
+    override suspend fun getAllOutputProperties(): Map<TransactionId, List<OutputProperties>> =
+        derivedDataDb.txOutputsView
+            .getAllOutputProperties()
+            .toList()
+            .groupBy(
+                keySelector = { (transactionId, _) -> TransactionId(transactionId) },
+                valueTransform = { (_, outputProperties) -> outputProperties }
+            )
+
     override fun getTransactionsByMemoSubstring(query: String): Flow<List<TransactionId>> =
         flow {
             emit(
@@ -70,6 +80,15 @@ internal class DbDerivedDataRepository(
 
     override fun getRecipients(transactionId: TransactionId): Flow<TransactionRecipient> =
         derivedDataDb.txOutputsView.getRecipients(transactionId.value)
+
+    override suspend fun getAllRecipients(): Map<TransactionId, List<TransactionRecipient>> =
+        derivedDataDb.txOutputsView
+            .getAllRecipients()
+            .toList()
+            .groupBy(
+                keySelector = { (transactionId, _) -> TransactionId(transactionId) },
+                valueTransform = { (_, recipient) -> recipient }
+            )
 
     override suspend fun debugQuery(query: String): String = derivedDataDb.debugQuery(query)
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/TxOutputsView.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/TxOutputsView.kt
@@ -1,5 +1,6 @@
 package cash.z.ecc.android.sdk.internal.db.derived
 
+import android.database.Cursor
 import androidx.sqlite.db.SupportSQLiteDatabase
 import cash.z.ecc.android.sdk.internal.db.queryAndMap
 import cash.z.ecc.android.sdk.internal.model.OutputProperties
@@ -94,22 +95,14 @@ internal class TxOutputsView(
             selection = SELECT_BY_TRANSACTION_ID_AND_NOT_CHANGE,
             selectionArgs = arrayOf(transactionId.byteArray),
             orderBy = ORDER_BY,
-            cursorParser = {
-                val idColumnOutputIndex = it.getColumnIndex(TxOutputsViewDefinition.COLUMN_INTEGER_OUTPUT_INDEX)
-                val idColumnOutputPoolIndex = it.getColumnIndex(TxOutputsViewDefinition.COLUMN_INTEGER_OUTPUT_POOL)
-
-                OutputProperties.new(
-                    index = it.getInt(idColumnOutputIndex),
-                    // Converting blob to Int
-                    poolType = it.getInt(idColumnOutputPoolIndex)
-                )
-            }
+            cursorParser = { it.parseOutputProperties() }
         )
 
     /**
      * Returns the non-change output properties for ALL transactions in a single query, grouped by transaction ID
      * via the emitted [Pair]. This is a batched alternative to [getOutputProperties] intended for callers that
-     * would otherwise need to query per-transaction in a loop.
+     * would otherwise need to query per-transaction in a loop. A transaction with only change outputs (or no
+     * outputs) does not emit any [Pair].
      */
     fun getAllOutputProperties(): Flow<Pair<FirstClassByteArray, OutputProperties>> =
         sqliteDatabase.queryAndMap(
@@ -119,19 +112,8 @@ internal class TxOutputsView(
             selectionArgs = null,
             orderBy = ORDER_BY_TRANSACTION_ID_AND_OUTPUT_INDEX,
             cursorParser = {
-                val idColumnTrxIdIndex = it.getColumnIndex(TxOutputsViewDefinition.COLUMN_BLOB_TRANSACTION_ID)
-                val idColumnOutputIndex = it.getColumnIndex(TxOutputsViewDefinition.COLUMN_INTEGER_OUTPUT_INDEX)
-                val idColumnOutputPoolIndex = it.getColumnIndex(TxOutputsViewDefinition.COLUMN_INTEGER_OUTPUT_POOL)
-
-                val transactionId = FirstClassByteArray(it.getBlob(idColumnTrxIdIndex))
-                val outputProperties =
-                    OutputProperties.new(
-                        index = it.getInt(idColumnOutputIndex),
-                        // Converting blob to Int
-                        poolType = it.getInt(idColumnOutputPoolIndex)
-                    )
-
-                transactionId to outputProperties
+                val transactionId = it.parseTransactionId()
+                transactionId to it.parseOutputProperties()
             }
         )
 
@@ -144,11 +126,7 @@ internal class TxOutputsView(
             selection = SELECT_BY_MEMO_QUERY,
             selectionArgs = arrayOf("%$query%"),
             orderBy = ORDER_BY,
-            cursorParser = {
-                val idColumnTrxIdIndex = it.getColumnIndex(TxOutputsViewDefinition.COLUMN_BLOB_TRANSACTION_ID)
-
-                FirstClassByteArray(it.getBlob(idColumnTrxIdIndex))
-            }
+            cursorParser = { it.parseTransactionId() }
         )
 
     fun getRecipients(transactionId: FirstClassByteArray) =
@@ -158,21 +136,14 @@ internal class TxOutputsView(
             selection = SELECT_BY_TRANSACTION_ID_AND_NOT_CHANGE,
             selectionArgs = arrayOf(transactionId.byteArray),
             orderBy = ORDER_BY,
-            cursorParser = {
-                val toAccountIndex = it.getColumnIndex(TxOutputsViewDefinition.COLUMN_BLOB_TO_ACCOUNT)
-                val toAddressIndex = it.getColumnIndex(TxOutputsViewDefinition.COLUMN_STRING_TO_ADDRESS)
-
-                TransactionRecipient(
-                    addressValue = if (!it.isNull(toAddressIndex)) it.getString(toAddressIndex) else null,
-                    accountUuid = if (!it.isNull(toAccountIndex)) AccountUuid(it.getBlob(toAccountIndex)) else null
-                )
-            }
+            cursorParser = { it.parseRecipient() }
         )
 
     /**
      * Returns the non-change recipients for ALL transactions in a single query, grouped by transaction ID via the
      * emitted [Pair]. This is a batched alternative to [getRecipients] intended for callers that would otherwise
-     * need to query per-transaction in a loop.
+     * need to query per-transaction in a loop. A transaction with only change outputs (or no outputs) does not
+     * emit any [Pair].
      */
     fun getAllRecipients(): Flow<Pair<FirstClassByteArray, TransactionRecipient>> =
         sqliteDatabase.queryAndMap(
@@ -182,20 +153,35 @@ internal class TxOutputsView(
             selectionArgs = null,
             orderBy = ORDER_BY_TRANSACTION_ID_AND_OUTPUT_INDEX,
             cursorParser = {
-                val idColumnTrxIdIndex = it.getColumnIndex(TxOutputsViewDefinition.COLUMN_BLOB_TRANSACTION_ID)
-                val toAccountIndex = it.getColumnIndex(TxOutputsViewDefinition.COLUMN_BLOB_TO_ACCOUNT)
-                val toAddressIndex = it.getColumnIndex(TxOutputsViewDefinition.COLUMN_STRING_TO_ADDRESS)
-
-                val transactionId = FirstClassByteArray(it.getBlob(idColumnTrxIdIndex))
-                val recipient =
-                    TransactionRecipient(
-                        addressValue = if (!it.isNull(toAddressIndex)) it.getString(toAddressIndex) else null,
-                        accountUuid = if (!it.isNull(toAccountIndex)) AccountUuid(it.getBlob(toAccountIndex)) else null
-                    )
-
-                transactionId to recipient
+                val transactionId = it.parseTransactionId()
+                transactionId to it.parseRecipient()
             }
         )
+
+    private fun Cursor.parseTransactionId(): FirstClassByteArray {
+        val idColumnTrxIdIndex = getColumnIndex(TxOutputsViewDefinition.COLUMN_BLOB_TRANSACTION_ID)
+        return FirstClassByteArray(getBlob(idColumnTrxIdIndex))
+    }
+
+    private fun Cursor.parseOutputProperties(): OutputProperties {
+        val idColumnOutputIndex = getColumnIndex(TxOutputsViewDefinition.COLUMN_INTEGER_OUTPUT_INDEX)
+        val idColumnOutputPoolIndex = getColumnIndex(TxOutputsViewDefinition.COLUMN_INTEGER_OUTPUT_POOL)
+
+        return OutputProperties.new(
+            index = getInt(idColumnOutputIndex),
+            poolType = getInt(idColumnOutputPoolIndex)
+        )
+    }
+
+    private fun Cursor.parseRecipient(): TransactionRecipient {
+        val toAccountIndex = getColumnIndex(TxOutputsViewDefinition.COLUMN_BLOB_TO_ACCOUNT)
+        val toAddressIndex = getColumnIndex(TxOutputsViewDefinition.COLUMN_STRING_TO_ADDRESS)
+
+        return TransactionRecipient(
+            addressValue = if (!isNull(toAddressIndex)) getString(toAddressIndex) else null,
+            accountUuid = if (!isNull(toAccountIndex)) AccountUuid(getBlob(toAccountIndex)) else null
+        )
+    }
 }
 
 internal object TxOutputsViewDefinition {

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/TxOutputsView.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/TxOutputsView.kt
@@ -27,6 +27,13 @@ internal class TxOutputsView(
                 TxOutputsViewDefinition.COLUMN_INTEGER_OUTPUT_POOL,
             )
 
+        private val PROJECTION_ALL_OUTPUT_PROPERTIES =
+            arrayOf(
+                TxOutputsViewDefinition.COLUMN_BLOB_TRANSACTION_ID,
+                TxOutputsViewDefinition.COLUMN_INTEGER_OUTPUT_INDEX,
+                TxOutputsViewDefinition.COLUMN_INTEGER_OUTPUT_POOL,
+            )
+
         private val PROJECTION_MEMOS =
             arrayOf(
                 TxOutputsViewDefinition.COLUMN_BLOB_TRANSACTION_ID
@@ -34,6 +41,13 @@ internal class TxOutputsView(
 
         private val PROJECTION_RECIPIENT =
             arrayOf(
+                TxOutputsViewDefinition.COLUMN_STRING_TO_ADDRESS,
+                TxOutputsViewDefinition.COLUMN_BLOB_TO_ACCOUNT
+            )
+
+        private val PROJECTION_ALL_RECIPIENT =
+            arrayOf(
+                TxOutputsViewDefinition.COLUMN_BLOB_TRANSACTION_ID,
                 TxOutputsViewDefinition.COLUMN_STRING_TO_ADDRESS,
                 TxOutputsViewDefinition.COLUMN_BLOB_TO_ACCOUNT
             )
@@ -54,6 +68,23 @@ internal class TxOutputsView(
                 "LOWER(%s) LIKE LOWER(?)",
                 TxOutputsViewDefinition.COLUMN_BLOB_MEMO,
             )
+
+        private val SELECT_NOT_CHANGE =
+            String.format(
+                Locale.ROOT,
+                // $NON-NLS
+                "%s == 0",
+                TxOutputsViewDefinition.COLUMN_INTEGER_IS_CHANGE
+            )
+
+        private val ORDER_BY_TRANSACTION_ID_AND_OUTPUT_INDEX =
+            String.format(
+                Locale.ROOT,
+                // $NON-NLS
+                "%s ASC, %s ASC",
+                TxOutputsViewDefinition.COLUMN_BLOB_TRANSACTION_ID,
+                TxOutputsViewDefinition.COLUMN_INTEGER_OUTPUT_INDEX
+            )
     }
 
     fun getOutputProperties(transactionId: FirstClassByteArray) =
@@ -72,6 +103,35 @@ internal class TxOutputsView(
                     // Converting blob to Int
                     poolType = it.getInt(idColumnOutputPoolIndex)
                 )
+            }
+        )
+
+    /**
+     * Returns the non-change output properties for ALL transactions in a single query, grouped by transaction ID
+     * via the emitted [Pair]. This is a batched alternative to [getOutputProperties] intended for callers that
+     * would otherwise need to query per-transaction in a loop.
+     */
+    fun getAllOutputProperties(): Flow<Pair<FirstClassByteArray, OutputProperties>> =
+        sqliteDatabase.queryAndMap(
+            table = TxOutputsViewDefinition.VIEW_NAME,
+            columns = PROJECTION_ALL_OUTPUT_PROPERTIES,
+            selection = SELECT_NOT_CHANGE,
+            selectionArgs = null,
+            orderBy = ORDER_BY_TRANSACTION_ID_AND_OUTPUT_INDEX,
+            cursorParser = {
+                val idColumnTrxIdIndex = it.getColumnIndex(TxOutputsViewDefinition.COLUMN_BLOB_TRANSACTION_ID)
+                val idColumnOutputIndex = it.getColumnIndex(TxOutputsViewDefinition.COLUMN_INTEGER_OUTPUT_INDEX)
+                val idColumnOutputPoolIndex = it.getColumnIndex(TxOutputsViewDefinition.COLUMN_INTEGER_OUTPUT_POOL)
+
+                val transactionId = FirstClassByteArray(it.getBlob(idColumnTrxIdIndex))
+                val outputProperties =
+                    OutputProperties.new(
+                        index = it.getInt(idColumnOutputIndex),
+                        // Converting blob to Int
+                        poolType = it.getInt(idColumnOutputPoolIndex)
+                    )
+
+                transactionId to outputProperties
             }
         )
 
@@ -106,6 +166,34 @@ internal class TxOutputsView(
                     addressValue = if (!it.isNull(toAddressIndex)) it.getString(toAddressIndex) else null,
                     accountUuid = if (!it.isNull(toAccountIndex)) AccountUuid(it.getBlob(toAccountIndex)) else null
                 )
+            }
+        )
+
+    /**
+     * Returns the non-change recipients for ALL transactions in a single query, grouped by transaction ID via the
+     * emitted [Pair]. This is a batched alternative to [getRecipients] intended for callers that would otherwise
+     * need to query per-transaction in a loop.
+     */
+    fun getAllRecipients(): Flow<Pair<FirstClassByteArray, TransactionRecipient>> =
+        sqliteDatabase.queryAndMap(
+            table = TxOutputsViewDefinition.VIEW_NAME,
+            columns = PROJECTION_ALL_RECIPIENT,
+            selection = SELECT_NOT_CHANGE,
+            selectionArgs = null,
+            orderBy = ORDER_BY_TRANSACTION_ID_AND_OUTPUT_INDEX,
+            cursorParser = {
+                val idColumnTrxIdIndex = it.getColumnIndex(TxOutputsViewDefinition.COLUMN_BLOB_TRANSACTION_ID)
+                val toAccountIndex = it.getColumnIndex(TxOutputsViewDefinition.COLUMN_BLOB_TO_ACCOUNT)
+                val toAddressIndex = it.getColumnIndex(TxOutputsViewDefinition.COLUMN_STRING_TO_ADDRESS)
+
+                val transactionId = FirstClassByteArray(it.getBlob(idColumnTrxIdIndex))
+                val recipient =
+                    TransactionRecipient(
+                        addressValue = if (!it.isNull(toAddressIndex)) it.getString(toAddressIndex) else null,
+                        accountUuid = if (!it.isNull(toAccountIndex)) AccountUuid(it.getBlob(toAccountIndex)) else null
+                    )
+
+                transactionId to recipient
             }
         )
 }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/exchange/UsdExchangeRateFetcher.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/exchange/UsdExchangeRateFetcher.kt
@@ -6,18 +6,26 @@ import cash.z.ecc.android.sdk.model.FetchFiatCurrencyResult
 import cash.z.ecc.android.sdk.model.FiatCurrencyConversion
 import co.electriccoin.lightwallet.client.util.Disposable
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlin.time.Clock
 
 internal class UsdExchangeRateFetcher(
-    private val isolatedTorClient: TorClient,
+    private val isolatedTorClientProvider: suspend () -> TorClient,
 ) : Disposable {
+    private val mutex = Mutex()
+    private var isolatedTorClient: TorClient? = null
+
+    private suspend fun getOrCreateIsolatedTorClient(): TorClient =
+        mutex.withLock { isolatedTorClient ?: isolatedTorClientProvider().also { isolatedTorClient = it } }
+
     @Suppress("TooGenericExceptionCaught", "ReturnCount")
     suspend operator fun invoke(): FetchFiatCurrencyResult {
         return retry {
             val rate =
                 try {
                     Twig.info { "[USD] Fetch start" }
-                    isolatedTorClient.getExchangeRateUsd()
+                    getOrCreateIsolatedTorClient().getExchangeRateUsd()
                 } catch (e: Exception) {
                     Twig.error(e) { "[USD] Fetch failed" }
                     return FetchFiatCurrencyResult.Error(e)
@@ -59,6 +67,9 @@ internal class UsdExchangeRateFetcher(
     }
 
     override suspend fun dispose() {
-        isolatedTorClient.dispose()
+        mutex.withLock {
+            isolatedTorClient?.dispose()
+            isolatedTorClient = null
+        }
     }
 }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/exchange/UsdExchangeRateFetcher.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/exchange/UsdExchangeRateFetcher.kt
@@ -1,31 +1,26 @@
 package cash.z.ecc.android.sdk.internal.exchange
 
 import cash.z.ecc.android.sdk.internal.Twig
-import cash.z.ecc.android.sdk.internal.model.TorClient
+import cash.z.ecc.android.sdk.internal.model.LazyTorClient
 import cash.z.ecc.android.sdk.model.FetchFiatCurrencyResult
 import cash.z.ecc.android.sdk.model.FiatCurrencyConversion
 import co.electriccoin.lightwallet.client.util.Disposable
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlin.time.Clock
 
 internal class UsdExchangeRateFetcher(
-    private val isolatedTorClientProvider: suspend () -> TorClient,
+    private val isolatedTorClient: LazyTorClient,
 ) : Disposable {
-    private val mutex = Mutex()
-    private var isolatedTorClient: TorClient? = null
-
-    private suspend fun getOrCreateIsolatedTorClient(): TorClient =
-        mutex.withLock { isolatedTorClient ?: isolatedTorClientProvider().also { isolatedTorClient = it } }
-
     @Suppress("TooGenericExceptionCaught", "ReturnCount")
     suspend operator fun invoke(): FetchFiatCurrencyResult {
         return retry {
             val rate =
                 try {
                     Twig.info { "[USD] Fetch start" }
-                    getOrCreateIsolatedTorClient().getExchangeRateUsd()
+                    isolatedTorClient.getOrCreate().getExchangeRateUsd()
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     Twig.error(e) { "[USD] Fetch failed" }
                     return FetchFiatCurrencyResult.Error(e)
@@ -67,9 +62,6 @@ internal class UsdExchangeRateFetcher(
     }
 
     override suspend fun dispose() {
-        mutex.withLock {
-            isolatedTorClient?.dispose()
-            isolatedTorClient = null
-        }
+        isolatedTorClient.dispose()
     }
 }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/repository/DerivedDataRepository.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/repository/DerivedDataRepository.kt
@@ -89,6 +89,10 @@ internal interface DerivedDataRepository {
     /**
      * Batched alternative to [getOutputProperties] that returns the non-change output properties for ALL
      * transactions in a single query, grouped by [TransactionId].
+     *
+     * The map only contains entries for transactions that have at least one non-change output; a transaction
+     * with only change outputs (or no outputs) is absent from the map rather than being present with an empty
+     * list.
      */
     suspend fun getAllOutputProperties(): Map<TransactionId, List<OutputProperties>>
 
@@ -99,6 +103,10 @@ internal interface DerivedDataRepository {
     /**
      * Batched alternative to [getRecipients] that returns the non-change recipients for ALL transactions in a
      * single query, grouped by [TransactionId].
+     *
+     * The map only contains entries for transactions that have at least one non-change recipient; a
+     * transaction with only change outputs (or no outputs) is absent from the map rather than being present
+     * with an empty list.
      */
     suspend fun getAllRecipients(): Map<TransactionId, List<TransactionRecipient>>
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/repository/DerivedDataRepository.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/repository/DerivedDataRepository.kt
@@ -86,9 +86,21 @@ internal interface DerivedDataRepository {
 
     fun getOutputProperties(transactionId: TransactionId): Flow<OutputProperties>
 
+    /**
+     * Batched alternative to [getOutputProperties] that returns the non-change output properties for ALL
+     * transactions in a single query, grouped by [TransactionId].
+     */
+    suspend fun getAllOutputProperties(): Map<TransactionId, List<OutputProperties>>
+
     fun getTransactionsByMemoSubstring(query: String): Flow<List<TransactionId>>
 
     fun getRecipients(transactionId: TransactionId): Flow<TransactionRecipient>
+
+    /**
+     * Batched alternative to [getRecipients] that returns the non-change recipients for ALL transactions in a
+     * single query, grouped by [TransactionId].
+     */
+    suspend fun getAllRecipients(): Map<TransactionId, List<TransactionRecipient>>
 
     suspend fun debugQuery(query: String): String
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/TransactionId.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/TransactionId.kt
@@ -45,10 +45,14 @@ data class TransactionId internal constructor(
         }
     }
 
+    // Computed once and reused; txIdString() is called many times per transaction on the same instance
+    // (activity-list mapping, cache keys, lookups), so caching avoids repeated byte->hex conversions.
+    private val txIdStringCache: String by lazy { value.byteArray.toHexReversed() }
+
     /**
      * @return Transaction ID in String
      */
-    fun txIdString() = value.byteArray.toHexReversed()
+    fun txIdString() = txIdStringCache
 
     override fun toString() = "TransactionId"
 }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/TransactionId.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/TransactionId.kt
@@ -45,8 +45,10 @@ data class TransactionId internal constructor(
         }
     }
 
-    // Computed once and reused; txIdString() is called many times per transaction on the same instance
-    // (activity-list mapping, cache keys, lookups), so caching avoids repeated byte->hex conversions.
+    /**
+     * Computed once and reused; [txIdString] is called many times per transaction on the same instance
+     * (activity-list mapping, cache keys, lookups), so caching avoids repeated byte->hex conversions.
+     */
     private val txIdStringCache: String by lazy { value.byteArray.toHexReversed() }
 
     /**

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/util/WalletClientFactory.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/util/WalletClientFactory.kt
@@ -2,7 +2,7 @@ package cash.z.ecc.android.sdk.util
 
 import android.content.Context
 import cash.z.ecc.android.sdk.internal.model.CombinedWalletClientImpl
-import cash.z.ecc.android.sdk.internal.model.TorClient
+import cash.z.ecc.android.sdk.internal.model.LazyTorClient
 import co.electriccoin.lightwallet.client.CombinedWalletClient
 import co.electriccoin.lightwallet.client.LightWalletClient
 import co.electriccoin.lightwallet.client.PartialTorWalletClient
@@ -14,28 +14,22 @@ import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
  */
 class WalletClientFactory(
     private val context: Context,
-    private val torClient: TorClient?
+    private val torClient: LazyTorClient?
 ) {
     /**
      * Creates a [CombinedWalletClientImpl] which will leverage Tor for lightwalletd connection for functions specified
      * in [PartialTorWalletClient].
      * Other functions specified in [WalletClient] will use regular lightwalletd connection using [LightWalletClient].
      *
+     * The base Tor client (and its isolated client used here) is not created until the first Tor-mode
+     * request is actually made, keeping Tor runtime creation off the cold-start path.
+     *
      * @return an instance of [WalletClient] for [endpoint]
      */
-    @Suppress("TooGenericExceptionCaught")
-    suspend fun create(endpoint: LightWalletEndpoint): CombinedWalletClient {
-        val torClient =
-            try {
-                torClient?.isolatedTorClient()
-            } catch (_: Exception) {
-                null
-            }
-
-        return CombinedWalletClientImpl.new(
+    suspend fun create(endpoint: LightWalletEndpoint): CombinedWalletClient =
+        CombinedWalletClientImpl.new(
             endpoint = endpoint,
             lightWalletClient = LightWalletClient.new(context, endpoint),
-            torClient = torClient,
+            torClientProvider = torClient?.let { holder -> { holder.getOrCreate().isolatedTorClient() } },
         )
-    }
 }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/util/WalletClientFactory.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/util/WalletClientFactory.kt
@@ -30,6 +30,6 @@ class WalletClientFactory(
         CombinedWalletClientImpl.new(
             endpoint = endpoint,
             lightWalletClient = LightWalletClient.new(context, endpoint),
-            torClientProvider = torClient?.let { holder -> { holder.getOrCreate().isolatedTorClient() } },
+            isolatedTorClient = torClient?.let { holder -> LazyTorClient { holder.getOrCreate().isolatedTorClient() } },
         )
 }

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/SynchronizerWalletInitializationTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/SynchronizerWalletInitializationTest.kt
@@ -43,7 +43,7 @@ class SynchronizerWalletInitializationTest {
 
             val result =
                 resolveWalletInitializationState(
-                    downloader = downloader(walletClient),
+                    downloaderProvider = { downloader(walletClient) },
                     fallbackTreeState = treeState(height = fallbackTreeStateHeight.value),
                     sdkFlags = sdkFlags,
                     walletInitMode = WalletInitMode.NewWallet
@@ -67,7 +67,7 @@ class SynchronizerWalletInitializationTest {
 
             val result =
                 resolveWalletInitializationState(
-                    downloader = downloader(walletClient),
+                    downloaderProvider = { downloader(walletClient) },
                     fallbackTreeState = fallbackTreeState,
                     sdkFlags = sdkFlags,
                     walletInitMode = WalletInitMode.NewWallet
@@ -93,7 +93,7 @@ class SynchronizerWalletInitializationTest {
 
             val result =
                 resolveWalletInitializationState(
-                    downloader = downloader(walletClient),
+                    downloaderProvider = { downloader(walletClient) },
                     fallbackTreeState = fallbackTreeState,
                     sdkFlags = sdkFlags,
                     walletInitMode = WalletInitMode.NewWallet,
@@ -120,7 +120,7 @@ class SynchronizerWalletInitializationTest {
 
             val result =
                 resolveWalletInitializationState(
-                    downloader = downloader(walletClient),
+                    downloaderProvider = { downloader(walletClient) },
                     fallbackTreeState = fallbackTreeState,
                     sdkFlags = sdkFlags,
                     walletInitMode = WalletInitMode.NewWallet
@@ -148,7 +148,7 @@ class SynchronizerWalletInitializationTest {
 
             val result =
                 resolveWalletInitializationState(
-                    downloader = downloader(walletClient),
+                    downloaderProvider = { downloader(walletClient) },
                     fallbackTreeState = fallbackTreeState,
                     sdkFlags = sdkFlags,
                     walletInitMode = WalletInitMode.NewWallet,


### PR DESCRIPTION
This PR contains the SDK-side performance work for [MOB-1403](https://linear.app/electric-coin-company/issue/MOB-1403) (cold start performance).

## Changes

- **Fully lazy Tor client** — `TorClient.new` (~1s) no longer blocks synchronizer cold start when the exchange-rate feature is unused; covered by the new `LazyTorClientTest`
- **Parallelized `Synchronizer.new` construction** and SDK native library preload support
- **Batched transaction outputs/recipients** — new `getTransactionOutputs()` / `getRecipients()` batch APIs backed by batched queries in `TxOutputsView` / `DbDerivedDataRepository`
- **Cached `txIdString`** on `TransactionId`
- Enabled parallel Gradle sync (`org.gradle.tooling.parallel=true`)

## Companion PR

App-side changes consuming these APIs: https://github.com/zodl-inc/zodl-android/pull/2357 (depends on this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)