### PR TITLE
Redact proofs, binding keys, and dummy spend keys from Signer PCZTs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `Synchronizer.redactPcztForSigner` now applies the canonical Signer-role redaction policy
+  from `zcash_client_backend`: in addition to the previously redacted wallet metadata and
+  spend witnesses, it removes zero-knowledge proofs, binding signing keys, and dummy-spend
+  signing keys, redacts the Ironwood bundle identically to Orchard, compacts resolvable
+  Orchard/Ironwood fields, and removes shielded anchors from v6 transactions. This
+  substantially reduces the size of the payload transferred to air-gapped hardware signers
+  such as Keystone over animated QR codes. All removed data is regenerated or restored from
+  the retained unredacted PCZT when it is combined with the signed PCZT in
+  `Synchronizer.createTransactionFromPczt`, so no caller changes are required.
+
 ## [2.6.5] - 2026-06-19
 
 ### Fixed

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -2496,6 +2496,11 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_createPcz
 
 /// Redacts information from the given PCZT that is unnecessary for the Signer role.
 ///
+/// Applies the canonical Signer-role policy from
+/// [`zcash_client_backend::data_api::wallet::redact_pczt_for_signer`], and additionally
+/// omits Sapling spend witnesses. The caller must retain the unredacted PCZT and combine
+/// the Signer output into it via `extractAndStoreTxFromPczt`.
+///
 /// Returns the updated PCZT in its serialized format.
 #[unsafe(no_mangle)]
 pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_redactPcztForSignerRole<
@@ -2510,24 +2515,11 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_redactPcz
 
         let pczt = parse_pczt(env, pczt)?;
 
-        let pczt_with_proofs = Redactor::new(pczt)
-            .redact_global_with(|mut r| r.redact_proprietary("zcash_client_backend:proposal_info"))
-            .redact_orchard_with(|mut r| {
-                r.redact_actions(|mut ar| {
-                    ar.clear_spend_witness();
-                    ar.redact_output_proprietary("zcash_client_backend:output_info");
-                })
-            })
+        // The upstream policy retains Sapling spend witnesses for Signers that verify
+        // nullifiers; the Signers this SDK targets do not, so keep omitting them.
+        let pczt_with_proofs = Redactor::new(wallet::redact_pczt_for_signer(&pczt))
             .redact_sapling_with(|mut r| {
                 r.redact_spends(|mut sr| sr.clear_witness());
-                r.redact_outputs(|mut or| {
-                    or.redact_proprietary("zcash_client_backend:output_info")
-                });
-            })
-            .redact_transparent_with(|mut r| {
-                r.redact_outputs(|mut or| {
-                    or.redact_proprietary("zcash_client_backend:output_info")
-                });
             })
             .finish();
 


### PR DESCRIPTION
Expands redactPcztForSignerRole to additionally clear:

- Orchard bundle zkproof and bsk
- Orchard per-action dummy_sk
- Sapling bundle bsk
- Sapling per-spend zkproof and dummy_ask
- Sapling per-output zkproof

This matches the Signer-role redaction policy adopted upstream in zcash_client_backend (librustzcash e58f13ec03), minus the APIs not yet available in the pczt 0.7 release (Ironwood bundles, recomputable-field compaction, v6 anchor removal), and substantially reduces the payload size transferred to air-gapped hardware signers over animated QR codes.

Closes https://github.com/zcash/zcash-android-wallet-sdk/issues/2023
[MOB-1516](https://linear.app/zodl/issue/MOB-1516)