### PR TITLE
feat(tor): full compact block sync over .onion lightwalletd endpoints

### DIFF
--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -159,6 +159,8 @@ dependencies = [
  "tor-dirmgr",
  "tor-error",
  "tor-guardmgr",
+ "tor-hsclient",
+ "tor-hscrypto",
  "tor-keymgr",
  "tor-linkspec",
  "tor-llcrypto",
@@ -2174,9 +2176,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "imt-tree"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c378a3c5c44b985233906c966bd82a4f775a83aa4e1bde1635961c2eb8673d7b"
+checksum = "1d0a4887bb71d68b3d0c5db9d42bb76df38b0dff4d261b863dada6383b6c2012"
 dependencies = [
  "anyhow",
  "ff",
@@ -3112,9 +3114,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pir-client"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f18409a3bbbc58985c0ba79ec464c65e6ebab19cc1a82c5d4e184c3484520100"
+checksum = "edef04868dc19983199d26c205129b86fd95e2856e3f7a7c096438e7debafb69"
 dependencies = [
  "anyhow",
  "ff",
@@ -3131,9 +3133,9 @@ dependencies = [
 
 [[package]]
 name = "pir-types"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd3d6025cac852a7b3b81d6d07d6e21cc03bb3d5873fc13144a74c56f325b9d"
+checksum = "27fca477d53f99bc04e449bb984231bb383c41ddc24a0304ecea48563c17e25b"
 dependencies = [
  "anyhow",
  "ff",
@@ -4884,6 +4886,7 @@ dependencies = [
  "tor-bytes",
  "tor-cert",
  "tor-error",
+ "tor-hscrypto",
  "tor-linkspec",
  "tor-llcrypto",
  "tor-memquota",
@@ -5083,6 +5086,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tor-circmgr",
  "tor-error",
+ "tor-hscrypto",
  "tor-linkspec",
  "tor-llcrypto",
  "tor-netdoc",
@@ -5239,6 +5243,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "tor-hsclient"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c0438676badc6265d6f34ce91c9b50fdb4dfe89ab85795f013fbfa80614304"
+dependencies = [
+ "async-trait",
+ "derive-deftly",
+ "derive_more",
+ "educe",
+ "either",
+ "futures",
+ "itertools 0.14.0",
+ "oneshot-fused-workaround",
+ "postage",
+ "rand 0.9.4",
+ "retry-error",
+ "safelog",
+ "slotmap-careful",
+ "strum",
+ "thiserror 2.0.18",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-bytes",
+ "tor-cell",
+ "tor-checkable",
+ "tor-circmgr",
+ "tor-config",
+ "tor-dirclient",
+ "tor-error",
+ "tor-hscrypto",
+ "tor-keymgr",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-memquota",
+ "tor-netdir",
+ "tor-netdoc",
+ "tor-persist",
+ "tor-proto",
+ "tor-protover",
+ "tor-rtcompat",
+ "tracing",
+]
+
+[[package]]
 name = "tor-hscrypto"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5263,6 +5311,7 @@ dependencies = [
  "tor-error",
  "tor-key-forge",
  "tor-llcrypto",
+ "tor-memquota",
  "tor-units",
  "void",
 ]
@@ -5450,7 +5499,9 @@ dependencies = [
  "async-trait",
  "bitflags",
  "derive_more",
+ "digest 0.10.7",
  "futures",
+ "hex",
  "humantime",
  "itertools 0.14.0",
  "num_enum",
@@ -5458,8 +5509,10 @@ dependencies = [
  "serde",
  "strum",
  "thiserror 2.0.18",
+ "time",
  "tor-basic-utils",
  "tor-error",
+ "tor-hscrypto",
  "tor-linkspec",
  "tor-llcrypto",
  "tor-netdoc",
@@ -5490,6 +5543,7 @@ dependencies = [
  "memchr",
  "paste",
  "phf",
+ "rand 0.9.4",
  "serde",
  "serde_with",
  "signature",
@@ -5505,8 +5559,11 @@ dependencies = [
  "tor-cert",
  "tor-checkable",
  "tor-error",
+ "tor-hscrypto",
+ "tor-linkspec",
  "tor-llcrypto",
  "tor-protover",
+ "tor-units",
  "void",
  "weak-table",
  "zeroize",
@@ -5588,6 +5645,7 @@ dependencies = [
  "tor-checkable",
  "tor-config",
  "tor-error",
+ "tor-hscrypto",
  "tor-linkspec",
  "tor-llcrypto",
  "tor-log-ratelim",
@@ -6016,9 +6074,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vote-commitment-tree"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870b893a2c53ec015d46fd3a33cf91715a9a968d34531208144f48e46398321c"
+checksum = "8cac5881d522e752d764520d78b7a2fb674eaab4e394fabd1b976cf5f1a7a26c"
 dependencies = [
  "anyhow",
  "ff",
@@ -6033,9 +6091,9 @@ dependencies = [
 
 [[package]]
 name = "vote-commitment-tree-client"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03af018a5afbd7e58f2b233c96e64cc581d56cf12dd7daedd337cf6eaa10f80e"
+checksum = "ba358e900080169be7be851f4aab556b1c1e2ca3d195d71ad2ef5a71abd00f81"
 dependencies = [
  "base64",
  "ff",
@@ -6049,9 +6107,9 @@ dependencies = [
 
 [[package]]
 name = "voting-circuits"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a5b61b6f99af50df900d839b9440fa36709166449c7fa831169391bc5f44bc"
+checksum = "37d8bd9964ce4aef9152a66ad8950af529de4bbbd875bfd9e5d95534abc50df9"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -6785,9 +6843,10 @@ dependencies = [
 
 [[package]]
 name = "zcash-android-wallet-sdk"
-version = "2.5.1"
+version = "2.6.4"
 dependencies = [
  "anyhow",
+ "arti-client",
  "bitflags",
  "bytes",
  "dlopen2",
@@ -7135,9 +7194,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23827ed8aa8fe8bd1bdda0f72cfffca36fe1d8fafde82e72b0f5561a7aae845"
+checksum = "0a0f6ac52e66228393eab773dcec0eacbb6e1c768e0b6e0675d89d3a78ef53f1"
 dependencies = [
  "anyhow",
  "blake2b_simd",

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -30,6 +30,7 @@ zcash_client_backend = { version = "0.23", features = [
     "unstable",
     "pczt",
 ] }
+arti-client = { version = "0.35", default-features = false, features = ["onion-service-client"] }
 zcash_client_sqlite = { version = "0.21", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
 zcash_note_encryption = "0.4.1"
 zcash_primitives = "0.28"

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/CombinedWalletClientImpl.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/CombinedWalletClientImpl.kt
@@ -2,6 +2,7 @@ package cash.z.ecc.android.sdk.internal.model
 
 import co.electriccoin.lightwallet.client.CombinedWalletClient
 import co.electriccoin.lightwallet.client.LightWalletClient
+import cash.z.ecc.android.sdk.internal.model.TorWalletClient
 import co.electriccoin.lightwallet.client.PartialTorWalletClient
 import co.electriccoin.lightwallet.client.PartialWalletClient
 import co.electriccoin.lightwallet.client.ServiceMode
@@ -14,6 +15,7 @@ import co.electriccoin.lightwallet.client.model.Response
 import co.electriccoin.lightwallet.client.model.ShieldedProtocolEnum
 import co.electriccoin.lightwallet.client.model.SubtreeRootUnsafe
 import co.electriccoin.lightwallet.client.model.UninitializedTorClientException
+import co.electriccoin.lightwallet.client.model.TreeStateUnsafe
 import co.electriccoin.lightwallet.client.util.use
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -35,7 +37,8 @@ class CombinedWalletClientImpl private constructor(
     override suspend fun dispose() {
         semaphore.withLock {
             lightWalletClient.dispose()
-            torClient?.dispose()
+            // Note: torClient is owned by SdkSynchronizer and disposed there.
+            // Disposing it here would cause double-dispose when SdkSynchronizer.close() runs.
             cache.forEach { (_, client) -> client.dispose() }
             cache.clear()
         }
@@ -52,7 +55,14 @@ class CombinedWalletClientImpl private constructor(
 
     override suspend fun getLatestBlockHeight(
         serviceMode: ServiceMode
-    ) = executeAsResponse(serviceMode) { getLatestBlockHeight() }
+    ): Response<BlockHeightUnsafe> {
+        val isOnion = endpoint.host.endsWith(".onion") && torClient != null
+        if ((serviceMode != ServiceMode.Direct || isOnion) && torClient != null) {
+            val client = semaphore.withLock { getOrCreate(ServiceMode.Group("onion-sync")) }
+            return client.getLatestBlockHeight()
+        }
+        return executeAsResponse(ServiceMode.Direct) { getLatestBlockHeight() }
+    }
 
     override suspend fun submitTransaction(
         tx: ByteArray,
@@ -62,7 +72,14 @@ class CombinedWalletClientImpl private constructor(
     override suspend fun getTreeState(
         height: BlockHeightUnsafe,
         serviceMode: ServiceMode
-    ) = executeAsResponse(serviceMode) { getTreeState(height) }
+    ): Response<TreeStateUnsafe> {
+        val isOnion = endpoint.host.endsWith(".onion") && torClient != null
+        if ((serviceMode != ServiceMode.Direct || isOnion) && torClient != null) {
+            val client = semaphore.withLock { getOrCreate(ServiceMode.Group("onion-sync")) }
+            return client.getTreeState(height)
+        }
+        return executeAsResponse(ServiceMode.Direct) { getTreeState(height) }
+    }
 
     override suspend fun checkSingleUseTransparentAddress(
         accountUuid: ByteArray,
@@ -103,8 +120,14 @@ class CombinedWalletClientImpl private constructor(
         heightRange: ClosedRange<BlockHeightUnsafe>,
         serviceMode: ServiceMode
     ): Flow<Response<CompactBlockUnsafe>> {
-        require(serviceMode == ServiceMode.Direct)
-        return executeAsFlow(serviceMode) {
+        val isOnion = endpoint.host.endsWith(".onion") && torClient != null
+        if (serviceMode != ServiceMode.Direct || isOnion) {
+            val client = semaphore.withLock { getOrCreate(ServiceMode.Group("onion-sync")) }
+            (client as? TorWalletClient)?.let {
+                return it.getBlockRange(heightRange.start.value, heightRange.endInclusive.value)
+            }
+        }
+        return executeAsFlow(ServiceMode.Direct) {
             require(this is LightWalletClient)
             getBlockRange(heightRange)
         }
@@ -128,8 +151,14 @@ class CombinedWalletClientImpl private constructor(
         maxEntries: UInt,
         serviceMode: ServiceMode
     ): Flow<Response<SubtreeRootUnsafe>> {
-        require(serviceMode == ServiceMode.Direct)
-        return executeAsFlow(serviceMode) {
+        val isOnion = endpoint.host.endsWith(".onion") && torClient != null
+        if (serviceMode != ServiceMode.Direct || isOnion) {
+            val client = semaphore.withLock { getOrCreate(ServiceMode.Group("onion-sync")) }
+            (client as? TorWalletClient)?.let {
+                return it.getSubtreeRoots(startIndex.toInt(), shieldedProtocol, maxEntries.toInt())
+            }
+        }
+        return executeAsFlow(ServiceMode.Direct) {
             require(this is LightWalletClient)
             getSubtreeRoots(startIndex, shieldedProtocol, maxEntries)
         }
@@ -205,7 +234,7 @@ class CombinedWalletClientImpl private constructor(
         if (torClient == null) throw UninitializedTorClientException(NullPointerException("torClient is null"))
 
         return try {
-            torClient.createWalletClient("https://${endpoint.host}:${endpoint.port}")
+            torClient.createWalletClient("${if (endpoint.isSecure) "https" else "grpc"}://${endpoint.host}:${endpoint.port}")
         } catch (e: Exception) {
             throw UninitializedTorClientException(e)
         }

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/TorWalletClient.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/TorWalletClient.kt
@@ -1,7 +1,6 @@
 package cash.z.ecc.android.sdk.internal.model
 
 import cash.z.ecc.android.sdk.internal.Backend
-import cash.z.wallet.sdk.internal.rpc.Service
 import co.electriccoin.lightwallet.client.PartialTorWalletClient
 import co.electriccoin.lightwallet.client.model.BlockHeightUnsafe
 import co.electriccoin.lightwallet.client.model.BlockIDUnsafe
@@ -11,7 +10,17 @@ import co.electriccoin.lightwallet.client.model.Response
 import co.electriccoin.lightwallet.client.model.SendResponseUnsafe
 import co.electriccoin.lightwallet.client.model.TreeStateUnsafe
 import com.google.protobuf.kotlin.toByteString
+import cash.z.wallet.sdk.internal.rpc.CompactFormats
+import cash.z.wallet.sdk.internal.rpc.Service
+import co.electriccoin.lightwallet.client.model.CompactBlockUnsafe
+import co.electriccoin.lightwallet.client.model.ShieldedProtocolEnum
+import co.electriccoin.lightwallet.client.model.SubtreeRootUnsafe
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -132,7 +141,80 @@ class TorWalletClient private constructor(
         }
     }
 
-    companion object {
+    /**
+     * Streams compact blocks in the given height range over Tor.
+     */
+    suspend fun getBlockRange(
+        startHeight: Long,
+        endHeight: Long
+    ): Flow<Response<CompactBlockUnsafe>> = flow {
+        semaphore.withLock {
+            val handle = checkNotNull(nativeHandle) { "TorWalletClient is disposed" }
+            val ch = Channel<ByteArray>(Channel.UNLIMITED)
+            withContext(Dispatchers.IO) {
+                try {
+                    getBlockRange(handle, startHeight, endHeight, object : BlockCallback {
+                        override fun onBlock(bytes: ByteArray) { ch.trySend(bytes) }
+                    })
+                } finally {
+                    ch.close()
+                }
+            }
+            for (bytes in ch) {
+                try {
+                    val block = CompactFormats.CompactBlock.parseFrom(bytes)
+                    emit(Response.Success(CompactBlockUnsafe.new(block)))
+                } catch (e: Exception) {
+                    emit(Response.Failure.OverTor(cause = e))
+                }
+            }
+        }
+    }.flowOn(Dispatchers.IO)
+
+    /**
+     * Fetches subtree roots over Tor.
+     */
+    suspend fun getSubtreeRoots(
+        startIndex: Int,
+        shieldedProtocol: ShieldedProtocolEnum,
+        maxEntries: Int
+    ): Flow<Response<SubtreeRootUnsafe>> = flow {
+        semaphore.withLock {
+            val handle = checkNotNull(nativeHandle) { "TorWalletClient is disposed" }
+            val protoVal = when (shieldedProtocol) {
+                ShieldedProtocolEnum.SAPLING -> 0
+                ShieldedProtocolEnum.ORCHARD -> 1
+            }
+            val ch = Channel<ByteArray>(Channel.UNLIMITED)
+            withContext(Dispatchers.IO) {
+                try {
+                    getSubtreeRoots(handle, startIndex, protoVal, maxEntries, object : SubtreeRootCallback {
+                        override fun onSubtreeRoot(bytes: ByteArray) { ch.trySend(bytes) }
+                    })
+                } finally {
+                    ch.close()
+                }
+            }
+            for (bytes in ch) {
+                try {
+                    val root = Service.SubtreeRoot.parseFrom(bytes)
+                    emit(Response.Success(SubtreeRootUnsafe.new(root)))
+                } catch (e: Exception) {
+                    emit(Response.Failure.OverTor(cause = e))
+                }
+            }
+        }
+    }.flowOn(Dispatchers.IO)
+
+    interface BlockCallback {
+        fun onBlock(bytes: ByteArray)
+    }
+
+    interface SubtreeRootCallback {
+        fun onSubtreeRoot(bytes: ByteArray)
+    }
+
+        companion object {
         internal suspend fun new(nativeHandle: Long, backend: Backend): TorWalletClient =
             withContext(Dispatchers.IO) {
                 TorWalletClient(nativeHandle, backend)
@@ -210,6 +292,11 @@ class TorWalletClient private constructor(
         @JvmStatic
         @Throws(RuntimeException::class)
         @Suppress("LongParameterList")
+        private external fun getBlockRange(nativeHandle: Long, startHeight: Long, endHeight: Long, callback: BlockCallback)
+
+        @JvmStatic
+        private external fun getSubtreeRoots(nativeHandle: Long, startIndex: Int, shieldedProtocol: Int, maxEntries: Int, callback: SubtreeRootCallback)
+
         private external fun fetchUtxosByAddress(
             nativeHandle: Long,
             dbDataPath: String,

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -3401,6 +3401,80 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_model_TorWalletClient_get
     unwrap_exc_or(&mut env, res, ptr::null_mut())
 }
 
+/// Streams compact blocks in the given range over Tor.
+/// Calls the provided callback for each serialized CompactBlock proto.
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_model_TorWalletClient_getBlockRange<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    lwd_conn: jlong,
+    start_height: jlong,
+    end_height: jlong,
+    callback: JObject<'local>,
+) {
+    let res = catch_unwind(&mut env, |env| {
+        let lwd_conn = ptr::with_exposed_provenance_mut::<crate::tor::LwdConn>(lwd_conn as usize);
+        let lwd_conn = unsafe { lwd_conn.as_mut() }
+            .ok_or_else(|| anyhow!("A Tor lightwalletd connection is required"))?;
+
+        lwd_conn.with_block_range(
+            start_height as u64,
+            end_height as u64,
+            |block_bytes| {
+                let java_bytes = utils::rust_bytes_to_java(env, &block_bytes)?;
+                env.call_method(
+                    &callback,
+                    "onBlock",
+                    "([B)V",
+                    &[jni::objects::JValueOwned::from(java_bytes).borrow()],
+                )?;
+                Ok(())
+            },
+        )
+    });
+    unwrap_exc_or(&mut env, res, ())
+}
+
+/// Fetches subtree roots over Tor.
+/// protocol: 0=Sapling, 1=Orchard
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_model_TorWalletClient_getSubtreeRoots<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    lwd_conn: jlong,
+    start_index: jint,
+    shielded_protocol: jint,
+    max_entries: jint,
+    callback: JObject<'local>,
+) {
+    let res = catch_unwind(&mut env, |env| {
+        let lwd_conn = ptr::with_exposed_provenance_mut::<crate::tor::LwdConn>(lwd_conn as usize);
+        let lwd_conn = unsafe { lwd_conn.as_mut() }
+            .ok_or_else(|| anyhow!("A Tor lightwalletd connection is required"))?;
+
+        lwd_conn.with_subtree_roots(
+            start_index as u32,
+            shielded_protocol,
+            max_entries as u32,
+            |root_bytes| {
+                let java_bytes = utils::rust_bytes_to_java(env, &root_bytes)?;
+                env.call_method(
+                    &callback,
+                    "onSubtreeRoot",
+                    "([B)V",
+                    &[jni::objects::JValueOwned::from(java_bytes).borrow()],
+                )?;
+                Ok(())
+            },
+        )
+    });
+    unwrap_exc_or(&mut env, res, ())
+}
+
 /// Checks to find any single-use ephemeral addresses exposed in the past day that have not yet
 /// received funds, excluding any whose next check time is in the future. This will then choose the
 /// address that is most overdue for checking, retrieve any UTXOs for that address over Tor, and

--- a/backend-lib/src/main/rust/tor.rs
+++ b/backend-lib/src/main/rust/tor.rs
@@ -251,6 +251,54 @@ impl LwdConn {
         })
     }
 
+    /// Streams compact blocks in the given range, calling the closure for each.
+    pub(crate) fn with_block_range(
+        &mut self,
+        start: u64,
+        end: u64,
+        mut f: impl FnMut(Vec<u8>) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        let request = service::BlockRange {
+            start: Some(service::BlockId { height: start, ..Default::default() }),
+            end: Some(service::BlockId { height: end, ..Default::default() }),
+            pool_types: vec![],
+        };
+
+        self.runtime.clone().block_on(async {
+            let mut blocks = self.conn.get_block_range(request).await?.into_inner();
+            while let Some(block) = blocks.message().await? {
+                use prost::Message;
+                f(block.encode_to_vec())?;
+            }
+            Ok(())
+        })
+    }
+
+    /// Fetches subtree roots for the given shielded protocol.
+    /// protocol: 0=Sapling, 1=Orchard
+    pub(crate) fn with_subtree_roots(
+        &mut self,
+        start_index: u32,
+        shielded_protocol: i32,
+        max_entries: u32,
+        mut f: impl FnMut(Vec<u8>) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        let request = service::GetSubtreeRootsArg {
+            start_index,
+            shielded_protocol,
+            max_entries,
+        };
+
+        self.runtime.clone().block_on(async {
+            let mut roots = self.conn.get_subtree_roots(request).await?.into_inner();
+            while let Some(root) = roots.message().await? {
+                use prost::Message;
+                f(root.encode_to_vec())?;
+            }
+            Ok(())
+        })
+    }
+
     /// Fetches the note commitment tree state corresponding to the given block.
     pub(crate) fn get_tree_state(
         &mut self,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
@@ -901,8 +901,9 @@ interface Synchronizer {
                     .defaultCompactBlockRepository(coordinator.fsBlockDbRoot(zcashNetwork, alias), backend)
 
             val torDir = Files.getTorDir(context)
+            val isOnionEndpoint = lightWalletEndpoint.host.endsWith(".onion")
             val torClient =
-                if (sdkFlags.isTorEnabled || sdkFlags.isExchangeRateEnabled) {
+                if (sdkFlags.isTorEnabled || sdkFlags.isExchangeRateEnabled || isOnionEndpoint) {
                     try {
                         TorClient.new(torDir, backend.backend)
                     } catch (e: Exception) {
@@ -928,7 +929,7 @@ interface Synchronizer {
             val walletClientFactory =
                 WalletClientFactory(
                     context = applicationContext,
-                    torClient = torClient.takeIf { sdkFlags.isTorEnabled }
+                    torClient = torClient.takeIf { sdkFlags.isTorEnabled || isOnionEndpoint }
                 )
 
             val walletClient = walletClientFactory.create(endpoint = lightWalletEndpoint)

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessor.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessor.kt
@@ -1353,7 +1353,7 @@ class CompactBlockProcessor internal constructor(
                     saplingStartIndex,
                     shieldedProtocol = ShieldedProtocolEnum.SAPLING,
                     maxEntries = UInt.MIN_VALUE,
-                    serviceMode = ServiceMode.Direct
+                    serviceMode = sdkFlags ifTor ServiceMode.DefaultTor
                 ).onEach { response ->
                     when (response) {
                         is Response.Success -> {
@@ -1405,7 +1405,7 @@ class CompactBlockProcessor internal constructor(
                     startIndex = orchardStartIndex,
                     shieldedProtocol = ShieldedProtocolEnum.ORCHARD,
                     maxEntries = UInt.MIN_VALUE,
-                    serviceMode = ServiceMode.Direct
+                    serviceMode = sdkFlags ifTor ServiceMode.DefaultTor
                 ).onEach { response ->
                     when (response) {
                         is Response.Success -> {
@@ -1924,7 +1924,7 @@ class CompactBlockProcessor internal constructor(
             downloadedBlocks =
                 downloader.downloadBlockRange(
                     heightRange = batch.range,
-                    serviceMode = ServiceMode.Direct
+                    serviceMode = sdkFlags ifTor ServiceMode.DefaultTor
                 )
         }
         traceScope.end()

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/util/WalletClientFactory.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/util/WalletClientFactory.kt
@@ -1,5 +1,6 @@
 package cash.z.ecc.android.sdk.util
 
+
 import android.content.Context
 import cash.z.ecc.android.sdk.internal.model.CombinedWalletClientImpl
 import cash.z.ecc.android.sdk.internal.model.TorClient
@@ -25,13 +26,9 @@ class WalletClientFactory(
      */
     @Suppress("TooGenericExceptionCaught")
     suspend fun create(endpoint: LightWalletEndpoint): CombinedWalletClient {
-        val torClient =
-            try {
-                torClient?.isolatedTorClient()
-            } catch (_: Exception) {
-                null
-            }
-
+        // Pass the original TorClient (not an isolated copy) so it stays alive
+        // for the lifetime of CombinedWalletClientImpl. The isolated clients
+        // for individual RPC calls are created inside CombinedWalletClientImpl.
         return CombinedWalletClientImpl.new(
             endpoint = endpoint,
             lightWalletClient = LightWalletClient.new(context, endpoint),


### PR DESCRIPTION
## Problem

When the user sets a `.onion` address as the lightwalletd server, the wallet connects to Tor for some operations (SubtreeRoots, exchange rate) but falls back to plain DNS for the core sync operations (getBlockRange, getTreeState, fetchLatestBlockHeight). This means the sync either stalls completely with DNS failures or leaks the IP address.

Two root causes:
1. `CompactBlockProcessor` passed `ServiceMode.Direct` to `getSubtreeRoots` and `downloadBlockRange`, bypassing the Tor path even when Tor was enabled
2. `CombinedWalletClientImpl` had no Tor routing for `getTreeState`, `getLatestBlockHeight`, `getBlockRange` when called with `ServiceMode.Direct` from a `.onion` endpoint

## Changes

### Rust (backend-lib)
- `tor.rs`: add `with_block_range()` and `with_subtree_roots()` to `LwdConn` using a callback pattern to stream gRPC responses from an existing Tor connection
- `lib.rs`: add JNI entry points `getBlockRange` and `getSubtreeRoots` on `TorWalletClient`

### Kotlin (backend-lib)
- `TorWalletClient.kt`: expose `getBlockRange` and `getSubtreeRoots` as `Flow<Response<…>>` via JNI callbacks + `Channel`
- `CombinedWalletClientImpl.kt`:
  - Override `getBlockRange`, `getSubtreeRoots`, `getTreeState`, `getLatestBlockHeight` to route to the Tor-cached `PartialTorWalletClient` when the endpoint host ends in `.onion`
  - Use `Group("onion-sync")` as the cache key (separate from `DefaultTor` used for exchange-rate) to avoid serving a non-`TorWalletClient` object to the streaming methods
  - Remove `torClient?.dispose()` from `CombinedWalletClientImpl.dispose()` — `SdkSynchronizer` owns the `TorClient` lifetime; the previous double-dispose caused `nativeHandle = null` before sync requests completed

### Kotlin (sdk-lib)
- `Synchronizer.kt`: create `TorClient` and pass it to `WalletClientFactory` when `lightWalletEndpoint.host.endsWith(".onion")` even if `SdkFlags.isTorEnabled` is false
- `WalletClientFactory.kt`: pass the original `TorClient` directly instead of calling `isolatedTorClient()` — the isolated copy was being GC'd/disposed before the first RPC
- `CompactBlockProcessor.kt`: pass `sdkFlags ifTor ServiceMode.DefaultTor` (instead of hardcoded `Direct`) to `getSubtreeRoots` and `downloadBlockRange`

## Testing

Tested on an Android emulator (x86_64, API 34) against a lightwalletd instance exposed via a Tor v3 onion service. The wallet bootstrapped Arti, connected through Tor, and downloaded compact blocks continuously:

```
CompactBlockDownloader: Downloading block at height: 3406014 succeeded.
...
CompactBlockDownloader: All blocks in range 3405029..3406028 downloaded successfully
CompactBlockProcessor: fetchTreeStateForHeight: Starting to fetch tree state for height 3406028
```

Depends on librustzcash#2698 which adds `arti-client/onion-service-client` to the `tor` feature and enables `StreamPrefs::connect_to_onion_services`.