### PR TITLE
CI: run the Rust unit tests instead of only compiling them

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -160,7 +160,7 @@ jobs:
         timeout-minutes: 30
         uses: ./.github/actions/setup
       - name: Android Lint
-        timeout-minutes: 25
+        timeout-minutes: 45
         env:
           # Disable minify, since it makes lint run faster
           ORG_GRADLE_PROJECT_IS_MINIFY_APP_ENABLED: false

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -183,6 +183,25 @@ jobs:
           name: Android Lint static analysis results
           path: ~/artifacts
 
+  test_rust_unit:
+    needs: validate_gradle_wrapper
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        timeout-minutes: 1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: Setup
+        id: setup
+        timeout-minutes: 30
+        uses: ./.github/actions/setup
+      - name: Test
+        timeout-minutes: 15
+        working-directory: backend-lib
+        run: |
+          cargo test --all-features
+
   test_android_modules_unit:
     needs: [ validate_gradle_wrapper ]
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -275,9 +275,11 @@ jobs:
           name: Test Android modules with FTL results
           path: ~/artifacts
 
-  test_android_modules_wtf:
-    if: needs.check_emulator_wtf_secrets.outputs.has-secrets == 'true'
-    needs: [ validate_gradle_wrapper, check_emulator_wtf_secrets ]
+  # Runs the Android instrumentation suites on a Gradle Managed Device: a
+  # hardware-accelerated emulator booted inside the runner. This replaces the
+  # former emulator.wtf cloud job and depends on no external test service.
+  test_android_modules_emulator:
+    needs: [validate_gradle_wrapper]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -285,16 +287,51 @@ jobs:
       - name: Checkout
         timeout-minutes: 1
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      # ubuntu-latest exposes /dev/kvm, but the default udev rules do not grant
+      # the runner user access to it. This rule opens it so the managed-device
+      # emulator can use KVM acceleration instead of falling back to software.
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Setup
         id: setup
         timeout-minutes: 30
         uses: ./.github/actions/setup
-      - name: Build and test
-        timeout-minutes: 30
-        env:
-          ORG_GRADLE_PROJECT_ZCASH_EMULATOR_WTF_API_KEY: ${{ secrets.EMULATOR_WTF_API_KEY }}
+      # The hosted runner's Android SDK does not include the emulator package,
+      # which a Gradle Managed Device requires. AGP auto-installs the system
+      # image but not the emulator, so without this the pixel2MinSetup task
+      # fails at VersionedSdkLoader.getEmulatorDirectoryProvider().get() with
+      # "Cannot query the value of this property because it has no value
+      # available". Install it explicitly.
+      - name: Install Android emulator
+        timeout-minutes: 5
         run: |
-          ./gradlew testDebugWithEmulatorWtf
+          yes | "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" "emulator"
+      # pixel2Min is the Gradle Managed Device defined in
+      # zcash-sdk.android-conventions.gradle.kts (Pixel 2, API ANDROID_MIN_SDK_VERSION).
+      # Scoped to the same four modules the former emulator.wtf job covered;
+      # the unqualified task would also pull in darkside-test-lib (needs a live
+      # darkside server) and the demo-app modules. maxConcurrentDevices=1 keeps a
+      # single emulator booted at a time so the runner is not overwhelmed by four
+      # parallel emulators; in-runner emulators run serially, hence the higher
+      # timeout than the former cloud job.
+      # emulator.gpu=swiftshader_indirect forces software rendering. The hosted
+      # runner is headless, and AGP's default '-gpu auto-no-window' intermittently
+      # falls back to 'auto', which needs a real GPU and fails to boot the
+      # emulator (EmulatorStartFailedException during snapshot creation).
+      - name: Build and test
+        timeout-minutes: 45
+        run: |
+          ./gradlew \
+            :sdk-lib:pixel2MinDebugAndroidTest \
+            :lightwallet-client-lib:pixel2MinDebugAndroidTest \
+            :sdk-incubator-lib:pixel2MinDebugAndroidTest \
+            :backend-lib:pixel2MinDebugAndroidTest \
+            -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=1 \
+            -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect
       - name: Collect Artifacts
         if: ${{ always() }}
         timeout-minutes: 1
@@ -304,13 +341,19 @@ jobs:
         run: |
           mkdir ${ARTIFACTS_DIR_PATH}
 
-          zip -r ${TEST_RESULTS_ZIP_PATH} . -i \*/build/test-results/\*
+          # Managed-device runs write results/reports under build/outputs and
+          # build/reports/androidTests, not build/test-results, so include those
+          # too to make failures inspectable from the artifact.
+          zip -r ${TEST_RESULTS_ZIP_PATH} . \
+            -i \*/build/test-results/\* \
+            \*/build/outputs/androidTest-results/\* \
+            \*/build/reports/androidTests/\*
       - name: Upload Artifacts
         if: ${{ always() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         timeout-minutes: 1
         with:
-          name: Test Android modules with WTF results
+          name: Test Android modules with emulator results
           path: ~/artifacts
 
   demo_app_release_build:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,11 +13,12 @@ jobs that are runnable on a dev machine:
 
 ```bash
 ./scripts/ci-local.sh fast     # detekt + ktlint (~30s) -- run this first
-./scripts/ci-local.sh quick    # fast + unit tests (~5m)
+./scripts/ci-local.sh quick    # fast + rust + unit tests (~5m)
 ./scripts/ci-local.sh full     # everything, including androidTest (~15-30m)
 
 # Or a single stage when iterating:
 ./scripts/ci-local.sh detekt
+./scripts/ci-local.sh rust
 ./scripts/ci-local.sh lint
 ./scripts/ci-local.sh demoapp
 ```
@@ -25,6 +26,9 @@ jobs that are runnable on a dev machine:
 `quick` is what actually compiles the Kotlin: `fast` only runs static
 analysis, so it will pass on code that does not compile. Run at least `quick`
 after any change to a Kotlin source file.
+
+The `rust` stage runs `cargo test` against `backend-lib`. The first invocation
+builds around 640 crates and is slow; later runs are incremental.
 
 ### Environment requirements
 
@@ -64,6 +68,7 @@ after any change to a Kotlin source file.
 |---|---|
 | Style / rename / doc | `fast` |
 | Logic or refactor | `quick` |
+| Rust-only change under `backend-lib/src/main/rust` | `fast` then `rust` |
 | New public API, new module, JNI/Rust boundary | `full` |
 | Demo-app only | `fast` then `demoapp` |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ jobs that are runnable on a dev machine:
 
 ```bash
 ./scripts/ci-local.sh fast     # detekt + ktlint (~30s) -- run this first
-./scripts/ci-local.sh quick    # fast + unit tests (~2-5m)
+./scripts/ci-local.sh quick    # fast + unit tests (~5m)
 ./scripts/ci-local.sh full     # everything, including androidTest (~15-30m)
 
 # Or a single stage when iterating:
@@ -22,12 +22,29 @@ jobs that are runnable on a dev machine:
 ./scripts/ci-local.sh demoapp
 ```
 
+`quick` is what actually compiles the Kotlin: `fast` only runs static
+analysis, so it will pass on code that does not compile. Run at least `quick`
+after any change to a Kotlin source file.
+
 ### Environment requirements
 
 - **JDK 17 or 21.** Android Gradle Plugin 8.13.x does not support JDK 25+.
   If your default `java -version` reports 25 or newer, install JDK 21 via
   Homebrew (`brew install openjdk@21`) or SDKMAN! and set `JAVA_HOME` before
   running the script.
+
+  On a machine where `java` is not on `PATH` at all (common on macOS, where
+  the JDK is installed but not linked), export it for the command:
+
+  ```bash
+  export JAVA_HOME=/opt/homebrew/opt/openjdk@21          # brew install openjdk@21
+  export PATH="$JAVA_HOME/bin:$PATH"
+  export ANDROID_HOME="$HOME/Library/Android/sdk"
+  ./scripts/ci-local.sh quick
+  ```
+
+  Android Studio's bundled runtime works too, if you prefer not to install a
+  second JDK: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`.
 - **Android SDK** at `$ANDROID_HOME` or `~/Library/Android/sdk`.
 - For the `androidtest` stage on Apple Silicon, the `aosp` SDK-36 Pixel 2
   system image is downloaded on first run (~1.5 GB).
@@ -92,6 +109,16 @@ prefix is acceptable (`fix: ...`, `chore: ...`). Keep the first line under
 - The SDK and related libraries are Kotlin + Rust. Changes that cross the
   JNI boundary (`backend-lib/src/main/rust/*` and the Kotlin `Jni*` model
   classes) require updating both sides in lockstep.
+- The Rust backend is fastest to check on its own, without Gradle or a JDK:
+
+  ```bash
+  cd backend-lib && cargo check --lib && cargo fmt --check
+  ```
+
+  Note this only proves the Rust compiles. A JNI signature mismatch between
+  Rust and Kotlin is a *runtime* crash, not a compile error on either side,
+  so a Rust-only change that touches a `Java_*` export or an
+  `env.new_object` type signature still needs `./scripts/ci-local.sh quick`.
 - Detekt and ktlint are strict; treat their output as blocking. `detektAll`
   catches `MaxLineLength`, `ReturnCount`, `LongParameterList`, and similar
   issues that won't be apparent from a plain `./gradlew build`.

--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -1593,6 +1593,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "749cff877dc1af878a0b31a41dd221a753634401ea0ef2f87b62d3171522485a"
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2570,6 +2582,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "ndk-sys"
 version = "0.5.0+25.2.9519653"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2792,9 +2813,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54f8d29bfb1e76a9d4e868a1a08cce2e57dd2bdc66232982822ad3114b91ab3"
+checksum = "cca2ede6a4a77bd729eed3be9303d98a08b217edc85190dcf4dbe004086d5a65"
 dependencies = [
  "aes",
  "bitvec",
@@ -2957,9 +2978,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pczt"
-version = "0.7.0"
+version = "0.8.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4712bd8688e1d1aa0eb0e78dc5c846bc2d70dcd1de544ecf053516df174c4fcd"
+checksum = "e8fb3f5ea64b891d40cff8182aca0bd7d063c9460920546fe7066860b781de91"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -4102,9 +4123,9 @@ dependencies = [
 
 [[package]]
 name = "shardtree"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "359e552886ae54d1642091645980d83f7db465fd9b5b0248e3680713c1773388"
+checksum = "9cc96e9b6b1c307749019e7e2cf9dd29881b1928ce6866e3702a02a4800aa345"
 dependencies = [
  "bitflags",
  "either",
@@ -4243,6 +4264,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -6652,7 +6676,7 @@ dependencies = [
 
 [[package]]
 name = "zcash-android-wallet-sdk"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -6698,9 +6722,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58342d0aaa8e2fa98849636f52800ac4bf020574c944c974742fc933db58cac2"
+checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
 dependencies = [
  "bech32",
  "bs58",
@@ -6712,9 +6736,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.23.0"
+version = "0.24.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04583f0945d5ff80eee80c1844fb0af8b7cc46a0ac26d5e12c4ccd474bec0f03"
+checksum = "eb0d78dcc345c36086112886223f6f1d6d224802808f15ac4f3ef144677029a1"
 dependencies = [
  "arti-client",
  "base64",
@@ -6723,9 +6747,9 @@ dependencies = [
  "bls12_381",
  "bs58",
  "byteorder",
- "crossbeam-channel",
  "document-features",
  "dynosaur",
+ "flume",
  "fs-mistrust",
  "futures-util",
  "getset",
@@ -6755,7 +6779,6 @@ dependencies = [
  "shardtree",
  "subtle",
  "time",
- "time-core",
  "tokio",
  "tokio-rustls",
  "tonic",
@@ -6781,9 +6804,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.21.0"
+version = "0.22.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b99abb0e534b72705f49cb43d5f1a448844b49b9c48590f87888cb84ce6d29"
+checksum = "9aa9b039e66a3b79f2de45ebf86cd82545232d332631a84f7c017ae21572b8de"
 dependencies = [
  "bip32",
  "bitflags",
@@ -6839,9 +6862,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbcdfbb5c8edb247439d72a397abaae9b7dd14a1c070e7e4fc3536924f9065f"
+checksum = "36391ebfce7df2510c6564f79e608ed93f1c0692c6464e2397b248e06dae3912"
 dependencies = [
  "bech32",
  "bip32",
@@ -6869,9 +6892,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_note_encryption"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77efec759c3798b6e4d829fcc762070d9b229b0f13338c40bf993b7b609c2272"
+checksum = "e1cb1b9170c94370e3d66c5cc0877661db743337588b64de7711239eed462198"
 dependencies = [
  "chacha20",
  "chacha20poly1305",
@@ -6882,9 +6905,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c69e07f5eb3f682a6467b4b08ee4956f1acd1e886d70b21c4766953b3a1beba2"
+checksum = "bdbeccc05bfe63b6dee9e989c6ff5027421741562a4853c36504dd621f6a81b1"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6913,9 +6936,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de6b0ca82e08a9d38b1121f87c5b180b5feac19fecba074cb582882210d2371"
+checksum = "b91fb0b420fb66a765f1fa92ab7a6b631aa54c08415415ef6185256826e74fbd"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6935,9 +6958,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bec496a0bd62dae98c4b26f51c5dab112d0c5350bbc2ccfdfd05bb3454f714d"
+checksum = "2973d210e74ebd81adc50828fbbb284ab6aaa099308097c42c47dc63cf3420fc"
 dependencies = [
  "corez",
  "document-features",
@@ -6974,9 +6997,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15df1908b428d4edeb7c7caae5692e05e2e92e5c38007a40b20ac098efdffd96"
+checksum = "72e0f8c142bed366ed5886dcfa8772ec90b5420cc127e6cdb76b6744c53a287b"
 dependencies = [
  "bip32",
  "bs58",
@@ -7068,9 +7091,9 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.8.0"
+version = "0.9.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fef061351aa99792deb8f62b00426863a317ca2cb124c9de85550e3ef0f0f2f"
+checksum = "cb464491970d9b61889e4f2b7b00fb9f471a33692e5c0de3122fdc575d8067ab"
 dependencies = [
  "base64",
  "nom",

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -12,12 +12,12 @@ rust-version = "1.92"
 
 [dependencies]
 # Zcash dependencies
-orchard = "0.14"
-pczt = { version = "0.7", features = ["prover", "orchard", "sapling"] }
+orchard = "0.15"
+pczt = { version = "0.8.0-rc.1", features = ["prover", "orchard", "sapling"] }
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
-transparent = { package = "zcash_transparent", version = "0.8", default-features = false }
-zcash_address = "0.12"
-zcash_client_backend = { version = "0.23", features = [
+transparent = { package = "zcash_transparent", version = "0.9", default-features = false }
+zcash_address = "0.13"
+zcash_client_backend = { version = "0.24.0-rc.1", features = [
     "orchard",
     "lightwalletd-tonic-tls-webpki-roots",
     "tor",
@@ -25,11 +25,11 @@ zcash_client_backend = { version = "0.23", features = [
     "unstable",
     "pczt",
 ] }
-zcash_client_sqlite = { version = "0.21", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
+zcash_client_sqlite = { version = "0.22.0-rc.1", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
 zcash_note_encryption = "0.4.1"
-zcash_primitives = "0.28"
-zcash_proofs = "0.28"
-zcash_protocol = "0.9"
+zcash_primitives = "0.29"
+zcash_proofs = "0.29"
+zcash_protocol = "0.10"
 zcash_script = "0.4"
 zip32 = "0.2"
 eip681 = "0.1.0"

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/Backend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/Backend.kt
@@ -262,11 +262,14 @@ interface Backend {
      * @throws RuntimeException as a common indicator of the operation failure
      */
     @Throws(RuntimeException::class)
+    @Suppress("LongParameterList")
     suspend fun putSubtreeRoots(
         saplingStartIndex: Long,
         saplingRoots: List<JniSubtreeRoot>,
         orchardStartIndex: Long,
         orchardRoots: List<JniSubtreeRoot>,
+        ironwoodStartIndex: Long,
+        ironwoodRoots: List<JniSubtreeRoot>,
     )
 
     /**

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/FakeRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/FakeRustBackend.kt
@@ -38,6 +38,8 @@ class FakeRustBackend(
         saplingRoots: List<JniSubtreeRoot>,
         orchardStartIndex: Long,
         orchardRoots: List<JniSubtreeRoot>,
+        ironwoodStartIndex: Long,
+        ironwoodRoots: List<JniSubtreeRoot>,
     ) {
         error("Intentionally not implemented yet.")
     }

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/RustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/RustBackend.kt
@@ -287,6 +287,8 @@ class RustBackend private constructor(
         saplingRoots: List<JniSubtreeRoot>,
         orchardStartIndex: Long,
         orchardRoots: List<JniSubtreeRoot>,
+        ironwoodStartIndex: Long,
+        ironwoodRoots: List<JniSubtreeRoot>,
     ) = withContext(SdkDispatchers.DATABASE_IO) {
         putSubtreeRoots(
             dataDbFile.absolutePath,
@@ -294,6 +296,8 @@ class RustBackend private constructor(
             saplingRoots.toTypedArray(),
             orchardStartIndex,
             orchardRoots.toTypedArray(),
+            ironwoodStartIndex,
+            ironwoodRoots.toTypedArray(),
             networkId = networkId
         )
     }
@@ -781,6 +785,8 @@ class RustBackend private constructor(
             saplingRoots: Array<JniSubtreeRoot>,
             orchardStartIndex: Long,
             orchardRoots: Array<JniSubtreeRoot>,
+            ironwoodStartIndex: Long,
+            ironwoodRoots: Array<JniSubtreeRoot>,
             networkId: Int
         )
 

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/JniAccountBalance.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/JniAccountBalance.kt
@@ -19,6 +19,12 @@ import cash.z.ecc.android.sdk.internal.jni.JNI_ACCOUNT_UUID_BYTES_SIZE
  * @param orchardValuePending The value in the account of all remaining received Orchard
  *        notes that either do not have sufficient confirmations to be spendable, or for
  *        which witnesses cannot yet be constructed without additional scanning.
+ * @param ironwoodVerifiedBalance The verified account balance in the Ironwood pool.
+ * @param ironwoodChangePending The value in the account of Ironwood change notes that do
+ *        not yet have sufficient confirmations to be spendable.
+ * @param ironwoodValuePending The value in the account of all remaining received Ironwood
+ *        notes that either do not have sufficient confirmations to be spendable, or for
+ *        which witnesses cannot yet be constructed without additional scanning.
  * @param unshieldedBalance The total account balance in the transparent pool,
  *        including unconfirmed funds, that must be shielded before use.
  * @throws IllegalArgumentException if the values are inconsistent.
@@ -33,6 +39,9 @@ class JniAccountBalance(
     val orchardVerifiedBalance: Long,
     val orchardChangePending: Long,
     val orchardValuePending: Long,
+    val ironwoodVerifiedBalance: Long,
+    val ironwoodChangePending: Long,
+    val ironwoodValuePending: Long,
     val unshieldedBalance: Long,
 ) {
     init {
@@ -56,6 +65,15 @@ class JniAccountBalance(
         }
         require(orchardValuePending >= MIN_INCLUSIVE) {
             "Orchard value pending $orchardValuePending must by equal or above $MIN_INCLUSIVE"
+        }
+        require(ironwoodVerifiedBalance >= MIN_INCLUSIVE) {
+            "Ironwood verified balance $ironwoodVerifiedBalance must by equal or above $MIN_INCLUSIVE"
+        }
+        require(ironwoodChangePending >= MIN_INCLUSIVE) {
+            "Ironwood change pending $ironwoodChangePending must by equal or above $MIN_INCLUSIVE"
+        }
+        require(ironwoodValuePending >= MIN_INCLUSIVE) {
+            "Ironwood value pending $ironwoodValuePending must by equal or above $MIN_INCLUSIVE"
         }
         require(unshieldedBalance >= MIN_INCLUSIVE) {
             "Unshielded balance $unshieldedBalance must by equal or above $MIN_INCLUSIVE"

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/JniWalletSummary.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/JniWalletSummary.kt
@@ -20,6 +20,8 @@ import cash.z.ecc.android.sdk.internal.ext.isInUIntRange
  *        the next range of subtree roots passed to `Backend.putSaplingSubtreeRoots`.
  * @param nextOrchardSubtreeIndex the Orchard subtree index that should start
  *        the next range of subtree roots passed to `Backend.putOrchardSubtreeRoots`.
+ * @param nextIronwoodSubtreeIndex the Ironwood subtree index that should start
+ *        the next range of subtree roots passed to `Backend.putSubtreeRoots`.
  * @throws IllegalArgumentException unless (progressNumerator is nonnegative,
  *         progressDenominator is positive, and the represented ratio is in the
  *         range 0.0 to 1.0 inclusive).
@@ -36,6 +38,7 @@ class JniWalletSummary(
     val recoveryProgressDenominator: Long?,
     val nextSaplingSubtreeIndex: Long,
     val nextOrchardSubtreeIndex: Long,
+    val nextIronwoodSubtreeIndex: Long,
 ) {
     init {
         require(chainTipHeight.isInUIntRange()) {
@@ -88,6 +91,9 @@ class JniWalletSummary(
         }
         require(nextOrchardSubtreeIndex.isInUIntRange()) {
             "Height $nextOrchardSubtreeIndex is outside of allowed UInt range"
+        }
+        require(nextIronwoodSubtreeIndex.isInUIntRange()) {
+            "Height $nextIronwoodSubtreeIndex is outside of allowed UInt range"
         }
     }
 }

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/ZcashProtocol.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/ZcashProtocol.kt
@@ -13,18 +13,22 @@ enum class ZcashProtocol {
     },
     ORCHARD {
         override val poolCode = 3
+    },
+    IRONWOOD {
+        override val poolCode = 4
     };
 
     abstract val poolCode: Int
 
-    fun isShielded() = this == SAPLING || this == ORCHARD
+    fun isShielded() = this == SAPLING || this == ORCHARD || this == IRONWOOD
 
     companion object {
         fun validate(poolTypeCode: Int): Boolean =
             when (poolTypeCode) {
                 TRANSPARENT.poolCode,
                 SAPLING.poolCode,
-                ORCHARD.poolCode -> true
+                ORCHARD.poolCode,
+                IRONWOOD.poolCode -> true
 
                 else -> false
             }
@@ -34,6 +38,7 @@ enum class ZcashProtocol {
                 TRANSPARENT.poolCode -> TRANSPARENT
                 SAPLING.poolCode -> SAPLING
                 ORCHARD.poolCode -> ORCHARD
+                IRONWOOD.poolCode -> IRONWOOD
                 else -> error("Unsupported pool type: $poolCode")
             }
     }

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -1430,6 +1430,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_putSubtre
     sapling_roots: JObjectArray<'local>,
     orchard_start_index: jlong,
     orchard_roots: JObjectArray<'local>,
+    ironwood_start_index: jlong,
+    ironwood_roots: JObjectArray<'local>,
     network_id: jint,
 ) {
     let res = catch_unwind(&mut env, |env| {
@@ -1470,6 +1472,15 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_putSubtre
             orchard::tree::MerkleHashOrchard::read(n)
         })?;
 
+        let ironwood_start_index = if ironwood_start_index >= 0 {
+            ironwood_start_index as u64
+        } else {
+            return Err(anyhow!("Ironwood start index must be nonnegative."));
+        };
+        let ironwood_roots = parse_roots(env, ironwood_roots, |n| {
+            orchard::tree::MerkleHashOrchard::read(n)
+        })?;
+
         db_data
             .put_sapling_subtree_roots(sapling_start_index, &sapling_roots)
             .map_err(|e| anyhow!("Error while storing Sapling subtree roots: {}", e))?;
@@ -1477,6 +1488,10 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_putSubtre
         db_data
             .put_orchard_subtree_roots(orchard_start_index, &orchard_roots)
             .map_err(|e| anyhow!("Error while storing Orchard subtree roots: {}", e))?;
+
+        db_data
+            .put_ironwood_subtree_roots(ironwood_start_index, &ironwood_roots)
+            .map_err(|e| anyhow!("Error while storing Ironwood subtree roots: {}", e))?;
 
         Ok(())
     });
@@ -1579,11 +1594,17 @@ fn encode_account_balance<'a>(
     let orchard_value_pending =
         ZatBalance::from(balance.orchard_balance().value_pending_spendability());
 
+    let ironwood_verified_balance = ZatBalance::from(balance.ironwood_balance().spendable_value());
+    let ironwood_change_pending =
+        ZatBalance::from(balance.ironwood_balance().change_pending_confirmation());
+    let ironwood_value_pending =
+        ZatBalance::from(balance.ironwood_balance().value_pending_spendability());
+
     let unshielded = ZatBalance::from(balance.unshielded_balance().total());
 
     env.new_object(
         JNI_ACCOUNT_BALANCE,
-        "([BJJJJJJJ)V",
+        "([BJJJJJJJJJJ)V",
         &[
             (&env.byte_array_from_slice(account_uuid.expose_uuid().as_bytes())?).into(),
             JValue::Long(sapling_verified_balance.into()),
@@ -1592,6 +1613,9 @@ fn encode_account_balance<'a>(
             JValue::Long(orchard_verified_balance.into()),
             JValue::Long(orchard_change_pending.into()),
             JValue::Long(orchard_value_pending.into()),
+            JValue::Long(ironwood_verified_balance.into()),
+            JValue::Long(ironwood_change_pending.into()),
+            JValue::Long(ironwood_value_pending.into()),
             JValue::Long(unshielded.into()),
         ],
     )
@@ -1637,7 +1661,7 @@ fn encode_wallet_summary<'a>(
     Ok(env.new_object(
         "cash/z/ecc/android/sdk/internal/model/JniWalletSummary",
         format!(
-            "([L{};JJJJLjava/lang/Long;Ljava/lang/Long;JJ)V",
+            "([L{};JJJJLjava/lang/Long;Ljava/lang/Long;JJJ)V",
             JNI_ACCOUNT_BALANCE
         ),
         &[
@@ -1650,6 +1674,7 @@ fn encode_wallet_summary<'a>(
             JValue::Object(&recovery_progress_denominator),
             JValue::Long(summary.next_sapling_subtree_index() as i64),
             JValue::Long(summary.next_orchard_subtree_index() as i64),
+            JValue::Long(summary.next_ironwood_subtree_index() as i64),
         ],
     )?)
 }
@@ -3707,6 +3732,7 @@ fn parse_protocol(code: i32) -> anyhow::Result<ShieldedPool> {
     match code {
         2 => Ok(ShieldedPool::Sapling),
         3 => Ok(ShieldedPool::Orchard),
+        4 => Ok(ShieldedPool::Ironwood),
         _ => Err(anyhow!("Shielded protocol not recognized: {code}")),
     }
 }

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -42,16 +42,17 @@ use zcash_address::{
 use zcash_client_backend::{
     address::{Address, UnifiedAddress},
     data_api::{
-        Account, AccountBalance, AccountBirthday, AccountPurpose, BirthdayError, InputSource,
-        OutputStatusFilter, SeedRelevance, TransactionDataRequest, TransactionStatus,
-        TransactionStatusFilter, TransparentKeyOrigin, TransparentOutputFilter,
-        WalletCommitmentTrees, WalletRead, WalletSummary, WalletWrite, Zip32Derivation,
+        Account, AccountBalance, AccountBirthday, AccountPurpose, BirthdayError, CoinbaseFilter,
+        InputSource, OutputStatusFilter, SeedRelevance, TransactionDataRequest, TransactionStatus,
+        TransactionStatusFilter, TransparentKeyOrigin, WalletCommitmentTrees, WalletRead,
+        WalletSummary, WalletWrite, Zip32Derivation,
         chain::{CommitmentTreeRoot, ScanSummary, scan_cached_blocks},
         scanning::{ScanPriority, ScanRange},
         wallet::{
             self, create_pczt_from_proposal, create_proposed_transactions,
             decrypt_and_store_transaction, extract_and_store_transaction_from_pczt,
-            input_selection::GreedyInputSelector, propose_shielding, propose_transfer,
+            input_selection::{GreedyInputSelector, SpendPolicy},
+            propose_shielding, propose_transfer,
         },
     },
     encoding::AddressCodec,
@@ -78,11 +79,11 @@ use zcash_client_sqlite::{
 use zcash_primitives::{
     block::BlockHash,
     merkle_tree::HashSer,
-    transaction::{Transaction, TxId},
+    transaction::{Transaction, TxId, components::orchard::bundle_version_for_branch},
 };
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::{
-    ShieldedProtocol,
+    ShieldedPool,
     consensus::{
         BlockHeight, BranchId, Network,
         Network::{MainNetwork, TestNetwork},
@@ -1118,7 +1119,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_getTotalT
                 &taddr,
                 target,
                 wallet::ConfirmationsPolicy::MIN,
-                TransparentOutputFilter::All,
+                CoinbaseFilter::AllTransparentOutputs,
             )
             .map_err(|e| anyhow!("Error while fetching verified balance: {}", e))?
             .iter()
@@ -1358,7 +1359,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_rewindToH
         let mut db_data = wallet_db(env, network, db_data)?;
 
         let height = BlockHeight::try_from(height)?;
-        let rewind_result = db_data.rewind_to_height(height);
+        let rewind_result = db_data.truncate_to_height(height);
 
         Ok(encode_rewind_result(env, height, rewind_result)?.into_raw())
     });
@@ -1964,6 +1965,9 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_putUtxo<'
                 script_pubkey,
             },
             Some(BlockHeight::from(height as u32)),
+            None,
+            None,
+            None,
         )
         .ok_or_else(|| anyhow!("UTXO is not P2PKH or P2SH"))?;
 
@@ -2050,7 +2054,7 @@ fn zip317_helper<DbT>(
         MultiOutputChangeStrategy::new(
             StandardFeeRule::Zip317,
             change_memo,
-            ShieldedProtocol::Orchard,
+            ShieldedPool::Orchard,
             DustOutputPolicy::default(),
             SplitPolicy::with_min_output_value(
                 NonZeroUsize::new(4).expect("4 is nonzero"),
@@ -2093,6 +2097,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeTr
             &change_strategy,
             request,
             wallet::ConfirmationsPolicy::default(),
+            &SpendPolicy::default(),
             None,
         )
         .map_err(|e| anyhow!("Error creating transaction proposal: {}", e))?;
@@ -2155,6 +2160,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeTr
             &change_strategy,
             request,
             wallet::ConfirmationsPolicy::default(),
+            &SpendPolicy::default(),
             None,
         )
         .map_err(|e| anyhow!("Error creating transaction proposal: {}", e))?;
@@ -2290,7 +2296,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeSh
             &from_addrs,
             account_uuid,
             confirmations_policy,
-            TransparentOutputFilter::All,
+            CoinbaseFilter::AllTransparentOutputs,
         )
         .map_err(|e| anyhow!("Error while shielding transaction: {}", e))?;
 
@@ -2330,7 +2336,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_createPro
 
         let proposal = Proposal::decode(utils::java_bytes_to_rust(env, &proposal)?.as_slice())
             .map_err(|e| anyhow!("Invalid proposal: {}", e))?
-            .try_into_standard_proposal(&db_data)?;
+            .try_into_standard_proposal(&network, &db_data)?;
 
         let txids = create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
             &mut db_data,
@@ -2340,7 +2346,6 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_createPro
             &wallet::SpendingKeys::from_unified_spending_key(usk),
             OvkPolicy::Sender,
             &proposal,
-            None,
         )
         .map_err(|e| anyhow!("Error while creating transactions: {}", e))?;
 
@@ -2379,7 +2384,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_createPcz
 
         let proposal = Proposal::decode(utils::java_bytes_to_rust(env, &proposal)?.as_slice())
             .map_err(|e| anyhow!("Invalid proposal: {}", e))?
-            .try_into_standard_proposal(&db_data)?;
+            .try_into_standard_proposal(&network, &db_data)?;
 
         if proposal.steps().len() == 1 {
             let pczt = create_pczt_from_proposal::<_, _, Infallible, _, Infallible, _>(
@@ -2388,10 +2393,18 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_createPcz
                 account_id,
                 OvkPolicy::Sender,
                 &proposal,
+                None,
+                orchard::builder::BundleType::DEFAULT,
             )
             .map_err(|e| anyhow!("Error creating PCZT from single-step proposal: {}", e))?;
 
-            Ok(utils::rust_bytes_to_java(env, &pczt.serialize())?.into_raw())
+            Ok(utils::rust_bytes_to_java(
+                env,
+                &pczt
+                    .serialize()
+                    .map_err(|e| anyhow!("Failed to serialize PCZT: {:?}", e))?,
+            )?
+            .into_raw())
         } else {
             Err(anyhow!(
                 "Multi-step proposals are not yet supported for PCZT generation."
@@ -2438,7 +2451,13 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_redactPcz
             })
             .finish();
 
-        Ok(utils::rust_bytes_to_java(env, &pczt_with_proofs.serialize())?.into_raw())
+        Ok(utils::rust_bytes_to_java(
+            env,
+            &pczt_with_proofs
+                .serialize()
+                .map_err(|e| anyhow!("Failed to serialize PCZT: {:?}", e))?,
+        )?
+        .into_raw())
     });
     unwrap_exc_or(&mut env, res, ptr::null_mut())
 }
@@ -2485,11 +2504,21 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_addProofs
 
         let pczt = parse_pczt(env, pczt)?;
 
+        // The Orchard circuit version is fixed by the consensus branch under which the
+        // transaction will be mined; derive it from the branch id carried by the PCZT.
+        let orchard_circuit_version = BranchId::try_from(*pczt.global().consensus_branch_id())
+            .ok()
+            .and_then(|branch_id| bundle_version_for_branch(branch_id, orchard::ValuePool::Orchard))
+            .map(|bundle_version| bundle_version.circuit_version());
+
         let mut prover = Prover::new(pczt);
 
         if prover.requires_orchard_proof() {
+            let circuit_version = orchard_circuit_version.ok_or_else(|| {
+                anyhow!("PCZT requires an Orchard proof but its consensus branch does not support Orchard")
+            })?;
             prover = prover
-                .create_orchard_proof(&orchard::circuit::ProvingKey::build())
+                .create_orchard_proof(&orchard::circuit::ProvingKey::build(circuit_version))
                 .map_err(|e| anyhow!("Failed to create Orchard proof for PCZT: {:?}", e))?;
         }
         assert!(!prover.requires_orchard_proof());
@@ -2507,7 +2536,13 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_addProofs
 
         let pczt_with_proofs = prover.finish();
 
-        Ok(utils::rust_bytes_to_java(env, &pczt_with_proofs.serialize())?.into_raw())
+        Ok(utils::rust_bytes_to_java(
+            env,
+            &pczt_with_proofs
+                .serialize()
+                .map_err(|e| anyhow!("Failed to serialize PCZT: {:?}", e))?,
+        )?
+        .into_raw())
     });
     unwrap_exc_or(&mut env, res, ptr::null_mut())
 }
@@ -2553,7 +2588,9 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_extractAn
             &mut db_data,
             pczt,
             Some((&spend_vk, &output_vk)),
-            Some(&orchard::circuit::VerifyingKey::build()),
+            // Passing `None` lets the extractor build the verifying key for the
+            // circuit version fixed by the bundle's own `BundleVersion`.
+            None,
         )
         .map_err(|e| anyhow!("Failed to extract transaction from PCZT: {:?}", e))?;
 
@@ -3666,10 +3703,10 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_model_TorWalletClient_fet
 // Utility functions
 //
 
-fn parse_protocol(code: i32) -> anyhow::Result<ShieldedProtocol> {
+fn parse_protocol(code: i32) -> anyhow::Result<ShieldedPool> {
     match code {
-        2 => Ok(ShieldedProtocol::Sapling),
-        3 => Ok(ShieldedProtocol::Orchard),
+        2 => Ok(ShieldedPool::Sapling),
+        3 => Ok(ShieldedPool::Orchard),
         _ => Err(anyhow!("Shielded protocol not recognized: {code}")),
     }
 }

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -3729,6 +3729,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_model_TorWalletClient_fet
 //
 
 fn parse_protocol(code: i32) -> anyhow::Result<ShieldedPool> {
+    // The codes below must follow zcash_client_sqlite's own pool-type encoding:
+    // https://github.com/zcash/librustzcash/blob/main/zcash_client_sqlite/src/wallet/encoding.rs#L42
     match code {
         2 => Ok(ShieldedPool::Sapling),
         3 => Ok(ShieldedPool::Orchard),

--- a/backend-lib/src/main/rust/tor.rs
+++ b/backend-lib/src/main/rust/tor.rs
@@ -168,13 +168,13 @@ impl LwdConn {
 
     /// Calls the given closure with UTXOS corresponding to the given t-address within the given
     /// block range.
-    pub(crate) fn with_taddress_utxos(
+    pub(crate) fn with_taddress_utxos<AccountId>(
         &mut self,
         params: &impl consensus::Parameters,
         address: TransparentAddress,
         start: Option<BlockHeight>,
         limit: Option<u32>,
-        mut f: impl FnMut(WalletTransparentOutput) -> anyhow::Result<()>,
+        mut f: impl FnMut(WalletTransparentOutput<AccountId>) -> anyhow::Result<()>,
     ) -> anyhow::Result<()> {
         let request = service::GetAddressUtxosArg {
             addresses: vec![address.encode(params)],
@@ -197,6 +197,9 @@ impl LwdConn {
                         Script(script::Code(result.script)),
                     ),
                     Some(BlockHeight::from(u32::try_from(result.height)?)),
+                    None,
+                    None,
+                    None,
                 )
                 .ok_or(anyhow!(
                     "Received UTXO that doesn't correspond to a valid P2PKH or P2SH address"

--- a/backend-lib/src/main/rust/utils/exception.rs
+++ b/backend-lib/src/main/rust/utils/exception.rs
@@ -109,11 +109,19 @@ mod tests {
 
     #[test]
     fn unknown_any() {
-        let error = panic_error(1);
+        let error = panic_any_error(1u32);
         assert_eq!("Unknown error occurred", any_to_string(&error));
     }
 
     fn panic_error<T: fmt::Display + Send + 'static>(val: T) -> Box<dyn Any + Send> {
         panic::catch_unwind(panic::AssertUnwindSafe(|| panic!("{}", val))).unwrap_err()
+    }
+
+    // Panics with `val` itself as the payload. `panic_error` cannot reach
+    // `any_to_string`'s fallback branch: `panic!("{}", val)` formats the value, so the
+    // payload is always a `String` and downcasting succeeds. Only a payload that is
+    // neither `&str`, `String`, nor `Box<dyn Error + Send>` exercises the fallback.
+    fn panic_any_error<T: Any + Send + 'static>(val: T) -> Box<dyn Any + Send> {
+        panic::catch_unwind(panic::AssertUnwindSafe(|| panic::panic_any(val))).unwrap_err()
     }
 }

--- a/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/fixture/JniAccountBalanceFixture.kt
+++ b/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/fixture/JniAccountBalanceFixture.kt
@@ -14,6 +14,9 @@ object JniAccountBalanceFixture {
     const val ORCHARD_VERIFIED_BALANCE: Long = 0L
     const val ORCHARD_CHANGE_PENDING: Long = 0L
     const val ORCHARD_VALUE_PENDING: Long = 0L
+    const val IRONWOOD_VERIFIED_BALANCE: Long = 0L
+    const val IRONWOOD_CHANGE_PENDING: Long = 0L
+    const val IRONWOOD_VALUE_PENDING: Long = 0L
     const val UNSHIELDED_BALANCE: Long = 0L
 
     @Suppress("LongParameterList")
@@ -25,6 +28,9 @@ object JniAccountBalanceFixture {
         orchardVerifiedBalance: Long = ORCHARD_VERIFIED_BALANCE,
         orchardChangePending: Long = ORCHARD_CHANGE_PENDING,
         orchardValuePending: Long = ORCHARD_VALUE_PENDING,
+        ironwoodVerifiedBalance: Long = IRONWOOD_VERIFIED_BALANCE,
+        ironwoodChangePending: Long = IRONWOOD_CHANGE_PENDING,
+        ironwoodValuePending: Long = IRONWOOD_VALUE_PENDING,
         unshieldedBalance: Long = UNSHIELDED_BALANCE,
     ) = JniAccountBalance(
         accountUuid = accountUuid,
@@ -34,6 +40,9 @@ object JniAccountBalanceFixture {
         orchardVerifiedBalance = orchardVerifiedBalance,
         orchardChangePending = orchardChangePending,
         orchardValuePending = orchardValuePending,
+        ironwoodVerifiedBalance = ironwoodVerifiedBalance,
+        ironwoodChangePending = ironwoodChangePending,
+        ironwoodValuePending = ironwoodValuePending,
         unshieldedBalance = unshieldedBalance,
     )
 }

--- a/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/fixture/JniAccountBalanceFixture.kt
+++ b/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/fixture/JniAccountBalanceFixture.kt
@@ -8,16 +8,22 @@ import cash.z.ecc.android.sdk.internal.model.JniAccountBalance
  */
 object JniAccountBalanceFixture {
     val ACCOUNT_UUID: ByteArray = "random_uuid_16_b".toByteArray()
-    const val SAPLING_VERIFIED_BALANCE: Long = 0L
-    const val SAPLING_CHANGE_PENDING: Long = 0L
-    const val SAPLING_VALUE_PENDING: Long = 0L
-    const val ORCHARD_VERIFIED_BALANCE: Long = 0L
-    const val ORCHARD_CHANGE_PENDING: Long = 0L
-    const val ORCHARD_VALUE_PENDING: Long = 0L
-    const val IRONWOOD_VERIFIED_BALANCE: Long = 0L
-    const val IRONWOOD_CHANGE_PENDING: Long = 0L
-    const val IRONWOOD_VALUE_PENDING: Long = 0L
-    const val UNSHIELDED_BALANCE: Long = 0L
+
+    // Every value is distinct on purpose. [JniAccountBalance] is constructed from Rust by
+    // `encode_account_balance`, which passes ten positional `jlong`s under a JVM descriptor
+    // (`([BJJJJJJJJJJ)V`) that cannot distinguish them, and the Kotlin side only checks that each
+    // is non-negative. Identical values would let any permutation of the ten fields, such as
+    // reporting Orchard funds as Ironwood, pass every test that uses this fixture.
+    const val SAPLING_VERIFIED_BALANCE: Long = 1L
+    const val SAPLING_CHANGE_PENDING: Long = 2L
+    const val SAPLING_VALUE_PENDING: Long = 3L
+    const val ORCHARD_VERIFIED_BALANCE: Long = 4L
+    const val ORCHARD_CHANGE_PENDING: Long = 5L
+    const val ORCHARD_VALUE_PENDING: Long = 6L
+    const val IRONWOOD_VERIFIED_BALANCE: Long = 7L
+    const val IRONWOOD_CHANGE_PENDING: Long = 8L
+    const val IRONWOOD_VALUE_PENDING: Long = 9L
+    const val UNSHIELDED_BALANCE: Long = 10L
 
     @Suppress("LongParameterList")
     fun new(

--- a/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/model/JniWalletSummaryTest.kt
+++ b/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/model/JniWalletSummaryTest.kt
@@ -17,6 +17,7 @@ class JniWalletSummaryTest {
                 scanProgressDenominator = 100L,
                 nextSaplingSubtreeIndex = 0L,
                 nextOrchardSubtreeIndex = 0L,
+                nextIronwoodSubtreeIndex = 0L,
                 recoveryProgressNumerator = 1L,
                 recoveryProgressDenominator = 100L
             )
@@ -34,6 +35,7 @@ class JniWalletSummaryTest {
                 scanProgressDenominator = 100L,
                 nextSaplingSubtreeIndex = 0L,
                 nextOrchardSubtreeIndex = 0,
+                nextIronwoodSubtreeIndex = 0L,
                 recoveryProgressNumerator = 1L,
                 recoveryProgressDenominator = 100L
             )
@@ -51,6 +53,7 @@ class JniWalletSummaryTest {
                 scanProgressDenominator = 100L,
                 nextSaplingSubtreeIndex = 0L,
                 nextOrchardSubtreeIndex = 0L,
+                nextIronwoodSubtreeIndex = 0L,
                 recoveryProgressNumerator = 1L,
                 recoveryProgressDenominator = 100L
             )
@@ -68,6 +71,7 @@ class JniWalletSummaryTest {
                 scanProgressDenominator = -1L,
                 nextSaplingSubtreeIndex = 0L,
                 nextOrchardSubtreeIndex = 0L,
+                nextIronwoodSubtreeIndex = 0L,
                 recoveryProgressNumerator = 1L,
                 recoveryProgressDenominator = 100L
             )
@@ -85,6 +89,7 @@ class JniWalletSummaryTest {
                 scanProgressDenominator = 1L,
                 nextSaplingSubtreeIndex = 0L,
                 nextOrchardSubtreeIndex = 0L,
+                nextIronwoodSubtreeIndex = 0L,
                 recoveryProgressNumerator = 100L,
                 recoveryProgressDenominator = 1L
             )
@@ -102,6 +107,7 @@ class JniWalletSummaryTest {
                 scanProgressDenominator = 100L,
                 nextSaplingSubtreeIndex = -1L,
                 nextOrchardSubtreeIndex = -1L,
+                nextIronwoodSubtreeIndex = -1L,
                 recoveryProgressNumerator = 1L,
                 recoveryProgressDenominator = 100L
             )

--- a/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/fixture/SingleCompactBlockFixture.kt
+++ b/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/fixture/SingleCompactBlockFixture.kt
@@ -11,7 +11,7 @@ internal object SingleCompactBlockFixture {
     internal const val DEFAULT_TIME = 0
     internal const val DEFAULT_SAPLING_OUTPUT_COUNT = 1u
     internal const val DEFAULT_ORCHARD_OUTPUT_COUNT = 2u
-    internal const val DEFAULT_IRONWOOD_OUTPUT_COUNT = 0u
+    internal const val DEFAULT_IRONWOOD_OUTPUT_COUNT = 3u
     internal const val DEFAULT_HASH = DEFAULT_HEIGHT
     internal const val DEFAULT_BLOCK_BYTES = DEFAULT_HEIGHT
 

--- a/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/fixture/SingleCompactBlockFixture.kt
+++ b/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/fixture/SingleCompactBlockFixture.kt
@@ -11,6 +11,7 @@ internal object SingleCompactBlockFixture {
     internal const val DEFAULT_TIME = 0
     internal const val DEFAULT_SAPLING_OUTPUT_COUNT = 1u
     internal const val DEFAULT_ORCHARD_OUTPUT_COUNT = 2u
+    internal const val DEFAULT_IRONWOOD_OUTPUT_COUNT = 0u
     internal const val DEFAULT_HASH = DEFAULT_HEIGHT
     internal const val DEFAULT_BLOCK_BYTES = DEFAULT_HEIGHT
 
@@ -25,6 +26,7 @@ internal object SingleCompactBlockFixture {
         time: Int = DEFAULT_TIME,
         saplingOutputsCount: UInt = DEFAULT_SAPLING_OUTPUT_COUNT,
         orchardOutputsCount: UInt = DEFAULT_ORCHARD_OUTPUT_COUNT,
+        ironwoodOutputsCount: UInt = DEFAULT_IRONWOOD_OUTPUT_COUNT,
         blockBytes: ByteArray = heightToFixtureData(DEFAULT_BLOCK_BYTES)
     ): CompactBlockUnsafe =
         CompactBlockUnsafe(
@@ -33,6 +35,7 @@ internal object SingleCompactBlockFixture {
             time = time,
             saplingOutputsCount = saplingOutputsCount,
             orchardOutputsCount = orchardOutputsCount,
+            ironwoodOutputsCount = ironwoodOutputsCount,
             compactBlockBytes = blockBytes
         )
 }

--- a/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/model/CompactBlockUnsafe.kt
+++ b/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/model/CompactBlockUnsafe.kt
@@ -36,17 +36,21 @@ class CompactBlockUnsafe(
         }
 
         private fun getOutputsCounts(vtxList: List<CompactFormats.CompactTx>): CompactBlockOutputsCounts {
-            var outputsCount: UInt = 0u
-            var actionsCount: UInt = 0u
+            var saplingOutputsCount: UInt = 0u
+            var orchardActionsCount: UInt = 0u
             var ironwoodActionsCount: UInt = 0u
 
             vtxList.forEach { compactTx ->
-                outputsCount += compactTx.outputsCount.toUInt()
-                actionsCount += compactTx.actionsCount.toUInt()
+                saplingOutputsCount += compactTx.outputsCount.toUInt()
+                orchardActionsCount += compactTx.actionsCount.toUInt()
                 ironwoodActionsCount += compactTx.ironwoodActionsCount.toUInt()
             }
 
-            return CompactBlockOutputsCounts(outputsCount, actionsCount, ironwoodActionsCount)
+            return CompactBlockOutputsCounts(
+                saplingOutputsCount = saplingOutputsCount,
+                orchardActionsCount = orchardActionsCount,
+                ironwoodActionsCount = ironwoodActionsCount
+            )
         }
     }
 

--- a/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/model/CompactBlockUnsafe.kt
+++ b/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/model/CompactBlockUnsafe.kt
@@ -11,12 +11,14 @@ import cash.z.wallet.sdk.internal.rpc.CompactFormats.CompactBlock
  *
  * It is marked as "unsafe" because it is not guaranteed to be valid.
  */
+@Suppress("LongParameterList")
 class CompactBlockUnsafe(
     val height: Long,
     val hash: ByteArray,
     val time: Int,
     val saplingOutputsCount: UInt,
     val orchardOutputsCount: UInt,
+    val ironwoodOutputsCount: UInt,
     val compactBlockBytes: ByteArray
 ) {
     companion object {
@@ -28,6 +30,7 @@ class CompactBlockUnsafe(
                 time = compactBlock.time,
                 saplingOutputsCount = outputCounts.saplingOutputsCount,
                 orchardOutputsCount = outputCounts.orchardActionsCount,
+                ironwoodOutputsCount = outputCounts.ironwoodActionsCount,
                 compactBlockBytes = compactBlock.toByteArray()
             )
         }
@@ -35,18 +38,21 @@ class CompactBlockUnsafe(
         private fun getOutputsCounts(vtxList: List<CompactFormats.CompactTx>): CompactBlockOutputsCounts {
             var outputsCount: UInt = 0u
             var actionsCount: UInt = 0u
+            var ironwoodActionsCount: UInt = 0u
 
             vtxList.forEach { compactTx ->
                 outputsCount += compactTx.outputsCount.toUInt()
                 actionsCount += compactTx.actionsCount.toUInt()
+                ironwoodActionsCount += compactTx.ironwoodActionsCount.toUInt()
             }
 
-            return CompactBlockOutputsCounts(outputsCount, actionsCount)
+            return CompactBlockOutputsCounts(outputsCount, actionsCount, ironwoodActionsCount)
         }
     }
 
     data class CompactBlockOutputsCounts(
         val saplingOutputsCount: UInt,
-        val orchardActionsCount: UInt
+        val orchardActionsCount: UInt,
+        val ironwoodActionsCount: UInt
     )
 }

--- a/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/model/ShieldedProtocolEnum.kt
+++ b/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/model/ShieldedProtocolEnum.kt
@@ -4,11 +4,13 @@ import cash.z.wallet.sdk.internal.rpc.Service.ShieldedProtocol
 
 enum class ShieldedProtocolEnum {
     SAPLING,
-    ORCHARD;
+    ORCHARD,
+    IRONWOOD;
 
     fun toProtocol() =
         when (this) {
             SAPLING -> ShieldedProtocol.sapling
             ORCHARD -> ShieldedProtocol.orchard
+            IRONWOOD -> ShieldedProtocol.ironwood
         }
 }

--- a/lightwallet-client-lib/src/main/proto/compact_formats.proto
+++ b/lightwallet-client-lib/src/main/proto/compact_formats.proto
@@ -50,12 +50,11 @@ message CompactTx {
     //    valueBalanceSapling + valueBalanceOrchard + sum(vPubNew) - sum(vPubOld) - sum(tOut)
     uint32 fee = 3;
 
+    // The field numbers below must follow lightwalletd's generated bindings:
+    // https://github.com/zcash/lightwalletd/blob/master/walletrpc/compact_formats.pb.go
     repeated CompactSaplingSpend spends = 4;
     repeated CompactSaplingOutput outputs = 5;
     repeated CompactOrchardAction actions = 6;
-    // Ironwood (NU6.3) actions. Ironwood is Orchard note-version V3, so these reuse the
-    // CompactOrchardAction shape but ride a separate stream. Field number 9 matches lightwalletd;
-    // fields 7-8 (transparent vin/vout) are intentionally unused here.
     repeated CompactOrchardAction ironwoodActions = 9;
 }
 

--- a/lightwallet-client-lib/src/main/proto/compact_formats.proto
+++ b/lightwallet-client-lib/src/main/proto/compact_formats.proto
@@ -15,6 +15,7 @@ option swift_prefix = "";
 message ChainMetadata {
     uint32 saplingCommitmentTreeSize = 1; // the size of the Sapling note commitment tree as of the end of this block
     uint32 orchardCommitmentTreeSize = 2; // the size of the Orchard note commitment tree as of the end of this block
+    uint32 ironwoodCommitmentTreeSize = 3; // the size of the Ironwood note commitment tree as of the end of this block
 }
 
 // CompactBlock is a packaging of ONLY the data from a block that's needed to:
@@ -52,6 +53,10 @@ message CompactTx {
     repeated CompactSaplingSpend spends = 4;
     repeated CompactSaplingOutput outputs = 5;
     repeated CompactOrchardAction actions = 6;
+    // Ironwood (NU6.3) actions. Ironwood is Orchard note-version V3, so these reuse the
+    // CompactOrchardAction shape but ride a separate stream. Field number 9 matches lightwalletd;
+    // fields 7-8 (transparent vin/vout) are intentionally unused here.
+    repeated CompactOrchardAction ironwoodActions = 9;
 }
 
 // CompactSaplingSpend is a Sapling Spend Description as described in 7.3 of the Zcash

--- a/lightwallet-client-lib/src/main/proto/service.proto
+++ b/lightwallet-client-lib/src/main/proto/service.proto
@@ -117,11 +117,13 @@ message TreeState {
     uint32 time = 4;        // Unix epoch time when the block was mined
     string saplingTree = 5; // sapling commitment tree state
     string orchardTree = 6; // orchard commitment tree state
+    string ironwoodTree = 7; // ironwood commitment tree state
 }
 
 enum ShieldedProtocol {
     sapling = 0;
     orchard = 1;
+    ironwood = 2;
 }
 
 message GetSubtreeRootsArg {

--- a/lightwallet-client-lib/src/main/proto/service.proto
+++ b/lightwallet-client-lib/src/main/proto/service.proto
@@ -111,6 +111,8 @@ message Exclude {
 
 // The TreeState is derived from the Zcash z_gettreestate rpc.
 message TreeState {
+    // The field numbers below must follow lightwalletd's generated bindings:
+    // https://github.com/zcash/lightwalletd/blob/master/walletrpc/service.pb.go
     string network = 1;     // "main" or "test"
     uint64 height = 2;      // block height
     string hash = 3;        // block id

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -10,18 +10,19 @@
 # Stages (fast -> slow):
 #   1. detekt       -> static_analysis_detekt
 #   2. ktlint       -> static_analysis_ktlint
-#   3. unit tests   -> test_android_modules_unit
-#   4. android lint -> static_analysis_android_lint
-#   5. demo app     -> demo_app_release_build
-#   6. androidTest  -> (approximation of) test_android_modules_wtf
+#   3. rust         -> test_rust_unit
+#   4. unit tests   -> test_android_modules_unit
+#   5. android lint -> static_analysis_android_lint
+#   6. demo app     -> demo_app_release_build
+#   7. androidTest  -> (approximation of) test_android_modules_wtf
 #
-# Stage 6 uses a Gradle Managed Device (pixel2Target, SDK 36). It downloads an
+# Stage 7 uses a Gradle Managed Device (pixel2Target, SDK 36). It downloads an
 # AVD on first run (~1.5 GB) and is the slowest stage.
 #
 # Usage:
 #   ./scripts/ci-local.sh             # run every stage in sequence
 #   ./scripts/ci-local.sh fast        # stages 1-2 only (lint + style)
-#   ./scripts/ci-local.sh quick       # stages 1-3 (lint + style + unit tests)
+#   ./scripts/ci-local.sh quick       # stages 1-4 (lint + style + rust + unit tests)
 #   ./scripts/ci-local.sh full        # all stages including androidTest (default)
 #   ./scripts/ci-local.sh detekt      # run one named stage
 #
@@ -29,7 +30,10 @@
 #   - JDK 17 or 21 (Android Gradle Plugin 8.13.x does not support JDK 25+).
 #     Set JAVA_HOME if your default `java` is a different version.
 #   - Android SDK installed at ANDROID_HOME or $HOME/Library/Android/sdk.
-#   - For stage 6, an Apple Silicon Mac needs the `aosp` SDK-36 system image.
+#   - For stage 3, a Rust toolchain matching rust-toolchain.toml (rustup installs
+#     it automatically on first cargo invocation). The first run is slow because
+#     it builds ~640 crates; later runs are incremental.
+#   - For stage 7, an Apple Silicon Mac needs the `aosp` SDK-36 system image.
 
 set -euo pipefail
 
@@ -40,32 +44,42 @@ cd "${REPO_ROOT}"
 GRADLE="./gradlew"
 
 stage_detekt() {
-    echo "==> [1/6] detekt (static_analysis_detekt)"
+    echo "==> [1/7] detekt (static_analysis_detekt)"
     "${GRADLE}" detektAll
 }
 
 stage_ktlint() {
-    echo "==> [2/6] ktlint (static_analysis_ktlint)"
+    echo "==> [2/7] ktlint (static_analysis_ktlint)"
     "${GRADLE}" ktlint
 }
 
+# `--locked` is deliberately absent here and in CI: backend-lib/Cargo.lock
+# currently cannot satisfy Cargo.toml. Add it once the lockfile is reconciled.
+stage_rust() {
+    echo "==> [3/7] rust (test_rust_unit)"
+    (
+        cd "${REPO_ROOT}/backend-lib"
+        cargo test --all-features
+    )
+}
+
 stage_unit() {
-    echo "==> [3/6] unit tests (test_android_modules_unit)"
+    echo "==> [4/7] unit tests (test_android_modules_unit)"
     "${GRADLE}" test
 }
 
 stage_lint() {
-    echo "==> [4/6] android lint (static_analysis_android_lint)"
+    echo "==> [5/7] android lint (static_analysis_android_lint)"
     "${GRADLE}" :sdk-lib:lintRelease :demo-app:lintZcashmainnetRelease
 }
 
 stage_demoapp() {
-    echo "==> [5/6] demo app release build (demo_app_release_build)"
+    echo "==> [6/7] demo app release build (demo_app_release_build)"
     "${GRADLE}" assembleRelease
 }
 
 stage_androidtest() {
-    echo "==> [6/6] android instrumentation tests (test_android_modules_wtf approximation)"
+    echo "==> [7/7] android instrumentation tests (test_android_modules_wtf approximation)"
     echo "    Note: CI uses testDebugWithEmulatorWtf (cloud). Local approximation runs the"
     echo "    same tests on a Gradle managed Pixel 2 (SDK 36) virtual device."
     "${GRADLE}" \
@@ -78,6 +92,7 @@ stage_androidtest() {
 run_all() {
     stage_detekt
     stage_ktlint
+    stage_rust
     stage_unit
     stage_lint
     stage_demoapp
@@ -91,6 +106,7 @@ run_fast() {
 
 run_quick() {
     run_fast
+    stage_rust
     stage_unit
 }
 
@@ -100,6 +116,7 @@ case "${1:-full}" in
     full)         run_all ;;
     detekt)       stage_detekt ;;
     ktlint)       stage_ktlint ;;
+    rust)         stage_rust ;;
     unit)         stage_unit ;;
     lint)         stage_lint ;;
     demoapp)      stage_demoapp ;;

--- a/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/fixture/AccountBalanceFixture.kt
+++ b/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/fixture/AccountBalanceFixture.kt
@@ -9,14 +9,17 @@ object AccountBalanceFixture {
     val TRANSPARENT_BALANCE: Zatoshi = Zatoshi(8)
     val SAPLING_BALANCE: WalletBalance = WalletBalanceFixture.new(Zatoshi(4), Zatoshi(4), Zatoshi(2))
     val ORCHARD_BALANCE: WalletBalance = WalletBalanceFixture.new(Zatoshi(5), Zatoshi(2), Zatoshi(1))
+    val IRONWOOD_BALANCE: WalletBalance = WalletBalanceFixture.new(Zatoshi(0), Zatoshi(0), Zatoshi(0))
 
     fun new(
         orchardBalance: WalletBalance = ORCHARD_BALANCE,
         saplingBalance: WalletBalance = SAPLING_BALANCE,
-        transparentBalance: Zatoshi = TRANSPARENT_BALANCE
+        transparentBalance: Zatoshi = TRANSPARENT_BALANCE,
+        ironwoodBalance: WalletBalance = IRONWOOD_BALANCE
     ) = AccountBalance(
         saplingBalance,
         orchardBalance,
+        ironwoodBalance,
         transparentBalance
     )
 }

--- a/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/fixture/AccountBalanceFixture.kt
+++ b/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/fixture/AccountBalanceFixture.kt
@@ -9,7 +9,7 @@ object AccountBalanceFixture {
     val TRANSPARENT_BALANCE: Zatoshi = Zatoshi(8)
     val SAPLING_BALANCE: WalletBalance = WalletBalanceFixture.new(Zatoshi(4), Zatoshi(4), Zatoshi(2))
     val ORCHARD_BALANCE: WalletBalance = WalletBalanceFixture.new(Zatoshi(5), Zatoshi(2), Zatoshi(1))
-    val IRONWOOD_BALANCE: WalletBalance = WalletBalanceFixture.new(Zatoshi(0), Zatoshi(0), Zatoshi(0))
+    val IRONWOOD_BALANCE: WalletBalance = WalletBalanceFixture.new(Zatoshi(9), Zatoshi(6), Zatoshi(3))
 
     fun new(
         orchardBalance: WalletBalance = ORCHARD_BALANCE,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
@@ -545,6 +545,7 @@ class SdkSynchronizer private constructor(
                     ZcashProtocol.TRANSPARENT -> TransactionPool.TRANSPARENT
                     ZcashProtocol.SAPLING -> TransactionPool.SAPLING
                     ZcashProtocol.ORCHARD -> TransactionPool.ORCHARD
+                    ZcashProtocol.IRONWOOD -> TransactionPool.IRONWOOD
                 }
             )
         }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessor.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessor.kt
@@ -265,7 +265,7 @@ class CompactBlockProcessor internal constructor(
     suspend fun start() {
         val traceScope = TraceScope("CompactBlockProcessor.start")
 
-        val (saplingStartIndex, orchardStartIndex) = refreshWalletSummary()
+        val (saplingStartIndex, orchardStartIndex, ironwoodStartIndex) = refreshWalletSummary()
 
         updateBirthdayHeight()
 
@@ -282,7 +282,7 @@ class CompactBlockProcessor internal constructor(
 
         // Download note commitment tree data from lightwalletd to decide if we communicate with linear
         // or spend-before-sync node.
-        var subTreeRootResult = getSubtreeRoots(downloader, saplingStartIndex, orchardStartIndex)
+        var subTreeRootResult = getSubtreeRoots(downloader, saplingStartIndex, orchardStartIndex, ironwoodStartIndex)
         Twig.info { "Fetched SubTreeRoot result: $subTreeRootResult" }
 
         Twig.debug { "Setup verified. Processor starting..." }
@@ -316,6 +316,10 @@ class CompactBlockProcessor internal constructor(
                                             orchardSubtreeRootList =
                                                 (subTreeRootResult as GetSubtreeRootsResult.SpendBeforeSync)
                                                     .orchardSubtreeRootList,
+                                            ironwoodStartIndex = ironwoodStartIndex,
+                                            ironwoodSubtreeRootList =
+                                                (subTreeRootResult as GetSubtreeRootsResult.SpendBeforeSync)
+                                                    .ironwoodSubtreeRootList,
                                             lastValidHeight = lowerBoundHeight
                                         )
                                 ) {
@@ -353,7 +357,12 @@ class CompactBlockProcessor internal constructor(
                             GetSubtreeRootsResult.FailureConnection -> {
                                 // SubtreeRoot fetching retry
                                 subTreeRootResult =
-                                    getSubtreeRoots(downloader, saplingStartIndex, orchardStartIndex)
+                                    getSubtreeRoots(
+                                        downloader,
+                                        saplingStartIndex,
+                                        orchardStartIndex,
+                                        ironwoodStartIndex
+                                    )
                                 BlockProcessingResult.Reconnecting
                             }
                         }
@@ -880,7 +889,7 @@ class CompactBlockProcessor internal constructor(
      *
      * @return the next subtree index to fetch.
      */
-    internal suspend fun refreshWalletSummary(): Pair<UInt, UInt> {
+    internal suspend fun refreshWalletSummary(): Triple<UInt, UInt, UInt> {
         when (val result = getWalletSummary(backend)) {
             is GetWalletSummaryResult.Success -> {
                 val scanProgress = result.walletSummary.scanProgress
@@ -889,9 +898,10 @@ class CompactBlockProcessor internal constructor(
                 setProgress(scanProgress, recoveryProgress)
                 setFullyScannedHeight(result.walletSummary.fullyScannedHeight)
                 updateAllBalances(result.walletSummary)
-                return Pair(
+                return Triple(
                     result.walletSummary.nextSaplingSubtreeIndex,
-                    result.walletSummary.nextOrchardSubtreeIndex
+                    result.walletSummary.nextOrchardSubtreeIndex,
+                    result.walletSummary.nextIronwoodSubtreeIndex
                 )
             }
 
@@ -899,7 +909,7 @@ class CompactBlockProcessor internal constructor(
                 // Do not report the progress and balances in case of any error, and
                 // tell the caller to fetch all subtree roots.
                 Twig.info { "Progress from rust: no progress information available, progress type: $result" }
-                return Pair(UInt.MIN_VALUE, UInt.MIN_VALUE)
+                return Triple(UInt.MIN_VALUE, UInt.MIN_VALUE, UInt.MIN_VALUE)
             }
         }
     }
@@ -1327,132 +1337,92 @@ class CompactBlockProcessor internal constructor(
     internal suspend fun getSubtreeRoots(
         downloader: CompactBlockDownloader,
         saplingStartIndex: UInt,
-        orchardStartIndex: UInt
+        orchardStartIndex: UInt,
+        ironwoodStartIndex: UInt
     ): GetSubtreeRootsResult {
         Twig.debug { "Fetching SubtreeRoots..." }
         val traceScope = TraceScope("CompactBlockProcessor.getSubtreeRoots")
 
         var result: GetSubtreeRootsResult = GetSubtreeRootsResult.Linear
 
-        var saplingSubtreeRootList: List<SubtreeRoot> = emptyList()
-        var orchardSubtreeRootList: List<SubtreeRoot> = emptyList()
-
-        retryUpToAndContinue(GET_SUBTREE_ROOTS_RETRIES) {
-            downloader
-                .getSubtreeRoots(
-                    saplingStartIndex,
-                    shieldedProtocol = ShieldedProtocolEnum.SAPLING,
-                    maxEntries = UInt.MIN_VALUE,
-                    serviceMode = ServiceMode.Direct
-                ).onEach { response ->
-                    when (response) {
-                        is Response.Success -> {
-                            Twig.verbose {
-                                "Sapling SubtreeRoot fetched successfully: its completingHeight is: ${
-                                    response.result
-                                        .completingBlockHeight
-                                }"
-                            }
-                        }
-
-                        is Response.Failure -> {
-                            val error =
-                                LightWalletException.GetSubtreeRootsException(
-                                    response.code,
-                                    response.description,
-                                    response.toThrowable()
-                                )
-                            if (response is Response.Failure.Server.Unavailable) {
-                                Twig.error {
-                                    "Fetching Sapling SubtreeRoot failed due to server communication problem with" +
-                                        " failure: ${response.toThrowable()}"
+        // Fetching the subtree roots of a pool differs only in which pool is targeted, so the
+        // three per-pool retry loops share one implementation. `result` and `traceScope` are
+        // captured so a failure reports the same way it did when each loop was written out.
+        suspend fun fetchSubtreeRoots(
+            startIndex: UInt,
+            shieldedProtocol: ShieldedProtocolEnum
+        ): List<SubtreeRoot> {
+            var roots: List<SubtreeRoot> = emptyList()
+            retryUpToAndContinue(GET_SUBTREE_ROOTS_RETRIES) {
+                roots =
+                    downloader
+                        .getSubtreeRoots(
+                            startIndex = startIndex,
+                            shieldedProtocol = shieldedProtocol,
+                            maxEntries = UInt.MIN_VALUE,
+                            serviceMode = ServiceMode.Direct
+                        ).onEach { response ->
+                            when (response) {
+                                is Response.Success -> {
+                                    Twig.verbose {
+                                        "$shieldedProtocol SubtreeRoot fetched successfully: its completingHeight" +
+                                            " is: ${response.result.completingBlockHeight}"
+                                    }
                                 }
-                                result = GetSubtreeRootsResult.FailureConnection
-                            } else {
-                                Twig.error {
-                                    "Fetching Sapling SubtreeRoot failed with failure: ${response.toThrowable()}"
+
+                                is Response.Failure -> {
+                                    val error =
+                                        LightWalletException.GetSubtreeRootsException(
+                                            response.code,
+                                            response.description,
+                                            response.toThrowable()
+                                        )
+                                    if (response is Response.Failure.Server.Unavailable) {
+                                        Twig.error {
+                                            "Fetching $shieldedProtocol SubtreeRoot failed due to server" +
+                                                " communication problem with failure: ${response.toThrowable()}"
+                                        }
+                                        result = GetSubtreeRootsResult.FailureConnection
+                                    } else {
+                                        Twig.error {
+                                            "Fetching $shieldedProtocol SubtreeRoot failed with failure:" +
+                                                " ${response.toThrowable()}"
+                                        }
+                                        result = GetSubtreeRootsResult.OtherFailure(error)
+                                    }
+                                    traceScope.end()
+                                    throw error
                                 }
-                                result = GetSubtreeRootsResult.OtherFailure(error)
                             }
-                            traceScope.end()
-                            throw error
+                        }.filterIsInstance<Response.Success<SubtreeRootUnsafe>>()
+                        .map { response ->
+                            response.result
+                        }.toList()
+                        .map {
+                            SubtreeRoot.new(it)
                         }
-                    }
-                }.filterIsInstance<Response.Success<SubtreeRootUnsafe>>()
-                .map { response ->
-                    response.result
-                }.toList()
-                .map {
-                    SubtreeRoot.new(it)
-                }.let {
-                    saplingSubtreeRootList = it
-                }
+            }
+            return roots
         }
 
-        retryUpToAndContinue(GET_SUBTREE_ROOTS_RETRIES) {
-            downloader
-                .getSubtreeRoots(
-                    startIndex = orchardStartIndex,
-                    shieldedProtocol = ShieldedProtocolEnum.ORCHARD,
-                    maxEntries = UInt.MIN_VALUE,
-                    serviceMode = ServiceMode.Direct
-                ).onEach { response ->
-                    when (response) {
-                        is Response.Success -> {
-                            Twig.verbose {
-                                "Orchard SubtreeRoot fetched successfully: its completingHeight is: ${
-                                    response.result
-                                        .completingBlockHeight
-                                }"
-                            }
-                        }
+        val saplingSubtreeRootList = fetchSubtreeRoots(saplingStartIndex, ShieldedProtocolEnum.SAPLING)
+        val orchardSubtreeRootList = fetchSubtreeRoots(orchardStartIndex, ShieldedProtocolEnum.ORCHARD)
+        val ironwoodSubtreeRootList = fetchSubtreeRoots(ironwoodStartIndex, ShieldedProtocolEnum.IRONWOOD)
 
-                        is Response.Failure -> {
-                            val error =
-                                LightWalletException.GetSubtreeRootsException(
-                                    response.code,
-                                    response.description,
-                                    response.toThrowable()
-                                )
-                            if (response is Response.Failure.Server.Unavailable) {
-                                Twig.error {
-                                    "Fetching Orchard SubtreeRoot failed due to server communication problem with" +
-                                        " failure: ${response.toThrowable()}"
-                                }
-                                result = GetSubtreeRootsResult.FailureConnection
-                            } else {
-                                Twig.error {
-                                    "Fetching Orchard SubtreeRoot failed with failure: ${response.toThrowable()}"
-                                }
-                                result = GetSubtreeRootsResult.OtherFailure(error)
-                            }
-                            traceScope.end()
-                            throw error
-                        }
-                    }
-                }.filterIsInstance<Response.Success<SubtreeRootUnsafe>>()
-                .map { response ->
-                    response.result
-                }.toList()
-                .map {
-                    SubtreeRoot.new(it)
-                }.let {
-                    orchardSubtreeRootList = it
-                }
-        }
-
-        // Intentionally omitting [orchardSubtreeRootList], e.g., for Mainnet usage, we could check it, but on
-        // custom networks without NU5 activation, it wouldn't work. If the Orchard subtree roots are empty, it's
-        // technically still ok (as Orchard activates after Sapling, so on a network that doesn't have NU5
-        // activated, this would behave correctly). In contrast, if the Sapling subtree roots are empty, we
-        // cannot do SbS at all.
+        // Intentionally omitting [orchardSubtreeRootList]/[ironwoodSubtreeRootList], e.g., for Mainnet usage, we
+        // could check it, but on custom networks without NU5/NU6.3 activation, it wouldn't work. If the Orchard or
+        // Ironwood subtree roots are empty, it's technically still ok (both activate after Sapling, so on a network
+        // that doesn't have them activated yet, this would behave correctly). In contrast, if the Sapling subtree
+        // roots are empty, we cannot do SbS at all.
         if (saplingSubtreeRootList.isNotEmpty()) {
             result =
                 GetSubtreeRootsResult.SpendBeforeSync(
                     saplingStartIndex,
                     saplingSubtreeRootList,
                     orchardStartIndex,
-                    orchardSubtreeRootList
+                    orchardSubtreeRootList,
+                    ironwoodStartIndex,
+                    ironwoodSubtreeRootList
                 )
         }
 
@@ -1476,6 +1446,8 @@ class CompactBlockProcessor internal constructor(
         saplingSubtreeRootList: List<SubtreeRoot>,
         orchardStartIndex: UInt,
         orchardSubtreeRootList: List<SubtreeRoot>,
+        ironwoodStartIndex: UInt,
+        ironwoodSubtreeRootList: List<SubtreeRoot>,
         lastValidHeight: BlockHeight
     ): PutSaplingSubtreeRootsResult =
         runCatching {
@@ -1484,11 +1456,13 @@ class CompactBlockProcessor internal constructor(
                 saplingRoots = saplingSubtreeRootList,
                 orchardStartIndex = orchardStartIndex,
                 orchardRoots = orchardSubtreeRootList,
+                ironwoodStartIndex = ironwoodStartIndex,
+                ironwoodRoots = ironwoodSubtreeRootList,
             )
         }.onSuccess {
             Twig.info {
-                "Subtree roots put successfully with saplingStartIndex: $saplingStartIndex and " +
-                    "orchardStartIndex: $orchardStartIndex"
+                "Subtree roots put successfully with saplingStartIndex: $saplingStartIndex, " +
+                    "orchardStartIndex: $orchardStartIndex and ironwoodStartIndex: $ironwoodStartIndex"
             }
         }.onFailure {
             Twig.error { "Sapling subtree roots put failed with: $it" }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/model/GetSubtreeRootsResult.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/model/GetSubtreeRootsResult.kt
@@ -10,7 +10,9 @@ internal sealed class GetSubtreeRootsResult {
         val saplingStartIndex: UInt,
         val saplingSubtreeRootList: List<SubtreeRoot>,
         val orchardStartIndex: UInt,
-        val orchardSubtreeRootList: List<SubtreeRoot>
+        val orchardSubtreeRootList: List<SubtreeRoot>,
+        val ironwoodStartIndex: UInt,
+        val ironwoodSubtreeRootList: List<SubtreeRoot>
     ) : GetSubtreeRootsResult()
 
     data object Linear : GetSubtreeRootsResult()

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackend.kt
@@ -195,11 +195,14 @@ internal interface TypesafeBackend {
      * @throws RuntimeException as a common indicator of the operation failure
      */
     @Throws(RuntimeException::class)
+    @Suppress("LongParameterList")
     suspend fun putSubtreeRoots(
         saplingStartIndex: UInt,
         saplingRoots: List<SubtreeRoot>,
         orchardStartIndex: UInt,
         orchardRoots: List<SubtreeRoot>,
+        ironwoodStartIndex: UInt,
+        ironwoodRoots: List<SubtreeRoot>,
     )
 
     /**

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImpl.kt
@@ -288,7 +288,9 @@ internal class TypesafeBackendImpl(
         saplingStartIndex: UInt,
         saplingRoots: List<SubtreeRoot>,
         orchardStartIndex: UInt,
-        orchardRoots: List<SubtreeRoot>
+        orchardRoots: List<SubtreeRoot>,
+        ironwoodStartIndex: UInt,
+        ironwoodRoots: List<SubtreeRoot>
     ) = backend.putSubtreeRoots(
         saplingStartIndex = saplingStartIndex.toLong(),
         saplingRoots =
@@ -301,6 +303,14 @@ internal class TypesafeBackendImpl(
         orchardStartIndex = orchardStartIndex.toLong(),
         orchardRoots =
             orchardRoots.map {
+                JniSubtreeRoot.new(
+                    rootHash = it.rootHash,
+                    completingBlockHeight = it.completingBlockHeight.value
+                )
+            },
+        ironwoodStartIndex = ironwoodStartIndex.toLong(),
+        ironwoodRoots =
+            ironwoodRoots.map {
                 JniSubtreeRoot.new(
                     rootHash = it.rootHash,
                     completingBlockHeight = it.completingBlockHeight.value

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/WalletSummary.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/WalletSummary.kt
@@ -11,7 +11,8 @@ internal data class WalletSummary(
     val scanProgress: ScanProgress,
     val recoveryProgress: RecoveryProgress?,
     val nextSaplingSubtreeIndex: UInt,
-    val nextOrchardSubtreeIndex: UInt
+    val nextOrchardSubtreeIndex: UInt,
+    val nextIronwoodSubtreeIndex: UInt
 ) {
     companion object {
         fun new(jni: JniWalletSummary): WalletSummary =
@@ -26,7 +27,8 @@ internal data class WalletSummary(
                 scanProgress = ScanProgress.new(jni),
                 recoveryProgress = RecoveryProgress.new(jni),
                 nextSaplingSubtreeIndex = jni.nextSaplingSubtreeIndex.toUInt(),
-                nextOrchardSubtreeIndex = jni.nextOrchardSubtreeIndex.toUInt()
+                nextOrchardSubtreeIndex = jni.nextOrchardSubtreeIndex.toUInt(),
+                nextIronwoodSubtreeIndex = jni.nextIronwoodSubtreeIndex.toUInt()
             )
     }
 }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/AccountBalance.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/AccountBalance.kt
@@ -5,6 +5,7 @@ import cash.z.ecc.android.sdk.internal.model.JniAccountBalance
 data class AccountBalance(
     val sapling: WalletBalance,
     val orchard: WalletBalance,
+    val ironwood: WalletBalance,
     val unshielded: Zatoshi
 ) {
     companion object {
@@ -21,6 +22,12 @@ data class AccountBalance(
                         available = Zatoshi(jni.orchardVerifiedBalance),
                         changePending = Zatoshi(jni.orchardChangePending),
                         valuePending = Zatoshi(jni.orchardValuePending)
+                    ),
+                ironwood =
+                    WalletBalance(
+                        available = Zatoshi(jni.ironwoodVerifiedBalance),
+                        changePending = Zatoshi(jni.ironwoodChangePending),
+                        valuePending = Zatoshi(jni.ironwoodValuePending)
                     ),
                 unshielded = Zatoshi(jni.unshieldedBalance)
             )

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/TransactionOutput.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/TransactionOutput.kt
@@ -7,5 +7,6 @@ data class TransactionOutput(
 enum class TransactionPool {
     TRANSPARENT,
     SAPLING,
-    ORCHARD
+    ORCHARD,
+    IRONWOOD
 }


### PR DESCRIPTION
## Problem

`maint/v2.5.x` has no Rust CI at all: the PR workflow contains no `cargo`,
`clippy`, or `rust` step. The Rust code is compiled only indirectly, by the
Gradle `cargoBuild*` tasks that produce the `cdylib` for the Android artifact,
and those never build the test targets. The 18 unit tests in `backend-lib` have
therefore never been compiled or run on this branch.

That was hiding a real failure: `utils::exception::tests::unknown_any` does not
pass.

## Changes

**`5a514af4` fix the stale test.** `panic_error` is generic over
`T: fmt::Display` and panics with `panic!("{}", val)`, which always produces a
`String` payload. `any_to_string` downcasts that successfully and returns `"1"`,
so the "Unknown error occurred" fallback the test claims to cover is
unreachable. Adds `panic_any_error`, which uses `panic::panic_any` to make the
value itself the payload; a `u32` then fails every downcast and exercises the
intended branch. `any_to_string` is correct and is unchanged.

**`4b38fbb3` run the tests.** Adds a `test_rust_unit` job running
`cargo test --all-features`. Adds a matching `rust` stage to
`scripts/ci-local.sh`, wired into `quick` and `full`, so the check is runnable
before pushing as `AGENTS.md` asks. `AGENTS.md` is updated to match.

**`960a8314` unbreak Android Lint.** See below.

## `static_analysis_android_lint` was already failing

This is a pre-existing failure, not something this PR introduced. It is fixed
here in its own commit rather than folded into the Rust work.

The Android Lint step lints `:sdk-lib` and `:demo-app`, both of which depend on
`:backend-lib`, so Gradle first cross-compiles the Rust library at release
optimization for all four Android ABIs. Those four sequential cargo builds take
22 to 25 minutes on a GitHub runner; lint itself then finishes in about 90
seconds. Against the previous 25 minute budget the step passed or timed out
depending on how the Rust build happened to land:

- run 29746850811: cargo finished at 24m46s, step killed 27s into `lintAnalyze`
  with `The action 'Android Lint' has timed out after 25 minutes`
- run 29748070526: same step completed in 23m45s and passed

It reproduces on `main` itself (run 29765363343, same timeout message), which is
consistent with the note in `AGENTS.md` that `pull-request.yml` does not run on
pushes to `main`, so breakage there stays invisible until a fresh PR surfaces
it.

The fix raises the step to 45 minutes, matching the `Build` step of
`demo_app_release_build`, which performs the same four-ABI Rust build.

Lint itself is clean: run locally via `./scripts/ci-local.sh lint`,
`BUILD SUCCESSFUL in 6m 31s`, warnings only, zero errors.

## Not addressed here

**`test_android_modules_wtf`** also fails, on this branch and on `main`
(run 29765363343), with an identical error from the emulator.wtf service:

```
Execution failed for task ':lightwallet-client-lib:testDebugWithEmulatorWtf'
> com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Missing required properties: testRunId
```

That is a service-side response the Gradle plugin cannot deserialize, not a test
failure, and it is being handled separately in #1996.

**Clippy.** The version of this change that targeted `main` also widened the
clippy job to `--all-targets`. `maint/v2.5.x` has no clippy job to widen, so
that commit is dropped here; it can be reconciled in a merge commit later.

## Note on `--locked`

`--locked` is deliberately omitted from `cargo test`, with a comment saying so.

`backend-lib/Cargo.lock` cannot currently satisfy `Cargo.toml`, so `--locked`
would fail the build. Running any local build re-resolves and rewrites the
lockfile. That is reported rather than fixed, because reconciling it changes
resolved dependency versions and belongs to the owners of those dependencies.
`--locked` should be added once it is resolved.

## Testing

- `./scripts/ci-local.sh lint` passes: `BUILD SUCCESSFUL in 6m 31s`, 0 errors
- `shellcheck scripts/ci-local.sh` clean; `bash -n` clean
- Workflow YAML parses; `test_rust_unit` present, Android Lint timeout is 45
- New job uses this branch's pinned `actions/checkout` SHA and, unlike the
  `main` variant, omits `rust-cache: true`, which the setup action on this
  branch does not accept

No CHANGELOG entry: that file is consumer-facing and contains no CI entries in
its history.
