### PR TITLE
Backport Orchard → Ironwood migration onto 2.5.x (no Slipstream)

### DIFF
--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,6 +44,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amplify"
@@ -159,6 +171,8 @@ dependencies = [
  "tor-dirmgr",
  "tor-error",
  "tor-guardmgr",
+ "tor-hsclient",
+ "tor-hscrypto",
  "tor-keymgr",
  "tor-linkspec",
  "tor-llcrypto",
@@ -404,6 +418,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "bip0039"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568b6890865156d9043af490d4c4081c385dd68ea10acd6ca15733d511e6b51c"
+dependencies = [
+ "hmac 0.12.1",
+ "pbkdf2",
+ "rand 0.8.6",
+ "sha2 0.10.9",
+ "unicode-normalization",
+ "zeroize",
+]
+
+[[package]]
 name = "bip32"
 version = "0.6.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +445,21 @@ dependencies = [
  "sha2 0.11.0-pre.4",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "bitcoin-private"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
+dependencies = [
+ "bitcoin-private",
 ]
 
 [[package]]
@@ -736,15 +779,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "component"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d77c427b730ea6e0b7ff8f7fb93894a320c06256b3d553be7432788eaee6963"
-dependencies = [
- "anyhow",
-]
-
-[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,6 +837,21 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -1052,6 +1101,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1099,7 +1154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d308ebe4b10924331bd079044b418da7b227d724d3e2408567a47ad7c3da2a0"
 dependencies = [
  "derive-deftly-macros",
- "heck",
+ "heck 0.5.0",
 ]
 
 [[package]]
@@ -1108,7 +1163,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "proc-macro-crate",
@@ -1454,8 +1509,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1493,6 +1547,14 @@ name = "f4jumble"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+dependencies = [
+ "blake2b_simd",
+]
+
+[[package]]
+name = "f4jumble"
+version = "0.1.1"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1572,6 +1634,12 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
@@ -1593,6 +1661,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "749cff877dc1af878a0b31a41dd221a753634401ea0ef2f87b62d3171522485a"
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1603,6 +1683,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "fpe"
@@ -1926,7 +2012,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1943,6 +2040,12 @@ checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -2097,6 +2200,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2166,6 +2285,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "imt-tree"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d0a4887bb71d68b3d0c5db9d42bb76df38b0dff4d261b863dada6383b6c2012"
+dependencies = [
+ "anyhow",
+ "ff",
+ "halo2_gadgets",
+ "hex",
+ "pasta_curves",
+ "rayon",
+]
+
+[[package]]
 name = "incrementalmerkletree"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2233,6 +2366,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -2349,6 +2491,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "keystone-ur"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a08a7e0ccd113dac19485c5c0fe87c70b663f896c48e4493814e446175078d4"
+dependencies = [
+ "bitcoin_hashes",
+ "crc",
+ "minicbor",
+ "phf 0.11.3",
+ "rand_xoshiro",
+]
+
+[[package]]
 name = "known-folders"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2399,6 +2554,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libflate"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85f7ef5c7e3c2ed51f0fbc40e016c66558b699f16593521f30b98713bbb99cb8"
+dependencies = [
+ "adler32",
+ "crc32fast",
+ "dary_heap",
+ "libflate_lz77",
+ "no_std_io2",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff7a10e427698aef6eef269482776debfef63384d30f13aad39a1a95e0e098fd"
+dependencies = [
+ "hashbrown 0.16.1",
+ "no_std_io2",
+ "rle-decode-fast",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2423,6 +2602,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2536,6 +2721,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minicbor"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7005aaf257a59ff4de471a9d5538ec868a21586534fff7f85dd97d4043a6139"
+dependencies = [
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1154809406efdb7982841adb6311b3d095b46f78342dd646736122fe6b19e267"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2565,9 +2770,24 @@ dependencies = [
 
 [[package]]
 name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "ndk-sys"
@@ -2576,6 +2796,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
 dependencies = [
  "jni-sys 0.3.1",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2827,6 +3056,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "orchard"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793e2e8c2323f35f082d1b3467ca8f576d646f9c93aef8c5168809d099245af8"
+dependencies = [
+ "aes",
+ "bitvec",
+ "blake2b_simd",
+ "corez",
+ "ff",
+ "fpe",
+ "getset",
+ "group",
+ "halo2_gadgets",
+ "halo2_poseidon",
+ "halo2_proofs",
+ "hex",
+ "incrementalmerkletree",
+ "lazy_static",
+ "memuse",
+ "nonempty",
+ "pasta_curves",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
+ "reddsa",
+ "serde",
+ "sinsemilla",
+ "subtle",
+ "tracing",
+ "visibility",
+ "zcash_note_encryption",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
 name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2935,10 +3200,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "pasta_curves"
-version = "0.5.1"
+name = "password-hash"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "pasta_curves"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3437083215c505e867eea5478371feba43d7689d6d15ec0a209eb46fb0d4cda6"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -2956,6 +3232,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "password-hash",
+]
+
+[[package]]
 name = "pczt"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2968,7 +3254,7 @@ dependencies = [
  "getset",
  "jubjub",
  "nonempty",
- "orchard",
+ "orchard 0.14.0",
  "pasta_curves",
  "postcard",
  "rand_core 0.6.4",
@@ -2978,10 +3264,38 @@ dependencies = [
  "serde",
  "serde_with",
  "zcash_note_encryption",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_primitives 0.28.0",
+ "zcash_protocol 0.9.0",
  "zcash_script",
- "zcash_transparent",
+ "zcash_transparent 0.8.0",
+]
+
+[[package]]
+name = "pczt"
+version = "0.8.0-rc.1"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+dependencies = [
+ "blake2b_simd",
+ "bls12_381",
+ "document-features",
+ "ff",
+ "getset",
+ "jubjub",
+ "nonempty",
+ "orchard 0.15.4",
+ "pasta_curves",
+ "postcard",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "secp256k1",
+ "serde",
+ "serde_with",
+ "zcash_note_encryption",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
+ "zcash_script",
+ "zcash_transparent 0.9.0",
 ]
 
 [[package]]
@@ -3001,11 +3315,21 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "indexmap 2.14.0",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.5.7",
  "indexmap 2.14.0",
 ]
 
@@ -3015,9 +3339,19 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -3026,9 +3360,19 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
  "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3038,7 +3382,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3047,11 +3404,20 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -3088,6 +3454,38 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pir-client"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edef04868dc19983199d26c205129b86fd95e2856e3f7a7c096438e7debafb69"
+dependencies = [
+ "anyhow",
+ "ff",
+ "futures",
+ "hex",
+ "imt-tree",
+ "log",
+ "pasta_curves",
+ "pir-types",
+ "serde_json",
+ "tokio",
+ "valar-ypir",
+]
+
+[[package]]
+name = "pir-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27fca477d53f99bc04e449bb984231bb383c41ddc24a0304ecea48563c17e25b"
+dependencies = [
+ "anyhow",
+ "ff",
+ "imt-tree",
+ "pasta_curves",
+ "serde",
+]
 
 [[package]]
 name = "pkcs1"
@@ -3199,6 +3597,16 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
@@ -3279,12 +3687,44 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.3",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+dependencies = [
+ "bytes",
+ "heck 0.4.1",
+ "itertools 0.10.5",
+ "lazy_static",
+ "log",
+ "multimap 0.8.3",
+ "petgraph 0.6.5",
+ "prettyplease 0.1.25",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
+ "regex",
+ "syn 1.0.109",
+ "tempfile",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -3293,17 +3733,30 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
- "multimap",
+ "multimap 0.10.1",
  "petgraph 0.8.3",
- "prettyplease",
- "prost",
- "prost-types",
+ "prettyplease 0.2.37",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
  "regex",
  "syn 2.0.117",
  "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3321,11 +3774,20 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+dependencies = [
+ "prost 0.11.9",
+]
+
+[[package]]
+name = "prost-types"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost",
+ "prost 0.14.3",
 ]
 
 [[package]]
@@ -3445,6 +3907,15 @@ dependencies = [
  "libc",
  "rand_core 0.9.5",
  "winapi",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3624,6 +4095,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3661,12 +4138,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-analyzer"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11707871ffa56ce568d4f15dd34c2f891a2aa5e4b3435b99b8f99938492525c3"
-
-[[package]]
 name = "rust_decimal"
 version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3698,6 +4169,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3705,7 +4189,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -4113,6 +4597,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "shardtree"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8147447aed7be4736e271825b8c3a4432efb7182e71363169b572371ddef452e"
+dependencies = [
+ "bitflags",
+ "either",
+ "incrementalmerkletree",
+ "tracing",
+]
+
+[[package]]
 name = "shellexpand"
 version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4222,7 +4718,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4243,6 +4739,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -4329,7 +4828,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4409,7 +4908,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4429,6 +4928,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-core"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c001ee18b7e5e3f62cbf58c7fe220119e68d902bb7443179c0c8aef30090e999"
+dependencies = [
+ "thiserror-core-impl",
+]
+
+[[package]]
+name = "thiserror-core-impl"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c60d69f36615a077cc7663b9cb8e42275722d23e58a7fa3d2c7f2915d09d04"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4729,7 +5248,7 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
 dependencies = [
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4742,7 +5261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.14.3",
  "tonic",
 ]
 
@@ -4752,10 +5271,10 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
- "prost-build",
- "prost-types",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
  "quote",
  "syn 2.0.117",
  "tempfile",
@@ -4837,6 +5356,7 @@ dependencies = [
  "tor-bytes",
  "tor-cert",
  "tor-error",
+ "tor-hscrypto",
  "tor-linkspec",
  "tor-llcrypto",
  "tor-memquota",
@@ -5036,6 +5556,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tor-circmgr",
  "tor-error",
+ "tor-hscrypto",
  "tor-linkspec",
  "tor-llcrypto",
  "tor-netdoc",
@@ -5192,6 +5713,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "tor-hsclient"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c0438676badc6265d6f34ce91c9b50fdb4dfe89ab85795f013fbfa80614304"
+dependencies = [
+ "async-trait",
+ "derive-deftly",
+ "derive_more",
+ "educe",
+ "either",
+ "futures",
+ "itertools 0.14.0",
+ "oneshot-fused-workaround",
+ "postage",
+ "rand 0.9.4",
+ "retry-error",
+ "safelog",
+ "slotmap-careful",
+ "strum",
+ "thiserror 2.0.18",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-bytes",
+ "tor-cell",
+ "tor-checkable",
+ "tor-circmgr",
+ "tor-config",
+ "tor-dirclient",
+ "tor-error",
+ "tor-hscrypto",
+ "tor-keymgr",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-memquota",
+ "tor-netdir",
+ "tor-netdoc",
+ "tor-persist",
+ "tor-proto",
+ "tor-protover",
+ "tor-rtcompat",
+ "tracing",
+]
+
+[[package]]
 name = "tor-hscrypto"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5216,6 +5781,7 @@ dependencies = [
  "tor-error",
  "tor-key-forge",
  "tor-llcrypto",
+ "tor-memquota",
  "tor-units",
  "void",
 ]
@@ -5403,7 +5969,9 @@ dependencies = [
  "async-trait",
  "bitflags",
  "derive_more",
+ "digest 0.10.7",
  "futures",
+ "hex",
  "humantime",
  "itertools 0.14.0",
  "num_enum",
@@ -5411,8 +5979,10 @@ dependencies = [
  "serde",
  "strum",
  "thiserror 2.0.18",
+ "time",
  "tor-basic-utils",
  "tor-error",
+ "tor-hscrypto",
  "tor-linkspec",
  "tor-llcrypto",
  "tor-netdoc",
@@ -5442,7 +6012,8 @@ dependencies = [
  "itertools 0.14.0",
  "memchr",
  "paste",
- "phf",
+ "phf 0.13.1",
+ "rand 0.9.4",
  "serde",
  "serde_with",
  "signature",
@@ -5458,8 +6029,11 @@ dependencies = [
  "tor-cert",
  "tor-checkable",
  "tor-error",
+ "tor-hscrypto",
+ "tor-linkspec",
  "tor-llcrypto",
  "tor-protover",
+ "tor-units",
  "void",
  "weak-table",
  "zeroize",
@@ -5541,6 +6115,7 @@ dependencies = [
  "tor-checkable",
  "tor-config",
  "tor-error",
+ "tor-hscrypto",
  "tor-linkspec",
  "tor-llcrypto",
  "tor-log-ratelim",
@@ -5889,6 +6464,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
+name = "ur"
+version = "0.3.0"
+source = "git+https://github.com/KeystoneHQ/ur-rs?tag=0.3.3#81b8bb3b6b3a823128489c81ffee5bb4001ba2ae"
+dependencies = [
+ "bitcoin_hashes",
+ "crc",
+ "minicbor",
+ "phf 0.11.3",
+ "rand_xoshiro",
+]
+
+[[package]]
+name = "ur-registry"
+version = "1.0.8"
+source = "git+https://github.com/KeystoneHQ/keystone-sdk-rust#7c90bf1ae504720c3f4b44ff26f996836d8b1553"
+dependencies = [
+ "bs58",
+ "hex",
+ "keystone-ur",
+ "libflate",
+ "minicbor",
+ "no_std_io2",
+ "paste",
+ "prost 0.11.9",
+ "prost-build 0.11.9",
+ "prost-types 0.11.9",
+ "serde",
+ "thiserror 1.0.69",
+ "thiserror-core",
+]
+
+[[package]]
 name = "uuid"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5898,6 +6505,38 @@ dependencies = [
  "js-sys",
  "serde_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "valar-spiral-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "208d4b69c6a9b7b0c7d856133009a514e10236cdc698ad0b6b87f2e3c4e6d9cb"
+dependencies = [
+ "fastrand",
+ "getrandom 0.2.17",
+ "rand 0.8.6",
+ "rand_chacha 0.3.1",
+ "serde_json",
+ "sha2 0.10.9",
+ "subtle",
+]
+
+[[package]]
+name = "valar-ypir"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c3852d9476a0e3efd6c3bfbfc54d3a21a68d8818c4779824ace78aec84a042"
+dependencies = [
+ "cc",
+ "fastrand",
+ "log",
+ "rand 0.8.6",
+ "rand_chacha 0.3.1",
+ "serde",
+ "serde_json",
+ "sha1",
+ "valar-spiral-rs",
 ]
 
 [[package]]
@@ -5934,6 +6573,60 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "vote-commitment-tree"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cac5881d522e752d764520d78b7a2fb674eaab4e394fabd1b976cf5f1a7a26c"
+dependencies = [
+ "anyhow",
+ "ff",
+ "halo2_gadgets",
+ "imt-tree",
+ "incrementalmerkletree",
+ "lazy_static",
+ "libc",
+ "pasta_curves",
+ "shardtree 0.6.2",
+]
+
+[[package]]
+name = "vote-commitment-tree-client"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba358e900080169be7be851f4aab556b1c1e2ca3d195d71ad2ef5a71abd00f81"
+dependencies = [
+ "base64",
+ "ff",
+ "hex",
+ "pasta_curves",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "vote-commitment-tree",
+]
+
+[[package]]
+name = "voting-circuits"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d8bd9964ce4aef9152a66ad8950af529de4bbbd875bfd9e5d95534abc50df9"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "halo2_gadgets",
+ "halo2_poseidon",
+ "halo2_proofs",
+ "incrementalmerkletree",
+ "itertools 0.14.0",
+ "lazy_static",
+ "orchard 0.14.0",
+ "pasta_curves",
+ "rand 0.8.6",
+ "sinsemilla",
+]
 
 [[package]]
 name = "walkdir"
@@ -6090,6 +6783,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -6542,7 +7247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -6553,9 +7258,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap 2.14.0",
- "prettyplease",
+ "prettyplease 0.2.37",
  "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
@@ -6569,7 +7274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
 dependencies = [
  "anyhow",
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6652,47 +7357,55 @@ dependencies = [
 
 [[package]]
 name = "zcash-android-wallet-sdk"
-version = "2.5.1"
+version = "2.6.5"
 dependencies = [
  "anyhow",
+ "bip0039",
  "bitflags",
  "bytes",
- "component",
  "dlopen2",
  "eip681",
  "fs-mistrust",
+ "hex",
  "http",
  "http-body-util",
+ "incrementalmerkletree",
  "jni",
  "libc",
  "log-panics",
  "nonempty",
- "orchard",
+ "orchard 0.15.4",
  "paranoid-android",
- "pczt",
- "prost",
+ "pczt 0.8.0-rc.1",
+ "prost 0.14.3",
  "rand 0.8.6",
  "rayon",
  "rusqlite",
- "rust-analyzer",
  "rust_decimal",
  "sapling-crypto",
  "secrecy",
+ "serde",
+ "serde_json",
+ "shardtree 0.7.1",
  "tonic",
  "tor-rtcompat",
  "tracing",
  "tracing-subscriber",
+ "ur",
+ "ur-registry",
  "uuid",
  "xz2",
- "zcash_address",
+ "zcash_address 0.13.0",
  "zcash_client_backend",
  "zcash_client_sqlite",
  "zcash_note_encryption",
- "zcash_primitives",
+ "zcash_pool_migration_backend",
+ "zcash_primitives 0.29.0",
  "zcash_proofs",
- "zcash_protocol",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent",
+ "zcash_transparent 0.9.0",
+ "zcash_voting",
  "zip32",
 ]
 
@@ -6705,16 +7418,28 @@ dependencies = [
  "bech32",
  "bs58",
  "corez",
- "f4jumble",
+ "f4jumble 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_encoding",
- "zcash_protocol",
+ "zcash_protocol 0.9.0",
+]
+
+[[package]]
+name = "zcash_address"
+version = "0.13.0"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+dependencies = [
+ "bech32",
+ "bs58",
+ "corez",
+ "f4jumble 0.1.1 (git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb)",
+ "zcash_encoding",
+ "zcash_protocol 0.10.0",
 ]
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04583f0945d5ff80eee80c1844fb0af8b7cc46a0ac26d5e12c4ccd474bec0f03"
+version = "0.24.0-rc.1"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
 dependencies = [
  "arti-client",
  "base64",
@@ -6723,9 +7448,9 @@ dependencies = [
  "bls12_381",
  "bs58",
  "byteorder",
- "crossbeam-channel",
  "document-features",
  "dynosaur",
+ "flume",
  "fs-mistrust",
  "futures-util",
  "getset",
@@ -6737,12 +7462,12 @@ dependencies = [
  "incrementalmerkletree",
  "memuse",
  "nonempty",
- "orchard",
+ "orchard 0.15.4",
  "pasta_curves",
- "pczt",
+ "pczt 0.8.0-rc.1",
  "percent-encoding",
  "postcard",
- "prost",
+ "prost 0.14.3",
  "rand 0.8.6",
  "rand_core 0.6.4",
  "rayon",
@@ -6752,10 +7477,9 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "shardtree",
+ "shardtree 0.7.1",
  "subtle",
  "time",
- "time-core",
  "tokio",
  "tokio-rustls",
  "tonic",
@@ -6766,24 +7490,23 @@ dependencies = [
  "tracing",
  "trait-variant",
  "webpki-roots",
- "which",
- "zcash_address",
+ "which 8.0.2",
+ "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_keys",
+ "zcash_keys 0.15.0",
  "zcash_note_encryption",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent",
+ "zcash_transparent 0.9.0",
  "zip32",
  "zip321",
 ]
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b99abb0e534b72705f49cb43d5f1a448844b49b9c48590f87888cb84ce6d29"
+version = "0.22.0-rc.1"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
 dependencies = [
  "bip32",
  "bitflags",
@@ -6796,8 +7519,8 @@ dependencies = [
  "jubjub",
  "maybe-rayon",
  "nonempty",
- "orchard",
- "prost",
+ "orchard 0.15.4",
+ "prost 0.14.3",
  "rand 0.8.6",
  "rand_core 0.6.4",
  "rand_distr",
@@ -6809,28 +7532,28 @@ dependencies = [
  "secp256k1",
  "secrecy",
  "serde",
- "shardtree",
+ "shardtree 0.7.1",
  "static_assertions",
  "subtle",
  "time",
  "tracing",
  "uuid",
- "zcash_address",
+ "zcash_address 0.13.0",
  "zcash_client_backend",
  "zcash_encoding",
- "zcash_keys",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_keys 0.15.0",
+ "zcash_pool_migration_backend",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent",
+ "zcash_transparent 0.9.0",
  "zip32",
 ]
 
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
 dependencies = [
  "corez",
  "hex",
@@ -6844,6 +7567,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fbcdfbb5c8edb247439d72a397abaae9b7dd14a1c070e7e4fc3536924f9065f"
 dependencies = [
  "bech32",
+ "blake2b_simd",
+ "bls12_381",
+ "bs58",
+ "corez",
+ "document-features",
+ "group",
+ "memuse",
+ "nonempty",
+ "orchard 0.14.0",
+ "rand_core 0.6.4",
+ "sapling-crypto",
+ "secrecy",
+ "subtle",
+ "tracing",
+ "zcash_address 0.12.0",
+ "zcash_encoding",
+ "zcash_protocol 0.9.0",
+ "zcash_transparent 0.8.0",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_keys"
+version = "0.15.0"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+dependencies = [
+ "bech32",
  "bip32",
  "blake2b_simd",
  "bls12_381",
@@ -6854,30 +7604,49 @@ dependencies = [
  "group",
  "memuse",
  "nonempty",
- "orchard",
+ "orchard 0.15.4",
  "rand_core 0.6.4",
  "sapling-crypto",
  "secrecy",
  "subtle",
  "tracing",
- "zcash_address",
+ "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_protocol",
- "zcash_transparent",
+ "zcash_protocol 0.10.0",
+ "zcash_transparent 0.9.0",
  "zip32",
 ]
 
 [[package]]
 name = "zcash_note_encryption"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77efec759c3798b6e4d829fcc762070d9b229b0f13338c40bf993b7b609c2272"
+checksum = "e1cb1b9170c94370e3d66c5cc0877661db743337588b64de7711239eed462198"
 dependencies = [
  "chacha20",
  "chacha20poly1305",
  "cipher",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "zcash_pool_migration_backend"
+version = "0.1.0"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+dependencies = [
+ "corez",
+ "getset",
+ "incrementalmerkletree",
+ "libm",
+ "orchard 0.15.4",
+ "pczt 0.8.0-rc.1",
+ "rand_core 0.6.4",
+ "shardtree 0.7.1",
+ "zcash_client_backend",
+ "zcash_keys 0.15.0",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
 ]
 
 [[package]]
@@ -6898,7 +7667,36 @@ dependencies = [
  "jubjub",
  "memuse",
  "nonempty",
- "orchard",
+ "orchard 0.14.0",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "sha2 0.10.9",
+ "zcash_encoding",
+ "zcash_note_encryption",
+ "zcash_protocol 0.9.0",
+ "zcash_script",
+ "zcash_transparent 0.8.0",
+]
+
+[[package]]
+name = "zcash_primitives"
+version = "0.29.0"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+dependencies = [
+ "blake2b_simd",
+ "block-buffer 0.11.0-rc.3",
+ "corez",
+ "crypto-common 0.2.0-rc.1",
+ "document-features",
+ "equihash",
+ "ff",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "memuse",
+ "nonempty",
+ "orchard 0.15.4",
  "rand_core 0.6.4",
  "redjubjub",
  "sapling-crypto",
@@ -6906,16 +7704,15 @@ dependencies = [
  "sha2 0.10.9",
  "zcash_encoding",
  "zcash_note_encryption",
- "zcash_protocol",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent",
+ "zcash_transparent 0.9.0",
 ]
 
 [[package]]
 name = "zcash_proofs"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de6b0ca82e08a9d38b1121f87c5b180b5feac19fecba074cb582882210d2371"
+version = "0.29.0"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6930,7 +7727,7 @@ dependencies = [
  "sapling-crypto",
  "tracing",
  "xdg",
- "zcash_primitives",
+ "zcash_primitives 0.29.0",
 ]
 
 [[package]]
@@ -6938,6 +7735,18 @@ name = "zcash_protocol"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bec496a0bd62dae98c4b26f51c5dab112d0c5350bbc2ccfdfd05bb3454f714d"
+dependencies = [
+ "corez",
+ "document-features",
+ "hex",
+ "memuse",
+ "zcash_encoding",
+]
+
+[[package]]
+name = "zcash_protocol"
+version = "0.10.0"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
 dependencies = [
  "corez",
  "document-features",
@@ -6989,11 +7798,81 @@ dependencies = [
  "secp256k1",
  "sha2 0.10.9",
  "subtle",
- "zcash_address",
+ "zcash_address 0.12.0",
  "zcash_encoding",
- "zcash_protocol",
+ "zcash_protocol 0.9.0",
  "zcash_script",
  "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_transparent"
+version = "0.9.0"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+dependencies = [
+ "bip32",
+ "bs58",
+ "corez",
+ "document-features",
+ "getset",
+ "hex",
+ "nonempty",
+ "ripemd 0.1.3",
+ "secp256k1",
+ "sha2 0.10.9",
+ "subtle",
+ "zcash_address 0.13.0",
+ "zcash_encoding",
+ "zcash_protocol 0.10.0",
+ "zcash_script",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_voting"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a0f6ac52e66228393eab773dcec0eacbb6e1c768e0b6e0675d89d3a78ef53f1"
+dependencies = [
+ "anyhow",
+ "blake2b_simd",
+ "bytes",
+ "ff",
+ "group",
+ "halo2_gadgets",
+ "halo2_proofs",
+ "hex",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "imt-tree",
+ "incrementalmerkletree",
+ "nonempty",
+ "orchard 0.14.0",
+ "pasta_curves",
+ "pczt 0.7.0",
+ "pir-client",
+ "pir-types",
+ "rand 0.8.6",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sinsemilla",
+ "subtle",
+ "thiserror 2.0.18",
+ "tokio",
+ "valar-spiral-rs",
+ "valar-ypir",
+ "vote-commitment-tree",
+ "vote-commitment-tree-client",
+ "voting-circuits",
+ "zcash_keys 0.14.0",
+ "zcash_primitives 0.28.0",
+ "zcash_protocol 0.9.0",
  "zip32",
 ]
 
@@ -7068,15 +7947,14 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fef061351aa99792deb8f62b00426863a317ca2cb124c9de85550e3ef0f0f2f"
+version = "0.9.0-rc.1"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
 dependencies = [
  "base64",
  "nom",
  "percent-encoding",
- "zcash_address",
- "zcash_protocol",
+ "zcash_address 0.13.0",
+ "zcash_protocol 0.10.0",
 ]
 
 [[package]]

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -12,12 +12,20 @@ rust-version = "1.92"
 
 [dependencies]
 # Zcash dependencies
-orchard = "0.14"
-pczt = { version = "0.7", features = ["prover", "orchard", "sapling"] }
+# Ironwood (NU6.3): tracks the same git rev as [patch.crates-io] below directly, since its
+# version (0.15.0) can't satisfy crates-io requirements while pinned to a ZIP 374 branch rev.
+orchard = { version = "0.15", features = ["unstable-voting-circuits"] }
+# Orchard->Ironwood migration engine (core/upstream implementation) — path dependency on the local
+# librustzcash checkout (this crate isn't published to crates.io). Replaces the former hand-rolled
+# `zcash_pool_migration` crate. The SQLite persistence side (formerly the separate
+# `zcash_pool_migration_sqlite` crate) has since been folded into `zcash_client_sqlite::pool_migration`
+# (see that dependency's `[patch.crates-io]` entry below) — no separate dependency needed for it.
+zcash_pool_migration_backend = { version = "0.1.0", features = ["wallet"] }
+pczt = { version = "0.8.0-rc.1", features = ["prover", "orchard", "sapling", "signer"] }
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
-transparent = { package = "zcash_transparent", version = "0.8", default-features = false }
-zcash_address = "0.12"
-zcash_client_backend = { version = "0.23", features = [
+transparent = { package = "zcash_transparent", version = "0.9", default-features = false }
+zcash_address = "0.13"
+zcash_client_backend = { version = "0.24.0-rc.1", features = [
     "orchard",
     "lightwalletd-tonic-tls-webpki-roots",
     "tor",
@@ -25,14 +33,19 @@ zcash_client_backend = { version = "0.23", features = [
     "unstable",
     "pczt",
 ] }
-zcash_client_sqlite = { version = "0.21", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
+zcash_client_sqlite = { version = "0.22.0-rc.1", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
 zcash_note_encryption = "0.4.1"
-zcash_primitives = "0.28"
-zcash_proofs = "0.28"
-zcash_protocol = "0.9"
+zcash_primitives = "0.29"
+zcash_proofs = "0.29"
+zcash_protocol = "0.10"
 zcash_script = "0.4"
 zip32 = "0.2"
 eip681 = "0.1.0"
+# Used by migration_finalize.rs to read `ShardTreeError`/`QueryError` variants when checking
+# note-witness availability at a migration transaction's anchor boundary.
+shardtree = "0.7"
+# Used by migration_engine.rs / migration_keystone.rs to construct Orchard witness positions.
+incrementalmerkletree = { version = "0.8", default-features = false }
 
 # Infrastructure
 prost = "0.14"
@@ -77,16 +90,52 @@ xz2 = { version = "0.1", features = ["static"] }
 component = "0.1.1"
 rust-analyzer = "0.0.1"
 
-## Uncomment this to test librustzcash changes locally
-#[patch.crates-io]
-#pczt = { package = "pczt", path = '../../clones/librustzcash/pczt' }
-#transparent = { package = "zcash_transparent", path = '../../clones/librustzcash/zcash_protocol' }
-#zcash_address = { path = '../../clones/librustzcash/components/zcash_address' }
-#zcash_client_backend = { path = '../../clones/librustzcash/zcash_client_backend' }
-#zcash_client_sqlite = { path = '../../clones/librustzcash/zcash_client_sqlite' }
-#zcash_primitives = { path = '../../clones/librustzcash/zcash_primitives' }
-#zcash_proofs = { path = '../../clones/librustzcash/zcash_proofs' }
-#zcash_protocol = { path = '../../clones/librustzcash/zcash_protocol' }
+# Keystone hardware-wallet batch signing for the Orchard migration flow.
+#
+# The compiled `keystone-sdk-android` AAR this project's Kotlin layer otherwise depends on
+# (co.electriccoin.zcash ui-lib) is stale (last release Oct 2025) and has no batch-signing API —
+# only single-PCZT `generatePczt`/`parsePczt`. Batch signing for Zcash (firmware + these UR
+# envelope types) was added to the Keystone ecosystem within the last month, but hasn't reached a
+# new Android SDK release yet. `chainapsis/vizor-wallet` (a different Zcash wallet, run by the
+# same contributors behind the Keystone firmware/core PRs) bypasses the compiled AAR entirely by
+# depending on `keystone-sdk-rust`'s `ur-registry` crate and `ur-rs` directly from git — this
+# mirrors that exact, verified-working pattern instead of waiting on an Android SDK release.
+# The actual batching primitive is `pczt::roles::signer::batch` (see the `signer` feature above),
+# not Keystone-specific; these crates only provide the outer UR/QR envelope.
+ur = { git = "https://github.com/KeystoneHQ/ur-rs", tag = "0.3.3" }
+ur-registry = { git = "https://github.com/KeystoneHQ/keystone-sdk-rust", package = "ur-registry", default-features = false, features = ["std"] }
+
+## Local librustzcash checkout, on main-latest (tracks upstream origin/main directly — as of
+## 2026-07-22 this has absorbed Danny/core team's former feat/pool-migration-sqlite stack (PR
+## #2669), account-keying the pool-migration store (PR #2712 + FK fixup #2720), and proving the
+## transfer at schedule time plus anchor-retention/proving-key-cache follow-ups (PR #2710 +
+## #2728/#2729/#2730/#2734)) — needed for zcash_pool_migration_backend above and
+## zcash_client_sqlite::pool_migration below. orchard is patched to the exact rev main pins
+## (0.15.0 isn't on crates.io yet with ZIP 374 support), everything else is a local path for fast
+## iteration.
+##
+## The pool-migration store is now scoped per-account (`PoolMigrations::for_account`, see
+## `migration_engine.rs`'s `Backend::new`) — the former singleton-per-pool cross-account collision
+## (see `project_core_migration_swap` notes) is resolved by this pull, not just documented.
+## `zcash_pool_migration_backend::engine::MigrationProver` (prove_transfer/prove_preparation) is
+## new, additive, and NOT yet adopted here — our own `migration_finalize.rs` hand-rolled proving
+## stopgap still does the job and is a separate follow-up to retire (it needs mutable wallet
+## commitment-tree access our current `Backend<'a, W>` doesn't hold, not a drop-in swap).
+## `#2716` (note locking) is NOT merged yet as of this pull — nothing to adopt there.
+[patch.crates-io]
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+zcash_pool_migration_backend = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+zip321 = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+pczt = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+equihash = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
 
 ## Uncomment this to test someone else's librustzcash changes in a branch
 #[patch.crates-io]
@@ -98,6 +147,13 @@ rust-analyzer = "0.0.1"
 #zcash_primitives = { git = "https://github.com/zcash/librustzcash", branch = "main" }
 #zcash_proofs = { git = "https://github.com/zcash/librustzcash", branch = "main" }
 #zcash_protocol = { git = "https://github.com/zcash/librustzcash", branch = "main" }
+
+[dev-dependencies]
+# Test-only: converts a BIP-39 mnemonic phrase to seed bytes for `migration::live_wallet_tests`,
+# which needs a real UnifiedSpendingKey to exercise the in-process-signing path
+# (`commit_preparation`) against a real wallet DB fixture — the app itself never uses this crate
+# (Kotlin does the mnemonic-to-seed conversion, Rust always receives already-derived seed bytes).
+bip0039 = "0.12"
 
 [lib]
 name = "zcashwalletsdk"

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/Backend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/Backend.kt
@@ -267,6 +267,8 @@ interface Backend {
         saplingRoots: List<JniSubtreeRoot>,
         orchardStartIndex: Long,
         orchardRoots: List<JniSubtreeRoot>,
+        ironwoodStartIndex: Long,
+        ironwoodRoots: List<JniSubtreeRoot>,
     )
 
     /**

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/FakeRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/FakeRustBackend.kt
@@ -38,6 +38,8 @@ class FakeRustBackend(
         saplingRoots: List<JniSubtreeRoot>,
         orchardStartIndex: Long,
         orchardRoots: List<JniSubtreeRoot>,
+        ironwoodStartIndex: Long,
+        ironwoodRoots: List<JniSubtreeRoot>,
     ) {
         error("Intentionally not implemented yet.")
     }

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/MigrationRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/MigrationRustBackend.kt
@@ -79,6 +79,37 @@ class MigrationRustBackend private constructor() {
             lockRemainingOrchardBalanceNative(dbDataPath, networkId, accountUuidBytes)
         }
 
+    /**
+     * DEBUG ONLY: wipes this account's in-progress migration entirely, so the next propose/commit
+     * call starts completely fresh. Not exposed to production users. Returns the number of
+     * migration rows deleted (0 or 1).
+     */
+    @Throws(RuntimeException::class)
+    suspend fun clearMigration(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray
+    ): Int =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            clearMigrationNative(dbDataPath, networkId, accountUuidBytes)
+        }
+
+    /**
+     * DEBUG ONLY: reschedules every not-yet-broadcast transfer in this account's migration to
+     * become due in quick succession (first ~2.5 min out, then ~5 min apart), for manually testing
+     * real broadcast execution without waiting out ZIP 318's privacy delay. Not exposed to
+     * production users. Returns the number of transfers rescheduled.
+     */
+    @Throws(RuntimeException::class)
+    suspend fun debugRescheduleTransfers(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray
+    ): Int =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            debugRescheduleTransfersNative(dbDataPath, networkId, accountUuidBytes)
+        }
+
     @Throws(RuntimeException::class)
     suspend fun hasOverdueTransfers(
         dbDataPath: String,
@@ -479,6 +510,22 @@ class MigrationRustBackend private constructor() {
         @JvmStatic
         @Throws(RuntimeException::class)
         private external fun lockRemainingOrchardBalanceNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray
+        ): Int
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun clearMigrationNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray
+        ): Int
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun debugRescheduleTransfersNative(
             dbDataPath: String,
             networkId: Int,
             accountUuidBytes: ByteArray

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/MigrationRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/MigrationRustBackend.kt
@@ -1,0 +1,704 @@
+package cash.z.ecc.android.sdk.internal.jni
+
+import androidx.annotation.Keep
+import cash.z.ecc.android.sdk.internal.SdkDispatchers
+import cash.z.ecc.android.sdk.internal.model.migration.JniKeystoneBatchDecodeResult
+import cash.z.ecc.android.sdk.internal.model.migration.JniKeystoneBatchSignedPczts
+import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationProgress
+import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationSchedule
+import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationState
+import cash.z.ecc.android.sdk.internal.model.migration.JniNoteSplitProposal
+import cash.z.ecc.android.sdk.internal.model.migration.JniPreparedTransfer
+import cash.z.ecc.android.sdk.internal.model.migration.JniTransferProposal
+import cash.z.ecc.android.sdk.internal.model.migration.JniUnsignedTransferPczt
+import kotlinx.coroutines.withContext
+
+/**
+ * JNI bridge to the `zcash_pool_migration` crate.
+ *
+ * Unlike [VotingRustBackend], this holds no handle/registry state: `MigrationContext::new` is
+ * cheap and every Rust-side call opens its own connection internally, so every method here is a
+ * self-contained call keyed by [dbDataPath]/[networkId]/[accountUuidBytes].
+ */
+@Keep
+@Suppress("TooManyFunctions")
+class MigrationRustBackend private constructor() {
+    @Throws(RuntimeException::class)
+    suspend fun migrationState(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray
+    ): JniMigrationState =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            migrationStateNative(dbDataPath, networkId, accountUuidBytes)
+                ?: error("migrationState returned null")
+        }
+
+    @Throws(RuntimeException::class)
+    suspend fun migrationProgress(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray
+    ): JniMigrationProgress? =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            migrationProgressNative(dbDataPath, networkId, accountUuidBytes)
+        }
+
+    @Throws(RuntimeException::class)
+    suspend fun isNoteSplitNeeded(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray
+    ): Boolean =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            isNoteSplitNeededNative(dbDataPath, networkId, accountUuidBytes)
+        }
+
+    @Throws(RuntimeException::class)
+    suspend fun estimateMigrationRunCount(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray
+    ): Int =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            estimateMigrationRunCountNative(dbDataPath, networkId, accountUuidBytes)
+        }
+
+    /**
+     * Locks whatever Orchard balance remains spendable for this account (dust below the
+     * migratable threshold, or a residual the user opted out of migrating) so ordinary note
+     * selection excludes it going forward. Returns the number of notes locked.
+     */
+    @Throws(RuntimeException::class)
+    suspend fun lockRemainingOrchardBalance(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray
+    ): Int =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            lockRemainingOrchardBalanceNative(dbDataPath, networkId, accountUuidBytes)
+        }
+
+    @Throws(RuntimeException::class)
+    suspend fun hasOverdueTransfers(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray
+    ): Boolean =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            hasOverdueTransfersNative(dbDataPath, networkId, accountUuidBytes)
+        }
+
+    @Throws(RuntimeException::class)
+    suspend fun hasInvalidTransfers(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray
+    ): Boolean =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            hasInvalidTransfersNative(dbDataPath, networkId, accountUuidBytes)
+        }
+
+    @Throws(RuntimeException::class)
+    suspend fun prepareNoteSplit(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray
+    ): JniNoteSplitProposal =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            prepareNoteSplitNative(dbDataPath, networkId, accountUuidBytes)
+                ?: error("prepareNoteSplit returned null")
+        }
+
+    @Throws(RuntimeException::class)
+    suspend fun signNoteSplit(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray,
+        outputValuesZatoshi: LongArray,
+        feeZatoshi: Long,
+        usk: ByteArray
+    ): JniPreparedTransfer =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            signNoteSplitNative(
+                dbDataPath,
+                networkId,
+                accountUuidBytes,
+                outputValuesZatoshi,
+                feeZatoshi,
+                usk
+            ) ?: error("signNoteSplit returned null")
+        }
+
+    @Throws(RuntimeException::class)
+    suspend fun extractBroadcastTx(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray,
+        pcztBytes: ByteArray
+    ): ByteArray =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            extractBroadcastTxNative(dbDataPath, networkId, accountUuidBytes, pcztBytes)
+                ?: error("extractBroadcastTx returned null")
+        }
+
+    /**
+     * [resultTag]: 0 = Success (requires [txId]), 1 = NetworkError (requires [retryable]),
+     * 2 = InvalidNote, 3 = Expired. [txId] is ignored except for tag 0 — pass an empty array
+     * otherwise.
+     */
+    @Throws(RuntimeException::class)
+    suspend fun recordTransferResult(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray,
+        transferId: String,
+        resultTag: Int,
+        retryable: Boolean,
+        txId: ByteArray
+    ) = withContext(SdkDispatchers.DATABASE_IO) {
+        recordTransferResultNative(
+            dbDataPath,
+            networkId,
+            accountUuidBytes,
+            transferId,
+            resultTag,
+            retryable,
+            txId
+        )
+    }
+
+    @Throws(RuntimeException::class)
+    suspend fun proposeMigrationTransfers(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray,
+        includeResidual: Boolean
+    ): JniMigrationSchedule =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            proposeMigrationTransfersNative(dbDataPath, networkId, accountUuidBytes, includeResidual)
+                ?: error("proposeMigrationTransfers returned null")
+        }
+
+    /**
+     * Proposes the migration schedule directly from a note-split's own output plan — use this
+     * instead of [proposeMigrationTransfers] whenever a split is about to run or just ran, so
+     * every crossing value is guaranteed to match a note the split actually produces (see
+     * `MigrationContext::propose_migration_transfers_from_split`'s Rust doc comment for why).
+     */
+    @Throws(RuntimeException::class)
+    suspend fun proposeMigrationTransfersFromSplit(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray,
+        outputValuesZatoshi: LongArray,
+        feeZatoshi: Long
+    ): JniMigrationSchedule =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            proposeMigrationTransfersFromSplitNative(
+                dbDataPath,
+                networkId,
+                accountUuidBytes,
+                outputValuesZatoshi,
+                feeZatoshi
+            ) ?: error("proposeMigrationTransfersFromSplit returned null")
+        }
+
+    @Throws(RuntimeException::class)
+    suspend fun proposeImmediateMigrationTransfers(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray
+    ): JniMigrationSchedule =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            proposeImmediateMigrationTransfersNative(dbDataPath, networkId, accountUuidBytes)
+                ?: error("proposeImmediateMigrationTransfers returned null")
+        }
+
+    @Suppress("LongParameterList")
+    @Throws(RuntimeException::class)
+    suspend fun signAndStoreMigrationSchedule(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray,
+        schedule: JniMigrationSchedule,
+        usk: ByteArray
+    ) = withContext(SdkDispatchers.DATABASE_IO) {
+        signAndStoreMigrationScheduleNative(
+            dbDataPath,
+            networkId,
+            accountUuidBytes,
+            Array(schedule.transfers.size) { schedule.transfers[it].id },
+            LongArray(schedule.transfers.size) { schedule.transfers[it].amountZatoshi },
+            LongArray(schedule.transfers.size) { schedule.transfers[it].anchorHeight },
+            LongArray(schedule.transfers.size) { schedule.transfers[it].nextExecutableAfterHeight },
+            LongArray(schedule.transfers.size) { schedule.transfers[it].expiryHeight },
+            schedule.estimatedDurationHours,
+            usk
+        )
+    }
+
+    @Throws(RuntimeException::class)
+    suspend fun isSyncRequiredBeforeNextTransfer(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray
+    ): Boolean =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            isSyncRequiredBeforeNextTransferNative(dbDataPath, networkId, accountUuidBytes)
+        }
+
+    @Throws(RuntimeException::class)
+    suspend fun finalizeReadyTransfers(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray
+    ): Int =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            finalizeReadyTransfersNative(dbDataPath, networkId, accountUuidBytes)
+        }
+
+    @Throws(RuntimeException::class)
+    suspend fun nextDueTransfer(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray
+    ): JniPreparedTransfer? =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            nextDueTransferNative(dbDataPath, networkId, accountUuidBytes)
+        }
+
+    @Throws(RuntimeException::class)
+    suspend fun restartCurrentMigrationStep(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray,
+        includeResidual: Boolean
+    ): JniMigrationSchedule =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            restartCurrentMigrationStepNative(dbDataPath, networkId, accountUuidBytes, includeResidual)
+                ?: error("restartCurrentMigrationStep returned null")
+        }
+
+    /**
+     * The pending (due-or-not-yet-due) scheduled transfer's full proposal fields, or `null` if
+     * nothing is scheduled yet (or only the note-split prep transaction is pending).
+     */
+    @Throws(RuntimeException::class)
+    suspend fun pendingTransferProposal(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray
+    ): JniTransferProposal? =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            pendingTransferProposalNative(dbDataPath, networkId, accountUuidBytes)
+        }
+
+    /**
+     * Lists every account's UUID in the wallet database, independent of any live `Synchronizer`.
+     */
+    @Throws(RuntimeException::class)
+    suspend fun getAccountUuids(
+        dbDataPath: String,
+        networkId: Int
+    ): List<ByteArray> =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            getAccountUuidsNative(dbDataPath, networkId).asList()
+        }
+
+    // ----- External signer (Keystone hardware wallet) -----
+
+    @Throws(RuntimeException::class)
+    suspend fun createUnsignedNoteSplitPczt(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray
+    ): ByteArray =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            createUnsignedNoteSplitPcztNative(dbDataPath, networkId, accountUuidBytes)
+                ?: error("createUnsignedNoteSplitPczt returned null")
+        }
+
+    @Throws(RuntimeException::class)
+    suspend fun storeSignedNoteSplitPczt(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray,
+        signedPczt: ByteArray
+    ): JniPreparedTransfer =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            storeSignedNoteSplitPcztNative(dbDataPath, networkId, accountUuidBytes, signedPczt)
+                ?: error("storeSignedNoteSplitPczt returned null")
+        }
+
+    @Throws(RuntimeException::class)
+    suspend fun createUnsignedTransferPczts(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray,
+        schedule: JniMigrationSchedule
+    ): Array<JniUnsignedTransferPczt> =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            createUnsignedTransferPcztsNative(
+                dbDataPath,
+                networkId,
+                accountUuidBytes,
+                Array(schedule.transfers.size) { schedule.transfers[it].id },
+                LongArray(schedule.transfers.size) { schedule.transfers[it].amountZatoshi },
+                LongArray(schedule.transfers.size) { schedule.transfers[it].anchorHeight },
+                LongArray(schedule.transfers.size) { schedule.transfers[it].nextExecutableAfterHeight },
+                LongArray(schedule.transfers.size) { schedule.transfers[it].expiryHeight },
+                schedule.estimatedDurationHours
+            ) ?: error("createUnsignedTransferPczts returned null")
+        }
+
+    /**
+     * [ids]/[pcztBytesList] are parallel arrays — signed PCZTs matched back to their staged
+     * unsigned originals by id, not by array position (`store_signed_schedule_pczts` is
+     * all-or-nothing across whatever set of ids is provided here).
+     */
+    @Throws(RuntimeException::class)
+    suspend fun storeSignedSchedulePczts(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray,
+        ids: Array<String>,
+        pcztBytesList: Array<ByteArray>
+    ) = withContext(SdkDispatchers.DATABASE_IO) {
+        storeSignedSchedulePcztsNative(dbDataPath, networkId, accountUuidBytes, ids, pcztBytesList)
+    }
+
+    // ----- Keystone batch-signing UR bridge (no wallet database access) -----
+
+    /**
+     * Builds the animated multi-part QR frames for a Keystone batch-signing request covering the
+     * optional note-split PCZT (pass `null` when no split is needed) and every schedule
+     * transfer's unsigned PCZT, in that order. [requestId] is an opaque correlation token (e.g. a
+     * UUID's bytes) the device round-trips, checked by [decodeKeystoneSignBatchPart].
+     */
+    @Throws(RuntimeException::class)
+    suspend fun buildKeystoneSignBatchQrParts(
+        requestId: ByteArray,
+        splitUnsignedPczt: ByteArray?,
+        transferUnsignedPczts: Array<ByteArray>,
+        maxFragmentLen: Int
+    ): Array<String> =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            buildKeystoneSignBatchQrPartsNative(
+                requestId,
+                splitUnsignedPczt,
+                transferUnsignedPczts,
+                maxFragmentLen
+            ) ?: error("buildKeystoneSignBatchQrParts returned null")
+        }
+
+    /**
+     * Discards any in-flight multi-part scan session. Call on scan-screen entry so a new attempt
+     * always starts from a clean slate.
+     */
+    @Throws(RuntimeException::class)
+    suspend fun resetKeystoneSignBatchDecoder() =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            resetKeystoneSignBatchDecoderNative()
+        }
+
+    /**
+     * Feeds one scanned QR frame into the active (or a freshly started) decode session. Errors
+     * (including a decoded [JniKeystoneBatchDecodeResult.data] whose request id doesn't match
+     * [expectedRequestId]) reset the session; call [resetKeystoneSignBatchDecoder] before retrying.
+     */
+    @Throws(RuntimeException::class)
+    suspend fun decodeKeystoneSignBatchPart(
+        part: String,
+        expectedRequestId: ByteArray
+    ): JniKeystoneBatchDecodeResult =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            decodeKeystoneSignBatchPartNative(part, expectedRequestId)
+                ?: error("decodeKeystoneSignBatchPart returned null")
+        }
+
+    /**
+     * Applies a completed batch-signing response back to the retained unsigned PCZTs — in the
+     * exact split-then-transfers order they were passed to [buildKeystoneSignBatchQrParts] —
+     * producing signed-but-unproven PCZT bytes for each, ready for
+     * [storeSignedNoteSplitPczt]/[storeSignedSchedulePczts].
+     */
+    @Throws(RuntimeException::class)
+    suspend fun applyKeystoneBatchSignatures(
+        splitUnsignedPczt: ByteArray?,
+        transferUnsignedPczts: Array<ByteArray>,
+        batchSignResponse: ByteArray
+    ): JniKeystoneBatchSignedPczts =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            applyKeystoneBatchSignaturesNative(
+                splitUnsignedPczt,
+                transferUnsignedPczts,
+                batchSignResponse
+            ) ?: error("applyKeystoneBatchSignatures returned null")
+        }
+
+    companion object {
+        suspend fun new(): MigrationRustBackend {
+            RustBackend.loadLibrary()
+
+            return MigrationRustBackend()
+        }
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun migrationStateNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray
+        ): JniMigrationState?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun migrationProgressNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray
+        ): JniMigrationProgress?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun isNoteSplitNeededNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray
+        ): Boolean
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun estimateMigrationRunCountNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray
+        ): Int
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun lockRemainingOrchardBalanceNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray
+        ): Int
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun hasOverdueTransfersNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray
+        ): Boolean
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun hasInvalidTransfersNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray
+        ): Boolean
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun prepareNoteSplitNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray
+        ): JniNoteSplitProposal?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun signNoteSplitNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray,
+            outputValuesZatoshi: LongArray,
+            feeZatoshi: Long,
+            usk: ByteArray
+        ): JniPreparedTransfer?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun extractBroadcastTxNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray,
+            pcztBytes: ByteArray
+        ): ByteArray?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun recordTransferResultNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray,
+            transferId: String,
+            resultTag: Int,
+            retryable: Boolean,
+            txId: ByteArray
+        )
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun proposeMigrationTransfersNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray,
+            includeResidual: Boolean
+        ): JniMigrationSchedule?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun proposeMigrationTransfersFromSplitNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray,
+            outputValuesZatoshi: LongArray,
+            feeZatoshi: Long
+        ): JniMigrationSchedule?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun proposeImmediateMigrationTransfersNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray
+        ): JniMigrationSchedule?
+
+        @JvmStatic
+        @Suppress("LongParameterList")
+        @Throws(RuntimeException::class)
+        private external fun signAndStoreMigrationScheduleNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray,
+            ids: Array<String>,
+            amountsZatoshi: LongArray,
+            anchorHeights: LongArray,
+            nextExecutableAfterHeights: LongArray,
+            expiryHeights: LongArray,
+            estimatedDurationHours: Int,
+            usk: ByteArray
+        )
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun isSyncRequiredBeforeNextTransferNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray
+        ): Boolean
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun finalizeReadyTransfersNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray
+        ): Int
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun nextDueTransferNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray
+        ): JniPreparedTransfer?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun restartCurrentMigrationStepNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray,
+            includeResidual: Boolean
+        ): JniMigrationSchedule?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun getAccountUuidsNative(
+            dbDataPath: String,
+            networkId: Int
+        ): Array<ByteArray>
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun pendingTransferProposalNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray
+        ): JniTransferProposal?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun createUnsignedNoteSplitPcztNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray
+        ): ByteArray?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun storeSignedNoteSplitPcztNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray,
+            signedPczt: ByteArray
+        ): JniPreparedTransfer?
+
+        @JvmStatic
+        @Suppress("LongParameterList")
+        @Throws(RuntimeException::class)
+        private external fun createUnsignedTransferPcztsNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray,
+            ids: Array<String>,
+            amountsZatoshi: LongArray,
+            anchorHeights: LongArray,
+            nextExecutableAfterHeights: LongArray,
+            expiryHeights: LongArray,
+            estimatedDurationHours: Int
+        ): Array<JniUnsignedTransferPczt>?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun storeSignedSchedulePcztsNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray,
+            ids: Array<String>,
+            pcztBytesList: Array<ByteArray>
+        )
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun buildKeystoneSignBatchQrPartsNative(
+            requestId: ByteArray,
+            splitUnsignedPczt: ByteArray?,
+            transferUnsignedPczts: Array<ByteArray>,
+            maxFragmentLen: Int
+        ): Array<String>?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun resetKeystoneSignBatchDecoderNative()
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun decodeKeystoneSignBatchPartNative(
+            part: String,
+            expectedRequestId: ByteArray
+        ): JniKeystoneBatchDecodeResult?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun applyKeystoneBatchSignaturesNative(
+            splitUnsignedPczt: ByteArray?,
+            transferUnsignedPczts: Array<ByteArray>,
+            batchSignResponse: ByteArray
+        ): JniKeystoneBatchSignedPczts?
+    }
+}

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/MigrationRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/MigrationRustBackend.kt
@@ -270,16 +270,6 @@ class MigrationRustBackend private constructor() {
     }
 
     @Throws(RuntimeException::class)
-    suspend fun isSyncRequiredBeforeNextTransfer(
-        dbDataPath: String,
-        networkId: Int,
-        accountUuidBytes: ByteArray
-    ): Boolean =
-        withContext(SdkDispatchers.DATABASE_IO) {
-            isSyncRequiredBeforeNextTransferNative(dbDataPath, networkId, accountUuidBytes)
-        }
-
-    @Throws(RuntimeException::class)
     suspend fun finalizeReadyTransfers(
         dbDataPath: String,
         networkId: Int,
@@ -629,14 +619,6 @@ class MigrationRustBackend private constructor() {
             estimatedDurationHours: Int,
             usk: ByteArray
         )
-
-        @JvmStatic
-        @Throws(RuntimeException::class)
-        private external fun isSyncRequiredBeforeNextTransferNative(
-            dbDataPath: String,
-            networkId: Int,
-            accountUuidBytes: ByteArray
-        ): Boolean
 
         @JvmStatic
         @Throws(RuntimeException::class)

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/MigrationRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/MigrationRustBackend.kt
@@ -142,13 +142,18 @@ class MigrationRustBackend private constructor() {
                 ?: error("prepareNoteSplit returned null")
         }
 
+    /**
+     * [proposalHandle] identifies the Rust-side cached plan to commit and sign — the one whose
+     * proposal ([JniNoteSplitProposal.proposalHandle]) the user reviewed. Throws if that plan is
+     * missing or has been superseded by a later propose/prepare call; the Rust side never signs
+     * anything the handle doesn't identify.
+     */
     @Throws(RuntimeException::class)
     suspend fun signNoteSplit(
         dbDataPath: String,
         networkId: Int,
         accountUuidBytes: ByteArray,
-        outputValuesZatoshi: LongArray,
-        feeZatoshi: Long,
+        proposalHandle: Long,
         usk: ByteArray
     ): JniPreparedTransfer =
         withContext(SdkDispatchers.DATABASE_IO) {
@@ -156,8 +161,7 @@ class MigrationRustBackend private constructor() {
                 dbDataPath,
                 networkId,
                 accountUuidBytes,
-                outputValuesZatoshi,
-                feeZatoshi,
+                proposalHandle,
                 usk
             ) ?: error("signNoteSplit returned null")
         }
@@ -213,26 +217,26 @@ class MigrationRustBackend private constructor() {
         }
 
     /**
-     * Proposes the migration schedule directly from a note-split's own output plan — use this
-     * instead of [proposeMigrationTransfers] whenever a split is about to run or just ran, so
-     * every crossing value is guaranteed to match a note the split actually produces (see
-     * `MigrationContext::propose_migration_transfers_from_split`'s Rust doc comment for why).
+     * Renders the transfer schedule of the exact cached plan [proposalHandle] identifies (the one
+     * whose note split the user was just shown by [prepareNoteSplit]) — use this instead of
+     * [proposeMigrationTransfers] whenever a split is about to run or just ran, so the schedule
+     * shown is guaranteed to belong to the same plan as the split. Unlike
+     * [proposeMigrationTransfers] this never re-plans; it throws if the identified plan is
+     * missing or superseded. The returned schedule carries the SAME handle.
      */
     @Throws(RuntimeException::class)
     suspend fun proposeMigrationTransfersFromSplit(
         dbDataPath: String,
         networkId: Int,
         accountUuidBytes: ByteArray,
-        outputValuesZatoshi: LongArray,
-        feeZatoshi: Long
+        proposalHandle: Long
     ): JniMigrationSchedule =
         withContext(SdkDispatchers.DATABASE_IO) {
             proposeMigrationTransfersFromSplitNative(
                 dbDataPath,
                 networkId,
                 accountUuidBytes,
-                outputValuesZatoshi,
-                feeZatoshi
+                proposalHandle
             ) ?: error("proposeMigrationTransfersFromSplit returned null")
         }
 
@@ -253,25 +257,25 @@ class MigrationRustBackend private constructor() {
             proposeImmediateSendMaxNative(dbDataPath, networkId, accountUuidBytes)
         }
 
-    @Suppress("LongParameterList")
+    /**
+     * Commits and signs the migration plan [proposalHandle] identifies. No schedule fields cross
+     * the boundary — the plan's details live only on the Rust side, and this throws if the
+     * identified plan is missing or has been superseded by a later propose/prepare call, so it
+     * can only ever sign the exact schedule the user was shown.
+     */
     @Throws(RuntimeException::class)
     suspend fun signAndStoreMigrationSchedule(
         dbDataPath: String,
         networkId: Int,
         accountUuidBytes: ByteArray,
-        schedule: JniMigrationSchedule,
+        proposalHandle: Long,
         usk: ByteArray
     ) = withContext(SdkDispatchers.DATABASE_IO) {
         signAndStoreMigrationScheduleNative(
             dbDataPath,
             networkId,
             accountUuidBytes,
-            Array(schedule.transfers.size) { schedule.transfers[it].id },
-            LongArray(schedule.transfers.size) { schedule.transfers[it].amountZatoshi },
-            LongArray(schedule.transfers.size) { schedule.transfers[it].anchorHeight },
-            LongArray(schedule.transfers.size) { schedule.transfers[it].nextExecutableAfterHeight },
-            LongArray(schedule.transfers.size) { schedule.transfers[it].expiryHeight },
-            schedule.estimatedDurationHours,
+            proposalHandle,
             usk
         )
     }
@@ -352,14 +356,20 @@ class MigrationRustBackend private constructor() {
 
     // ----- External signer (Keystone hardware wallet) -----
 
+    /**
+     * Commits the migration plan [proposalHandle] identifies (unsigned — external-signer path)
+     * and returns the note split's unsigned PCZT. Same handle contract as [signNoteSplit]: throws
+     * if the identified plan is missing or superseded.
+     */
     @Throws(RuntimeException::class)
     suspend fun createUnsignedNoteSplitPczt(
         dbDataPath: String,
         networkId: Int,
-        accountUuidBytes: ByteArray
+        accountUuidBytes: ByteArray,
+        proposalHandle: Long
     ): ByteArray =
         withContext(SdkDispatchers.DATABASE_IO) {
-            createUnsignedNoteSplitPcztNative(dbDataPath, networkId, accountUuidBytes)
+            createUnsignedNoteSplitPcztNative(dbDataPath, networkId, accountUuidBytes, proposalHandle)
                 ?: error("createUnsignedNoteSplitPczt returned null")
         }
 
@@ -375,24 +385,24 @@ class MigrationRustBackend private constructor() {
                 ?: error("storeSignedNoteSplitPczt returned null")
         }
 
+    /**
+     * Builds the unsigned transfer PCZTs of the migration plan [proposalHandle] identifies
+     * (committing it first if [createUnsignedNoteSplitPczt] hasn't already). Same handle contract
+     * as [signAndStoreMigrationSchedule].
+     */
     @Throws(RuntimeException::class)
     suspend fun createUnsignedTransferPczts(
         dbDataPath: String,
         networkId: Int,
         accountUuidBytes: ByteArray,
-        schedule: JniMigrationSchedule
+        proposalHandle: Long
     ): Array<JniUnsignedTransferPczt> =
         withContext(SdkDispatchers.DATABASE_IO) {
             createUnsignedTransferPcztsNative(
                 dbDataPath,
                 networkId,
                 accountUuidBytes,
-                Array(schedule.transfers.size) { schedule.transfers[it].id },
-                LongArray(schedule.transfers.size) { schedule.transfers[it].amountZatoshi },
-                LongArray(schedule.transfers.size) { schedule.transfers[it].anchorHeight },
-                LongArray(schedule.transfers.size) { schedule.transfers[it].nextExecutableAfterHeight },
-                LongArray(schedule.transfers.size) { schedule.transfers[it].expiryHeight },
-                schedule.estimatedDurationHours
+                proposalHandle
             ) ?: error("createUnsignedTransferPczts returned null")
         }
 
@@ -574,8 +584,7 @@ class MigrationRustBackend private constructor() {
             dbDataPath: String,
             networkId: Int,
             accountUuidBytes: ByteArray,
-            outputValuesZatoshi: LongArray,
-            feeZatoshi: Long,
+            proposalHandle: Long,
             usk: ByteArray
         ): JniPreparedTransfer?
 
@@ -615,8 +624,7 @@ class MigrationRustBackend private constructor() {
             dbDataPath: String,
             networkId: Int,
             accountUuidBytes: ByteArray,
-            outputValuesZatoshi: LongArray,
-            feeZatoshi: Long
+            proposalHandle: Long
         ): JniMigrationSchedule?
 
         @JvmStatic
@@ -628,18 +636,12 @@ class MigrationRustBackend private constructor() {
         ): ByteArray
 
         @JvmStatic
-        @Suppress("LongParameterList")
         @Throws(RuntimeException::class)
         private external fun signAndStoreMigrationScheduleNative(
             dbDataPath: String,
             networkId: Int,
             accountUuidBytes: ByteArray,
-            ids: Array<String>,
-            amountsZatoshi: LongArray,
-            anchorHeights: LongArray,
-            nextExecutableAfterHeights: LongArray,
-            expiryHeights: LongArray,
-            estimatedDurationHours: Int,
+            proposalHandle: Long,
             usk: ByteArray
         )
 
@@ -696,7 +698,8 @@ class MigrationRustBackend private constructor() {
         private external fun createUnsignedNoteSplitPcztNative(
             dbDataPath: String,
             networkId: Int,
-            accountUuidBytes: ByteArray
+            accountUuidBytes: ByteArray,
+            proposalHandle: Long
         ): ByteArray?
 
         @JvmStatic
@@ -709,18 +712,12 @@ class MigrationRustBackend private constructor() {
         ): JniPreparedTransfer?
 
         @JvmStatic
-        @Suppress("LongParameterList")
         @Throws(RuntimeException::class)
         private external fun createUnsignedTransferPcztsNative(
             dbDataPath: String,
             networkId: Int,
             accountUuidBytes: ByteArray,
-            ids: Array<String>,
-            amountsZatoshi: LongArray,
-            anchorHeights: LongArray,
-            nextExecutableAfterHeights: LongArray,
-            expiryHeights: LongArray,
-            estimatedDurationHours: Int
+            proposalHandle: Long
         ): Array<JniUnsignedTransferPczt>?
 
         @JvmStatic

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/MigrationRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/MigrationRustBackend.kt
@@ -7,6 +7,7 @@ import cash.z.ecc.android.sdk.internal.model.migration.JniKeystoneBatchSignedPcz
 import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationProgress
 import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationSchedule
 import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationState
+import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationTransferStates
 import cash.z.ecc.android.sdk.internal.model.migration.JniNoteSplitProposal
 import cash.z.ecc.android.sdk.internal.model.migration.JniPreparedTransfer
 import cash.z.ecc.android.sdk.internal.model.migration.JniTransferProposal
@@ -235,15 +236,21 @@ class MigrationRustBackend private constructor() {
             ) ?: error("proposeMigrationTransfersFromSplit returned null")
         }
 
+    /**
+     * Proposes an ordinary send-max transaction sweeping all spendable Orchard funds into this
+     * account's own Ironwood receiver — bypasses the migration engine entirely (no `MigrationState`
+     * is read or written). Returns the proposal proto-encoded exactly like an ordinary send's
+     * `RustBackend.proposeTransfer`, for decoding via the same
+     * `Proposal.fromByteArray`/`ProposalUnsafe.parse` path.
+     */
     @Throws(RuntimeException::class)
-    suspend fun proposeImmediateMigrationTransfers(
+    suspend fun proposeImmediateSendMax(
         dbDataPath: String,
         networkId: Int,
         accountUuidBytes: ByteArray
-    ): JniMigrationSchedule =
+    ): ByteArray =
         withContext(SdkDispatchers.DATABASE_IO) {
-            proposeImmediateMigrationTransfersNative(dbDataPath, networkId, accountUuidBytes)
-                ?: error("proposeImmediateMigrationTransfers returned null")
+            proposeImmediateSendMaxNative(dbDataPath, networkId, accountUuidBytes)
         }
 
     @Suppress("LongParameterList")
@@ -287,6 +294,22 @@ class MigrationRustBackend private constructor() {
     ): JniPreparedTransfer? =
         withContext(SdkDispatchers.DATABASE_IO) {
             nextDueTransferNative(dbDataPath, networkId, accountUuidBytes)
+        }
+
+    /**
+     * The live, persisted status (broadcast/mined vs. still pending, plus current
+     * `scheduled_height`) of every committed transfer transaction, read straight from the
+     * migration store — reflects any reschedule immediately, unlike the app's own cached plan.
+     * Returns `null` if there's no in-progress migration.
+     */
+    @Throws(RuntimeException::class)
+    suspend fun migrationTransferStates(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray
+    ): JniMigrationTransferStates? =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            migrationTransferStatesNative(dbDataPath, networkId, accountUuidBytes)
         }
 
     @Throws(RuntimeException::class)
@@ -598,11 +621,11 @@ class MigrationRustBackend private constructor() {
 
         @JvmStatic
         @Throws(RuntimeException::class)
-        private external fun proposeImmediateMigrationTransfersNative(
+        private external fun proposeImmediateSendMaxNative(
             dbDataPath: String,
             networkId: Int,
             accountUuidBytes: ByteArray
-        ): JniMigrationSchedule?
+        ): ByteArray
 
         @JvmStatic
         @Suppress("LongParameterList")
@@ -635,6 +658,14 @@ class MigrationRustBackend private constructor() {
             networkId: Int,
             accountUuidBytes: ByteArray
         ): JniPreparedTransfer?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun migrationTransferStatesNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray
+        ): JniMigrationTransferStates?
 
         @JvmStatic
         @Throws(RuntimeException::class)

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/MigrationRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/MigrationRustBackend.kt
@@ -343,6 +343,20 @@ class MigrationRustBackend private constructor() {
         }
 
     /**
+     * The zatoshi value below which a leftover post-migration Orchard balance is treated as dust
+     * rather than a residual worth migrating in its own transfer — see
+     * `MIGRATION_DUST_THRESHOLD_ZATOSHI` in `migration.rs`. A fixed protocol-level constant, not
+     * derived from any wallet/account state — still routed through `SdkDispatchers.DATABASE_IO`
+     * only for consistency with every other call in this class, not because it touches a
+     * database.
+     */
+    @Throws(RuntimeException::class)
+    suspend fun migrationDustThresholdZatoshi(): Long =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            migrationDustThresholdZatoshiNative()
+        }
+
+    /**
      * Lists every account's UUID in the wallet database, independent of any live `Synchronizer`.
      */
     @Throws(RuntimeException::class)
@@ -677,6 +691,10 @@ class MigrationRustBackend private constructor() {
             accountUuidBytes: ByteArray,
             includeResidual: Boolean
         ): JniMigrationSchedule?
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun migrationDustThresholdZatoshiNative(): Long
 
         @JvmStatic
         @Throws(RuntimeException::class)

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/RustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/RustBackend.kt
@@ -287,6 +287,8 @@ class RustBackend private constructor(
         saplingRoots: List<JniSubtreeRoot>,
         orchardStartIndex: Long,
         orchardRoots: List<JniSubtreeRoot>,
+        ironwoodStartIndex: Long,
+        ironwoodRoots: List<JniSubtreeRoot>,
     ) = withContext(SdkDispatchers.DATABASE_IO) {
         putSubtreeRoots(
             dataDbFile.absolutePath,
@@ -294,6 +296,8 @@ class RustBackend private constructor(
             saplingRoots.toTypedArray(),
             orchardStartIndex,
             orchardRoots.toTypedArray(),
+            ironwoodStartIndex,
+            ironwoodRoots.toTypedArray(),
             networkId = networkId
         )
     }
@@ -553,7 +557,7 @@ class RustBackend private constructor(
     companion object {
         internal val rustLibraryLoader = NativeLibraryLoader("zcashwalletsdk")
 
-        private val rustLogging: RustLogging = RustLogging.Off
+        private val rustLogging: RustLogging = RustLogging.Debug
 
         suspend fun loadLibrary() {
             rustLibraryLoader.load {
@@ -781,6 +785,8 @@ class RustBackend private constructor(
             saplingRoots: Array<JniSubtreeRoot>,
             orchardStartIndex: Long,
             orchardRoots: Array<JniSubtreeRoot>,
+            ironwoodStartIndex: Long,
+            ironwoodRoots: Array<JniSubtreeRoot>,
             networkId: Int
         )
 

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/JniAccountBalance.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/JniAccountBalance.kt
@@ -19,6 +19,12 @@ import cash.z.ecc.android.sdk.internal.jni.JNI_ACCOUNT_UUID_BYTES_SIZE
  * @param orchardValuePending The value in the account of all remaining received Orchard
  *        notes that either do not have sufficient confirmations to be spendable, or for
  *        which witnesses cannot yet be constructed without additional scanning.
+ * @param ironwoodVerifiedBalance The verified account balance in the Ironwood pool.
+ * @param ironwoodChangePending The value in the account of Ironwood change notes that do
+ *        not yet have sufficient confirmations to be spendable.
+ * @param ironwoodValuePending The value in the account of all remaining received Ironwood
+ *        notes that either do not have sufficient confirmations to be spendable, or for
+ *        which witnesses cannot yet be constructed without additional scanning.
  * @param unshieldedBalance The total account balance in the transparent pool,
  *        including unconfirmed funds, that must be shielded before use.
  * @throws IllegalArgumentException if the values are inconsistent.
@@ -33,6 +39,9 @@ class JniAccountBalance(
     val orchardVerifiedBalance: Long,
     val orchardChangePending: Long,
     val orchardValuePending: Long,
+    val ironwoodVerifiedBalance: Long,
+    val ironwoodChangePending: Long,
+    val ironwoodValuePending: Long,
     val unshieldedBalance: Long,
 ) {
     init {
@@ -56,6 +65,15 @@ class JniAccountBalance(
         }
         require(orchardValuePending >= MIN_INCLUSIVE) {
             "Orchard value pending $orchardValuePending must by equal or above $MIN_INCLUSIVE"
+        }
+        require(ironwoodVerifiedBalance >= MIN_INCLUSIVE) {
+            "Ironwood verified balance $ironwoodVerifiedBalance must by equal or above $MIN_INCLUSIVE"
+        }
+        require(ironwoodChangePending >= MIN_INCLUSIVE) {
+            "Ironwood change pending $ironwoodChangePending must by equal or above $MIN_INCLUSIVE"
+        }
+        require(ironwoodValuePending >= MIN_INCLUSIVE) {
+            "Ironwood value pending $ironwoodValuePending must by equal or above $MIN_INCLUSIVE"
         }
         require(unshieldedBalance >= MIN_INCLUSIVE) {
             "Unshielded balance $unshieldedBalance must by equal or above $MIN_INCLUSIVE"

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/JniWalletSummary.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/JniWalletSummary.kt
@@ -20,6 +20,8 @@ import cash.z.ecc.android.sdk.internal.ext.isInUIntRange
  *        the next range of subtree roots passed to `Backend.putSaplingSubtreeRoots`.
  * @param nextOrchardSubtreeIndex the Orchard subtree index that should start
  *        the next range of subtree roots passed to `Backend.putOrchardSubtreeRoots`.
+ * @param nextIronwoodSubtreeIndex the Ironwood subtree index that should start
+ *        the next range of subtree roots passed to `Backend.putSubtreeRoots`.
  * @throws IllegalArgumentException unless (progressNumerator is nonnegative,
  *         progressDenominator is positive, and the represented ratio is in the
  *         range 0.0 to 1.0 inclusive).
@@ -36,6 +38,7 @@ class JniWalletSummary(
     val recoveryProgressDenominator: Long?,
     val nextSaplingSubtreeIndex: Long,
     val nextOrchardSubtreeIndex: Long,
+    val nextIronwoodSubtreeIndex: Long,
 ) {
     init {
         require(chainTipHeight.isInUIntRange()) {
@@ -88,6 +91,9 @@ class JniWalletSummary(
         }
         require(nextOrchardSubtreeIndex.isInUIntRange()) {
             "Height $nextOrchardSubtreeIndex is outside of allowed UInt range"
+        }
+        require(nextIronwoodSubtreeIndex.isInUIntRange()) {
+            "Height $nextIronwoodSubtreeIndex is outside of allowed UInt range"
         }
     }
 }

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/ProposalUnsafe.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/ProposalUnsafe.kt
@@ -2,6 +2,7 @@ package cash.z.ecc.android.sdk.internal.model
 
 import cash.z.wallet.sdk.internal.ffi.ProposalOuterClass.FeeRule
 import cash.z.wallet.sdk.internal.ffi.ProposalOuterClass.Proposal
+import cash.z.wallet.sdk.internal.ffi.ProposalOuterClass.ValuePool
 
 /**
  * A transaction proposal created by the Rust backend in response to a Kotlin request.
@@ -49,4 +50,21 @@ class ProposalUnsafe(
      * Returns the total fee required by this proposal for its transactions.
      */
     fun totalFeeRequired(): Long = inner.stepsList.fold(0) { acc, step -> acc + step.balance.feeRequired }
+
+    /**
+     * Returns whether any step of this proposal directly spends an Orchard note — i.e. an input
+     * whose [ProposedInput] carries a [ReceivedOutput] with [ValuePool.Orchard], not a
+     * back-reference to a prior step's own output ([PriorStepOutput]/[PriorStepChange]). Used to
+     * warn the user before an ordinary (non-migration) send that would spend Orchard funds, since
+     * Orchard's current shielded-pool composition can leak the transaction amount on-chain in a
+     * way Sapling-only spends don't (see the app's Orchard Privacy Warning). A multi-step proposal
+     * whose only Orchard involvement is via a prior-step back-reference is not detected here — that
+     * shape doesn't arise from this wallet's own ordinary send construction.
+     */
+    fun usesOrchardInputs(): Boolean =
+        inner.stepsList.any { step ->
+            step.inputsList.any { input ->
+                input.hasReceivedOutput() && input.receivedOutput.valuePool == ValuePool.Orchard
+            }
+        }
 }

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/ZcashProtocol.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/ZcashProtocol.kt
@@ -13,18 +13,25 @@ enum class ZcashProtocol {
     },
     ORCHARD {
         override val poolCode = 3
+    },
+    // Ironwood (NU6.3): must match zcash_client_sqlite's own pool-type encoding exactly
+    // (PoolType::Shielded(ShieldedPool::Ironwood) => 4i64 in wallet/encoding.rs) — this enum has
+    // no other way to stay in sync with that Rust-side mapping.
+    IRONWOOD {
+        override val poolCode = 4
     };
 
     abstract val poolCode: Int
 
-    fun isShielded() = this == SAPLING || this == ORCHARD
+    fun isShielded() = this == SAPLING || this == ORCHARD || this == IRONWOOD
 
     companion object {
         fun validate(poolTypeCode: Int): Boolean =
             when (poolTypeCode) {
                 TRANSPARENT.poolCode,
                 SAPLING.poolCode,
-                ORCHARD.poolCode -> true
+                ORCHARD.poolCode,
+                IRONWOOD.poolCode -> true
 
                 else -> false
             }
@@ -34,6 +41,7 @@ enum class ZcashProtocol {
                 TRANSPARENT.poolCode -> TRANSPARENT
                 SAPLING.poolCode -> SAPLING
                 ORCHARD.poolCode -> ORCHARD
+                IRONWOOD.poolCode -> IRONWOOD
                 else -> error("Unsupported pool type: $poolCode")
             }
     }

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/migration/JniMigrationModels.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/migration/JniMigrationModels.kt
@@ -10,7 +10,6 @@ import cash.z.ecc.android.sdk.internal.ext.isInUIntRange
 class JniMigrationProgress(
     val completedTransfers: Int,
     val totalTransfers: Int,
-    val remainingOrchardValueZatoshi: Long,
     val nextTransferReadyAtHeight: Long
 ) {
     init {

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/migration/JniMigrationModels.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/migration/JniMigrationModels.kt
@@ -63,6 +63,33 @@ class JniMigrationSchedule(
 )
 
 /**
+ * Serves as cross layer (Kotlin, Rust) communication class. The live, persisted status of one
+ * committed transfer transaction — [id] is its real, stable `MigrationTxId` (same format/value as
+ * `JniTransferProposal.id`), NOT its pool-crossing/funding-note index. ZIP 318 deliberately shuffles
+ * crossing order away from the broadcast-height order the app displays transfers in, so [id] is the
+ * only key that reliably correlates back to a specific `MigrationPlan.transfers` entry (via that
+ * entry's own `id` field).
+ */
+@Keep
+class JniMigrationTransferState(
+    val id: String,
+    val isSent: Boolean,
+    val scheduledHeight: Long
+)
+
+/**
+ * Serves as cross layer (Kotlin, Rust) communication class. The live schedule/status of every
+ * committed transfer transaction, read directly from the persisted migration store — unlike
+ * [JniMigrationSchedule] (a one-time proposal snapshot), this reflects whatever the store's
+ * `scheduled_height`/state columns hold right now, including any later reschedule.
+ */
+@Keep
+class JniMigrationTransferStates(
+    val transfers: Array<JniMigrationTransferState>,
+    val tipHeight: Long
+)
+
+/**
  * Serves as cross layer (Kotlin, Rust) communication class. One transfer's unsigned, proven (self-
  * funding transfers are the exception: not yet proven, per the sign-now/prove-later scheme) PCZT,
  * staged in the engine and awaiting an external signer (e.g. Keystone).

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/migration/JniMigrationModels.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/migration/JniMigrationModels.kt
@@ -24,11 +24,17 @@ class JniMigrationProgress(
 
 /**
  * Serves as cross layer (Kotlin, Rust) communication class.
+ *
+ * [proposalHandle] is the opaque identifier of the Rust-side cached migration plan this proposal
+ * was rendered from. The plan's details never cross the JNI boundary inward: commit calls pass
+ * this handle back, and the Rust side refuses to sign any plan other than the one it identifies
+ * (erroring if a later propose/prepare call superseded it).
  */
 @Keep
 class JniNoteSplitProposal(
     val outputValuesZatoshi: LongArray,
-    val feeZatoshi: Long
+    val feeZatoshi: Long,
+    val proposalHandle: Long
 )
 
 /**
@@ -55,11 +61,15 @@ class JniTransferProposal(
 
 /**
  * Serves as cross layer (Kotlin, Rust) communication class.
+ *
+ * [proposalHandle] identifies the Rust-side cached migration plan this schedule was rendered
+ * from — see [JniNoteSplitProposal.proposalHandle] for the contract.
  */
 @Keep
 class JniMigrationSchedule(
     val transfers: Array<JniTransferProposal>,
-    val estimatedDurationHours: Int
+    val estimatedDurationHours: Int,
+    val proposalHandle: Long
 )
 
 /**

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/migration/JniMigrationModels.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/migration/JniMigrationModels.kt
@@ -1,0 +1,148 @@
+package cash.z.ecc.android.sdk.internal.model.migration
+
+import androidx.annotation.Keep
+import cash.z.ecc.android.sdk.internal.ext.isInUIntRange
+
+/**
+ * Serves as cross layer (Kotlin, Rust) communication class.
+ */
+@Keep
+class JniMigrationProgress(
+    val completedTransfers: Int,
+    val totalTransfers: Int,
+    val remainingOrchardValueZatoshi: Long,
+    val nextTransferReadyAtHeight: Long
+) {
+    init {
+        if (nextTransferReadyAtHeight != -1L) {
+            require(nextTransferReadyAtHeight.isInUIntRange()) {
+                "Height $nextTransferReadyAtHeight is outside of allowed UInt range and is not -1"
+            }
+        }
+    }
+}
+
+/**
+ * Serves as cross layer (Kotlin, Rust) communication class.
+ */
+@Keep
+class JniNoteSplitProposal(
+    val outputValuesZatoshi: LongArray,
+    val feeZatoshi: Long
+)
+
+/**
+ * Serves as cross layer (Kotlin, Rust) communication class.
+ */
+@Keep
+class JniPreparedTransfer(
+    val id: String,
+    val txid: ByteArray,
+    val pcztBytes: ByteArray
+)
+
+/**
+ * Serves as cross layer (Kotlin, Rust) communication class.
+ */
+@Keep
+class JniTransferProposal(
+    val id: String,
+    val amountZatoshi: Long,
+    val anchorHeight: Long,
+    val nextExecutableAfterHeight: Long,
+    val expiryHeight: Long
+)
+
+/**
+ * Serves as cross layer (Kotlin, Rust) communication class.
+ */
+@Keep
+class JniMigrationSchedule(
+    val transfers: Array<JniTransferProposal>,
+    val estimatedDurationHours: Int
+)
+
+/**
+ * Serves as cross layer (Kotlin, Rust) communication class. One transfer's unsigned, proven (self-
+ * funding transfers are the exception: not yet proven, per the sign-now/prove-later scheme) PCZT,
+ * staged in the engine and awaiting an external signer (e.g. Keystone).
+ */
+@Keep
+class JniUnsignedTransferPczt(
+    val id: String,
+    val pcztBytes: ByteArray
+)
+
+/**
+ * Serves as cross layer (Kotlin, Rust) communication class. The result of feeding one scanned QR
+ * frame to the Keystone batch-signing UR decoder — see `migration_keystone::decode_sign_batch_part`.
+ *
+ * [firmwareVersion] is the signing device's raw `[major, minor, build]` firmware version, non-null
+ * once [complete] — read directly from the `zcash-batch-sig-result` envelope's own field, not
+ * scanned out of any signed PCZT (the batch response is signatures-only and never echoes PCZT
+ * bytes back, so a PCZT-proprietary-field scan always comes back empty for this flow).
+ */
+@Keep
+class JniKeystoneBatchDecodeResult(
+    val complete: Boolean,
+    val progress: Int,
+    val data: ByteArray?,
+    val firmwareVersion: ByteArray?
+)
+
+/**
+ * Serves as cross layer (Kotlin, Rust) communication class. The signed-but-unproven PCZT bytes
+ * produced by applying a Keystone batch-signing response back to the retained unsigned PCZTs —
+ * see `migration_keystone::apply_batch_signatures`. `transferSignedPczts` is index-aligned with
+ * whatever order the caller passed the unsigned transfer PCZTs in.
+ */
+@Keep
+class JniKeystoneBatchSignedPczts(
+    val splitSignedPczt: ByteArray?,
+    val transferSignedPczts: Array<ByteArray>
+)
+
+/**
+ * Serves as cross layer (Kotlin, Rust) communication class.
+ */
+@Keep
+sealed class JniAttentionReason {
+    @Keep
+    class InvalidTransfer(
+        val transferId: String
+    ) : JniAttentionReason()
+
+    @Keep
+    class TransferExpired : JniAttentionReason()
+
+    @Keep
+    class SyncRequiredBeforeNext : JniAttentionReason()
+}
+
+/**
+ * Serves as cross layer (Kotlin, Rust) communication class.
+ */
+@Keep
+sealed class JniMigrationState {
+    @Keep
+    class NotStarted : JniMigrationState()
+
+    @Keep
+    class SplitPendingConfirmation : JniMigrationState()
+
+    @Keep
+    class ReadyToPropose : JniMigrationState()
+
+    @Keep
+    class InProgress(
+        val progress: JniMigrationProgress
+    ) : JniMigrationState()
+
+    @Keep
+    class RequiresAttention(
+        val reason: JniAttentionReason
+    ) : JniMigrationState()
+
+    @Keep
+    class Complete : JniMigrationState()
+}

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -42,16 +42,17 @@ use zcash_address::{
 use zcash_client_backend::{
     address::{Address, UnifiedAddress},
     data_api::{
-        Account, AccountBalance, AccountBirthday, AccountPurpose, BirthdayError, InputSource,
-        OutputStatusFilter, SeedRelevance, TransactionDataRequest, TransactionStatus,
-        TransactionStatusFilter, TransparentKeyOrigin, TransparentOutputFilter,
-        WalletCommitmentTrees, WalletRead, WalletSummary, WalletWrite, Zip32Derivation,
+        Account, AccountBalance, AccountBirthday, AccountPurpose, BirthdayError, CoinbaseFilter,
+        InputSource, OutputStatusFilter, SeedRelevance, TransactionDataRequest, TransactionStatus,
+        TransactionStatusFilter, TransparentKeyOrigin, WalletCommitmentTrees, WalletRead,
+        WalletSummary, WalletWrite, Zip32Derivation,
         chain::{CommitmentTreeRoot, ScanSummary, scan_cached_blocks},
         scanning::{ScanPriority, ScanRange},
         wallet::{
             self, create_pczt_from_proposal, create_proposed_transactions,
             decrypt_and_store_transaction, extract_and_store_transaction_from_pczt,
-            input_selection::GreedyInputSelector, propose_shielding, propose_transfer,
+            input_selection::{GreedyInputSelector, LockFilter, SpendPolicy},
+            propose_shielding, propose_transfer,
         },
     },
     encoding::AddressCodec,
@@ -82,7 +83,7 @@ use zcash_primitives::{
 };
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::{
-    ShieldedProtocol,
+    ShieldedPool,
     consensus::{
         BlockHeight, BranchId, Network,
         Network::{MainNetwork, TestNetwork},
@@ -101,6 +102,10 @@ use crate::utils::{
 };
 
 mod eip681;
+mod migration;
+mod migration_engine;
+mod migration_keystone;
+mod migration_plan_cache;
 mod tor;
 mod utils;
 
@@ -1118,7 +1123,10 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_getTotalT
                 &taddr,
                 target,
                 wallet::ConfirmationsPolicy::MIN,
-                TransparentOutputFilter::All,
+                CoinbaseFilter::AllTransparentOutputs,
+                // Balance display, not a spend selection — show the true total regardless of any
+                // lock another in-flight proposal might hold, matching pre-locking behavior.
+                LockFilter::Unfiltered,
             )
             .map_err(|e| anyhow!("Error while fetching verified balance: {}", e))?
             .iter()
@@ -1358,7 +1366,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_rewindToH
         let mut db_data = wallet_db(env, network, db_data)?;
 
         let height = BlockHeight::try_from(height)?;
-        let rewind_result = db_data.rewind_to_height(height);
+        let rewind_result = db_data.truncate_to_height(height);
 
         Ok(encode_rewind_result(env, height, rewind_result)?.into_raw())
     });
@@ -1429,6 +1437,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_putSubtre
     sapling_roots: JObjectArray<'local>,
     orchard_start_index: jlong,
     orchard_roots: JObjectArray<'local>,
+    ironwood_start_index: jlong,
+    ironwood_roots: JObjectArray<'local>,
     network_id: jint,
 ) {
     let res = catch_unwind(&mut env, |env| {
@@ -1469,6 +1479,17 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_putSubtre
             orchard::tree::MerkleHashOrchard::read(n)
         })?;
 
+        // Ironwood is Orchard note-version V3 and shares Orchard's commitment-tree machinery, so
+        // its subtree roots are Orchard-shaped too — reuse the same hash type/parser.
+        let ironwood_start_index = if ironwood_start_index >= 0 {
+            ironwood_start_index as u64
+        } else {
+            return Err(anyhow!("Ironwood start index must be nonnegative."));
+        };
+        let ironwood_roots = parse_roots(env, ironwood_roots, |n| {
+            orchard::tree::MerkleHashOrchard::read(n)
+        })?;
+
         db_data
             .put_sapling_subtree_roots(sapling_start_index, &sapling_roots)
             .map_err(|e| anyhow!("Error while storing Sapling subtree roots: {}", e))?;
@@ -1476,6 +1497,10 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_putSubtre
         db_data
             .put_orchard_subtree_roots(orchard_start_index, &orchard_roots)
             .map_err(|e| anyhow!("Error while storing Orchard subtree roots: {}", e))?;
+
+        db_data
+            .put_ironwood_subtree_roots(ironwood_start_index, &ironwood_roots)
+            .map_err(|e| anyhow!("Error while storing Ironwood subtree roots: {}", e))?;
 
         Ok(())
     });
@@ -1578,11 +1603,17 @@ fn encode_account_balance<'a>(
     let orchard_value_pending =
         ZatBalance::from(balance.orchard_balance().value_pending_spendability());
 
+    let ironwood_verified_balance = ZatBalance::from(balance.ironwood_balance().spendable_value());
+    let ironwood_change_pending =
+        ZatBalance::from(balance.ironwood_balance().change_pending_confirmation());
+    let ironwood_value_pending =
+        ZatBalance::from(balance.ironwood_balance().value_pending_spendability());
+
     let unshielded = ZatBalance::from(balance.unshielded_balance().total());
 
     env.new_object(
         JNI_ACCOUNT_BALANCE,
-        "([BJJJJJJJ)V",
+        "([BJJJJJJJJJJ)V",
         &[
             (&env.byte_array_from_slice(account_uuid.expose_uuid().as_bytes())?).into(),
             JValue::Long(sapling_verified_balance.into()),
@@ -1591,6 +1622,9 @@ fn encode_account_balance<'a>(
             JValue::Long(orchard_verified_balance.into()),
             JValue::Long(orchard_change_pending.into()),
             JValue::Long(orchard_value_pending.into()),
+            JValue::Long(ironwood_verified_balance.into()),
+            JValue::Long(ironwood_change_pending.into()),
+            JValue::Long(ironwood_value_pending.into()),
             JValue::Long(unshielded.into()),
         ],
     )
@@ -1636,7 +1670,7 @@ fn encode_wallet_summary<'a>(
     Ok(env.new_object(
         "cash/z/ecc/android/sdk/internal/model/JniWalletSummary",
         format!(
-            "([L{};JJJJLjava/lang/Long;Ljava/lang/Long;JJ)V",
+            "([L{};JJJJLjava/lang/Long;Ljava/lang/Long;JJJ)V",
             JNI_ACCOUNT_BALANCE
         ),
         &[
@@ -1649,6 +1683,7 @@ fn encode_wallet_summary<'a>(
             JValue::Object(&recovery_progress_denominator),
             JValue::Long(summary.next_sapling_subtree_index() as i64),
             JValue::Long(summary.next_orchard_subtree_index() as i64),
+            JValue::Long(summary.next_ironwood_subtree_index() as i64),
         ],
     )?)
 }
@@ -1964,6 +1999,10 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_putUtxo<'
                 script_pubkey,
             },
             Some(BlockHeight::from(height as u32)),
+            // This JNI entry point has no account context to attribute the UTXO to.
+            None,
+            None,
+            None,
         )
         .ok_or_else(|| anyhow!("UTXO is not P2PKH or P2SH"))?;
 
@@ -2050,7 +2089,7 @@ fn zip317_helper<DbT>(
         MultiOutputChangeStrategy::new(
             StandardFeeRule::Zip317,
             change_memo,
-            ShieldedProtocol::Orchard,
+            ShieldedPool::Orchard,
             DustOutputPolicy::default(),
             SplitPolicy::with_min_output_value(
                 NonZeroUsize::new(4).expect("4 is nonzero"),
@@ -2093,6 +2132,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeTr
             &change_strategy,
             request,
             wallet::ConfirmationsPolicy::default(),
+            &SpendPolicy::default(),
+            None,
             None,
         )
         .map_err(|e| anyhow!("Error creating transaction proposal: {}", e))?;
@@ -2155,6 +2196,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeTr
             &change_strategy,
             request,
             wallet::ConfirmationsPolicy::default(),
+            &SpendPolicy::default(),
+            None,
             None,
         )
         .map_err(|e| anyhow!("Error creating transaction proposal: {}", e))?;
@@ -2290,7 +2333,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeSh
             &from_addrs,
             account_uuid,
             confirmations_policy,
-            TransparentOutputFilter::All,
+            CoinbaseFilter::AllTransparentOutputs,
+            None,
         )
         .map_err(|e| anyhow!("Error while shielding transaction: {}", e))?;
 
@@ -2330,7 +2374,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_createPro
 
         let proposal = Proposal::decode(utils::java_bytes_to_rust(env, &proposal)?.as_slice())
             .map_err(|e| anyhow!("Invalid proposal: {}", e))?
-            .try_into_standard_proposal(&db_data)?;
+            .try_into_standard_proposal(&network, &db_data)?;
 
         let txids = create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
             &mut db_data,
@@ -2379,7 +2423,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_createPcz
 
         let proposal = Proposal::decode(utils::java_bytes_to_rust(env, &proposal)?.as_slice())
             .map_err(|e| anyhow!("Invalid proposal: {}", e))?
-            .try_into_standard_proposal(&db_data)?;
+            .try_into_standard_proposal(&network, &db_data)?;
 
         if proposal.steps().len() == 1 {
             let pczt = create_pczt_from_proposal::<_, _, Infallible, _, Infallible, _>(
@@ -2388,10 +2432,18 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_createPcz
                 account_id,
                 OvkPolicy::Sender,
                 &proposal,
+                None,
+                orchard::builder::BundleType::DEFAULT,
             )
             .map_err(|e| anyhow!("Error creating PCZT from single-step proposal: {}", e))?;
 
-            Ok(utils::rust_bytes_to_java(env, &pczt.serialize())?.into_raw())
+            Ok(utils::rust_bytes_to_java(
+                env,
+                &pczt
+                    .serialize()
+                    .map_err(|e| anyhow!("PCZT encoding error: {:?}", e))?,
+            )?
+            .into_raw())
         } else {
             Err(anyhow!(
                 "Multi-step proposals are not yet supported for PCZT generation."
@@ -2438,7 +2490,13 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_redactPcz
             })
             .finish();
 
-        Ok(utils::rust_bytes_to_java(env, &pczt_with_proofs.serialize())?.into_raw())
+        Ok(utils::rust_bytes_to_java(
+            env,
+            &pczt_with_proofs
+                .serialize()
+                .map_err(|e| anyhow!("PCZT encoding error: {:?}", e))?,
+        )?
+        .into_raw())
     });
     unwrap_exc_or(&mut env, res, ptr::null_mut())
 }
@@ -2488,8 +2546,14 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_addProofs
         let mut prover = Prover::new(pczt);
 
         if prover.requires_orchard_proof() {
+            // Process-wide cached proving key (`zcash_primitives`, adopted 2026-07-23) — building
+            // one is expensive, and this JNI entry point is called on every ordinary shielded send,
+            // not just migrations, so rebuilding it per call was wasted work on every proof.
+            let pk = zcash_primitives::transaction::builder::cached_orchard_proving_key(
+                orchard::circuit::OrchardCircuitVersion::PostNu6_3,
+            );
             prover = prover
-                .create_orchard_proof(&orchard::circuit::ProvingKey::build())
+                .create_orchard_proof(pk)
                 .map_err(|e| anyhow!("Failed to create Orchard proof for PCZT: {:?}", e))?;
         }
         assert!(!prover.requires_orchard_proof());
@@ -2507,7 +2571,13 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_addProofs
 
         let pczt_with_proofs = prover.finish();
 
-        Ok(utils::rust_bytes_to_java(env, &pczt_with_proofs.serialize())?.into_raw())
+        Ok(utils::rust_bytes_to_java(
+            env,
+            &pczt_with_proofs
+                .serialize()
+                .map_err(|e| anyhow!("PCZT encoding error: {:?}", e))?,
+        )?
+        .into_raw())
     });
     unwrap_exc_or(&mut env, res, ptr::null_mut())
 }
@@ -2553,7 +2623,9 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_extractAn
             &mut db_data,
             pczt,
             Some((&spend_vk, &output_vk)),
-            Some(&orchard::circuit::VerifyingKey::build()),
+            Some(&orchard::circuit::VerifyingKey::build(
+                orchard::circuit::OrchardCircuitVersion::PostNu6_3,
+            )),
         )
         .map_err(|e| anyhow!("Failed to extract transaction from PCZT: {:?}", e))?;
 
@@ -3666,10 +3738,13 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_model_TorWalletClient_fet
 // Utility functions
 //
 
-fn parse_protocol(code: i32) -> anyhow::Result<ShieldedProtocol> {
+fn parse_protocol(code: i32) -> anyhow::Result<ShieldedPool> {
     match code {
-        2 => Ok(ShieldedProtocol::Sapling),
-        3 => Ok(ShieldedProtocol::Orchard),
+        2 => Ok(ShieldedPool::Sapling),
+        3 => Ok(ShieldedPool::Orchard),
+        // Must match ZcashProtocol.kt's poolCode and zcash_client_sqlite's own pool-type
+        // encoding (wallet/encoding.rs) exactly.
+        4 => Ok(ShieldedPool::Ironwood),
         _ => Err(anyhow!("Shielded protocol not recognized: {code}")),
     }
 }

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -35,7 +35,7 @@ use jni::{
     sys::{JNI_FALSE, JNI_TRUE, jboolean, jbyteArray, jint, jlong, jobject, jobjectArray},
 };
 use rand::rngs::OsRng;
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension};
 use std::ptr;
 
 use zcash_client_backend::data_api::wallet::input_selection::LockFilter;
@@ -97,7 +97,51 @@ fn open_at(db_path: &std::path::Path, network: Network) -> anyhow::Result<(Walle
     // The pool-migration tables are created by `zcash_client_sqlite`'s own schema migrations
     // (`orchard_ironwood_migration_tables`, run as part of the wallet's normal `init_wallet_db`
     // call, see `lib.rs`), not by this crate — no separate init call needed here.
+    ensure_migration_schema_current(&store_conn)?;
     Ok((wallet, store_conn))
+}
+
+/// Self-heals `orchard_ironwood_migration_transactions` against a wallet created between two
+/// pre-release librustzcash schema revisions.
+///
+/// `orchard_ironwood_migration_tables`'s migration has repeatedly grown its DDL IN PLACE, under
+/// the SAME never-changing `MIGRATION_ID` (account-keying, commit `ff15da7c8f`; this table's
+/// `lock_owner` column, commit `fcf4ceb3b1`) — this is librustzcash's stated, deliberate policy
+/// while the feature is unreleased ("these tables have not been part of a public release... a
+/// developer database must be recreated", `ff15da7c8f`'s commit message), not an oversight. Since
+/// `schemerz` never re-runs a migration whose id it already recorded as applied, and the DDL is
+/// `CREATE TABLE IF NOT EXISTS` (a no-op on an existing table), a wallet that already ran this
+/// migration under an OLDER shape keeps that older shape forever and crashes with "no such
+/// column" the moment newer code queries the missing one (confirmed live twice now: `account_id`,
+/// then `lock_owner`).
+///
+/// Rather than requiring a full wallet wipe on every such churn, patch the one column difference
+/// we've hit directly: idempotent (checks before altering), and a no-op if the table doesn't
+/// exist yet (a wallet that has never attempted a migration) or already has the column.
+fn ensure_migration_schema_current(conn: &Connection) -> anyhow::Result<()> {
+    let table_exists: bool = conn
+        .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'orchard_ironwood_migration_transactions'")
+        .map_err(|e| anyhow!("Error checking migration schema: {}", e))?
+        .exists([])
+        .map_err(|e| anyhow!("Error checking migration schema: {}", e))?;
+    if !table_exists {
+        return Ok(());
+    }
+    let has_lock_owner: bool = conn
+        .prepare(
+            "SELECT 1 FROM pragma_table_info('orchard_ironwood_migration_transactions') \
+             WHERE name = 'lock_owner'",
+        )
+        .map_err(|e| anyhow!("Error checking migration schema: {}", e))?
+        .exists([])
+        .map_err(|e| anyhow!("Error checking migration schema: {}", e))?;
+    if !has_lock_owner {
+        conn.execute_batch(
+            "ALTER TABLE orchard_ironwood_migration_transactions ADD COLUMN lock_owner BLOB",
+        )
+        .map_err(|e| anyhow!("Error patching migration schema (lock_owner): {}", e))?;
+    }
+    Ok(())
 }
 
 fn open(
@@ -650,11 +694,16 @@ fn try_prove(
     };
     match result {
         Ok(()) => Ok(true),
-        Err(ProveError::Prover(
-            WalletProveError::UnknownSpentNote(_)
-            | WalletProveError::AnchorNotFound(_)
-            | WalletProveError::WitnessNotFound(_),
-        )) => Ok(false),
+        Err(ProveError::Prover(reason @ WalletProveError::UnknownSpentNote(_)))
+        | Err(ProveError::Prover(reason @ WalletProveError::AnchorNotFound(_)))
+        | Err(ProveError::Prover(reason @ WalletProveError::WitnessNotFound(_))) => {
+            tracing::debug!(
+                "MIGRATION_DIAG try_prove: {:?} not yet provable (transient): {:?}",
+                id,
+                reason
+            );
+            Ok(false)
+        }
         Err(e) => Err(anyhow!(
             "Error proving migration transaction {:?}: {}",
             id,
@@ -1174,6 +1223,17 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
             })
             .map(|t| (t.id(), t.kind()))
             .collect();
+        tracing::debug!(
+            "MIGRATION_DIAG finalizeReadyTransfers: target={:?}, {} Signed transaction(s) total, \
+             {} prove-ready this call",
+            target,
+            state
+                .transactions()
+                .iter()
+                .filter(|t| matches!(t.state(), MigrationTxState::Signed))
+                .count(),
+            ready.len(),
+        );
 
         let mut finalized_count = 0;
         for (id, kind) in ready {
@@ -1230,6 +1290,22 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
             })
             .collect();
         due.sort_by_key(|t| t.scheduled_height());
+        tracing::debug!(
+            "MIGRATION_DIAG nextDueTransfer: tip={:?}, {} transfer(s) total, states={:?}, {} due now",
+            tip,
+            state
+                .transactions()
+                .iter()
+                .filter(|t| matches!(t.kind(), MigrationTxKind::Transfer { .. }))
+                .count(),
+            state
+                .transactions()
+                .iter()
+                .filter(|t| matches!(t.kind(), MigrationTxKind::Transfer { .. }))
+                .map(|t| (t.id(), t.state(), t.scheduled_height()))
+                .collect::<Vec<_>>(),
+            due.len(),
+        );
 
         let Some(tx) = due.into_iter().next() else {
             return Ok(ptr::null_mut());
@@ -1375,6 +1451,134 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         )
     });
     unwrap_exc_or(&mut env, res, ptr::null_mut())
+}
+
+/// DEBUG ONLY: wipes this account's in-progress migration entirely (every preparation and
+/// transfer transaction, signed or not, proved or not, broadcast or not), so the next
+/// propose/commit call starts completely fresh — for manual testing, not exposed to production
+/// users. Deletes the account's single row in `orchard_ironwood_migrations`; every child table
+/// (`_transactions`, `_crossing_values`, `_prep_inputs`/`_prep_outputs`, `_transaction_deps`)
+/// cascades via its own `ON DELETE CASCADE` foreign key — no separate cleanup needed. Distinct
+/// from `restartCurrentMigrationStepNative`, which recovers a RequiresAttention migration by
+/// re-planning the remaining balance, not wiping it.
+///
+/// Returns the number of migration rows deleted (0 or 1 — the table enforces at most one
+/// in-progress migration per account).
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_clearMigrationNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+) -> jint {
+    let res = catch_unwind(&mut env, |env| {
+        let (_network, _wallet, store_conn) = open(env, db_data, network_id)?;
+        let account = crate::account_id_from_jni(env, account_uuid)?;
+        let deleted = store_conn
+            .execute(
+                "DELETE FROM orchard_ironwood_migrations \
+                 WHERE account_id = (SELECT id FROM accounts WHERE uuid = ?1)",
+                rusqlite::params![account.expose_uuid()],
+            )
+            .map_err(|e| anyhow!("Error clearing migration: {}", e))?;
+        Ok(deleted as jint)
+    });
+    unwrap_exc_or(&mut env, res, 0)
+}
+
+/// DEBUG ONLY: overrides this account's persisted migration schedule so its transfers become due
+/// in quick succession, for manually testing real broadcast execution without waiting out ZIP
+/// 318's privacy-motivated delay (mean ~3h between transfers — see `zcash_pool_migration_backend::
+/// scheduling`'s module doc: this is a deliberate anti-correlation choice, not a technical
+/// requirement). Not exposed to production users.
+///
+/// Only `scheduled_height` (which gates BROADCAST — see `next_broadcastable`) is touched; nothing
+/// about proving, anchors, or dependency-mining is bypassed:
+/// - A transfer's `anchor_boundary` (drawn at commit time) is left exactly as the engine chose it.
+///   It settles (becomes provable) on its own once the chain tip passes it by one block — that
+///   boundary is already a historical, already-mined block when drawn, so this is normally within
+///   about one block regardless of this override, not something this function needs to touch.
+/// - Transfers do NOT depend on each other (confirmed directly: `MigrationTransaction::depends_on`
+///   for a `Transfer` never lists another transfer's id, only the single preparation transaction
+///   that minted its own funding note, if any) — so every transfer can be staggered independently;
+///   there is no need to wait for transfer N to broadcast before N+1 becomes due.
+/// - A transfer whose funding note comes from an actual note-split (preparation) transaction still
+///   genuinely cannot broadcast until that preparation transaction is MINED (`deps_mined`) — this
+///   function does not and cannot bypass that; it only affects how soon a transfer becomes due
+///   once its real dependencies are satisfied.
+///
+/// Every not-yet-broadcast/mined TRANSFER (preparation transactions are left alone) is
+/// rescheduled to `tip + FIRST_DELAY_BLOCKS + i * STRIDE_BLOCKS`, in `i` = the transfers' existing
+/// relative order (by their current `scheduled_height`, so the engine's own ZIP 318 shuffle order
+/// is preserved even though the absolute heights are now compressed) — the first becomes due in
+/// about `FIRST_DELAY_BLOCKS * 75s`, each subsequent one `STRIDE_BLOCKS * 75s` after that.
+///
+/// Returns the number of transfers rescheduled.
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_debugRescheduleTransfersNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+) -> jint {
+    // ~2.5 min to the first transfer, ~5 min between each subsequent one, at the ~75s/block
+    // testnet/mainnet target spacing.
+    const FIRST_DELAY_BLOCKS: u32 = 2;
+    const STRIDE_BLOCKS: u32 = 4;
+
+    let res = catch_unwind(&mut env, |env| {
+        let (_network, wallet, store_conn) = open(env, db_data, network_id)?;
+        let account = crate::account_id_from_jni(env, account_uuid)?;
+        let target = target_height(&wallet)?;
+
+        let migration_id: Option<i64> = store_conn
+            .query_row(
+                "SELECT m.id FROM orchard_ironwood_migrations m \
+                 JOIN accounts a ON a.id = m.account_id \
+                 WHERE a.uuid = ?1",
+                rusqlite::params![account.expose_uuid()],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|e| anyhow!("Error reading migration row: {}", e))?;
+        let Some(migration_id) = migration_id else {
+            return Ok(0);
+        };
+
+        let tx_ids: Vec<i64> = {
+            let mut stmt = store_conn
+                .prepare(
+                    "SELECT tx_id FROM orchard_ironwood_migration_transactions \
+                     WHERE migration_id = ?1 AND kind = 'transfer' \
+                       AND state NOT IN ('broadcast', 'mined') \
+                     ORDER BY scheduled_height ASC",
+                )
+                .map_err(|e| anyhow!("Error preparing transfer query: {}", e))?;
+            stmt.query_map(rusqlite::params![migration_id], |row| row.get(0))
+                .map_err(|e| anyhow!("Error reading pending transfers: {}", e))?
+                .collect::<Result<_, _>>()
+                .map_err(|e| anyhow!("Error reading pending transfers: {}", e))?
+        };
+
+        for (i, tx_id) in tx_ids.iter().enumerate() {
+            let new_height = u32::from(target) + FIRST_DELAY_BLOCKS + (i as u32) * STRIDE_BLOCKS;
+            store_conn
+                .execute(
+                    "UPDATE orchard_ironwood_migration_transactions \
+                     SET scheduled_height = ?1 WHERE migration_id = ?2 AND tx_id = ?3",
+                    rusqlite::params![new_height, migration_id, tx_id],
+                )
+                .map_err(|e| anyhow!("Error rescheduling transfer {tx_id}: {}", e))?;
+        }
+        Ok(tx_ids.len() as jint)
+    });
+    unwrap_exc_or(&mut env, res, 0)
 }
 
 #[unsafe(no_mangle)]

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -1,0 +1,2499 @@
+//! JNI bindings for the migration engine.
+//!
+//! Rewired (2026-07-21) from our own hand-rolled `zcash_pool_migration` crate onto the core/
+//! upstream `zcash_pool_migration_backend` crate plus `zcash_client_sqlite::pool_migration`
+//! (Danny/core team, `zcash/librustzcash` PR #2669 + stack; the SQLite persistence side was later
+//! folded from a standalone `zcash_pool_migration_sqlite` crate into `zcash_client_sqlite` proper).
+//! See `migration_engine.rs` for the adapter wiring our wallet DB into the new engine's traits, and
+//! `docs/superpowers/specs/2026-07-21-current-migration-implementation-spec.md` (zashi-android
+//! repo) for the full gap analysis this rewire is based on.
+//!
+//! Every JNI function here keeps its original signature and JNI-visible behavior so no Kotlin
+//! code needed to change — the engine swap is entirely internal to this file and
+//! `migration_engine.rs`. Two known, deliberate deviations from the old crate's exact semantics:
+//!
+//! 1. The new engine's `Schedule` type has no `anchor_height` (ZIP 374 defers anchor selection to
+//!    proving time, not planning time) — `JniTransferProposal.anchorHeight` is populated with the
+//!    schedule's `broadcast_height()` as a placeholder so the Kotlin type doesn't need to change;
+//!    it no longer carries a real commitment-tree anchor value. Callers must not treat it as one.
+//! 2. `finalizeReadyTransfersNative` and `nextDueTransferNative` prove transactions ahead of
+//!    broadcast (ZIP 374) via `try_prove` (see its doc comment), which wraps
+//!    `zcash_pool_migration_backend`'s own `WalletMigrationProver`/`engine::prove_transfer`/
+//!    `prove_preparation` — adopted 2026-07-23, replacing this file's former hand-ported
+//!    `migration_finalize.rs` stopgap (removed) now that core provides the equivalent built-in.
+//! 3. The commit functions (`signNoteSplitNative`, `signAndStoreMigrationScheduleNative`,
+//!    `createUnsignedNoteSplitPcztNative`, `createUnsignedTransferPcztsNative`) ignore the
+//!    Kotlin-supplied schedule arrays and instead sign the plan cached by the most recent
+//!    `propose*`/`prepare*` call, via `commit_or_reuse`/`migration_plan_cache` — see that module's
+//!    doc comment for why (the new engine's plan types have no public constructor to rebuild one
+//!    from primitives, verified directly, not assumed).
+
+use anyhow::anyhow;
+use jni::{
+    JNIEnv,
+    objects::{JByteArray, JClass, JLongArray, JObject, JObjectArray, JString, JValue},
+    sys::{JNI_FALSE, JNI_TRUE, jboolean, jbyteArray, jint, jlong, jobject, jobjectArray},
+};
+use rand::rngs::OsRng;
+use rusqlite::Connection;
+use std::ptr;
+
+use zcash_client_backend::data_api::wallet::input_selection::LockFilter;
+use zcash_client_backend::data_api::{InputSource, WalletRead, WalletWrite};
+use zcash_client_backend::keys::UnifiedSpendingKey;
+use zcash_client_backend::wallet::{LockOwner, OutputRef};
+use zcash_client_sqlite::AccountUuid;
+use zcash_client_sqlite::util::SystemClock;
+use zcash_protocol::consensus::{BLOCKS_PER_HOUR, BlockHeight, Network, NetworkConstants};
+use zcash_protocol::value::Zatoshis;
+use zcash_protocol::{PoolType, ShieldedPool};
+
+use zcash_pool_migration_backend::engine::{
+    self, MigrationCrypto, MigrationPlan, MigrationState, MigrationTxId, MigrationTxKind,
+    MigrationTxState, PoolMigrationRead, PoolMigrationWrite, ProveError,
+};
+use zcash_pool_migration_backend::wallet::{WalletMigrationProver, WalletProveError};
+
+use crate::migration_engine::Backend;
+use crate::utils::{catch_unwind, exception::unwrap_exc_or};
+
+const JNI_MIGRATION_PROGRESS: &str =
+    "cash/z/ecc/android/sdk/internal/model/migration/JniMigrationProgress";
+const JNI_ATTENTION_REASON: &str =
+    "cash/z/ecc/android/sdk/internal/model/migration/JniAttentionReason";
+const JNI_MIGRATION_STATE: &str =
+    "cash/z/ecc/android/sdk/internal/model/migration/JniMigrationState";
+const JNI_NOTE_SPLIT_PROPOSAL: &str =
+    "cash/z/ecc/android/sdk/internal/model/migration/JniNoteSplitProposal";
+const JNI_PREPARED_TRANSFER: &str =
+    "cash/z/ecc/android/sdk/internal/model/migration/JniPreparedTransfer";
+const JNI_TRANSFER_PROPOSAL: &str =
+    "cash/z/ecc/android/sdk/internal/model/migration/JniTransferProposal";
+const JNI_MIGRATION_SCHEDULE: &str =
+    "cash/z/ecc/android/sdk/internal/model/migration/JniMigrationSchedule";
+const JNI_UNSIGNED_TRANSFER_PCZT: &str =
+    "cash/z/ecc/android/sdk/internal/model/migration/JniUnsignedTransferPczt";
+const JNI_KEYSTONE_BATCH_DECODE_RESULT: &str =
+    "cash/z/ecc/android/sdk/internal/model/migration/JniKeystoneBatchDecodeResult";
+const JNI_KEYSTONE_BATCH_SIGNED_PCZTS: &str =
+    "cash/z/ecc/android/sdk/internal/model/migration/JniKeystoneBatchSignedPczts";
+
+type Wallet = zcash_client_sqlite::WalletDb<Connection, Network, SystemClock, OsRng>;
+
+/// Opens a fresh wallet-read connection plus a second, independent connection for the migration
+/// store (same on-disk file — SQLite supports multiple connections to one file; mirrors the old
+/// `MigrationContext::open_wallet`/`store_conn` pattern, which also opened two connections).
+/// Every JNI function here calls this fresh and drops it at the end (no persistent handle),
+/// exactly like the old file's documented contract.
+///
+/// JNI-free (takes a plain path, not a `JString`) so it — and everything built on top of it — is
+/// callable directly from `cargo test` against a real wallet DB file, without an emulator or a
+/// Kotlin/JNI round-trip. See the `tests` module at the bottom of this file.
+fn open_at(db_path: &std::path::Path, network: Network) -> anyhow::Result<(Wallet, Connection)> {
+    let wallet = Wallet::for_path(db_path.to_path_buf(), network, SystemClock, OsRng)
+        .map_err(|e| anyhow!("Error opening wallet database connection: {}", e))?;
+    let store_conn = Connection::open(db_path)
+        .map_err(|e| anyhow!("Error opening migration store connection: {}", e))?;
+    // The pool-migration tables are created by `zcash_client_sqlite`'s own schema migrations
+    // (`orchard_ironwood_migration_tables`, run as part of the wallet's normal `init_wallet_db`
+    // call, see `lib.rs`), not by this crate — no separate init call needed here.
+    Ok((wallet, store_conn))
+}
+
+fn open(
+    env: &mut JNIEnv,
+    db_data: JString,
+    network_id: jint,
+) -> anyhow::Result<(Network, Wallet, Connection)> {
+    let network = crate::parse_network(network_id as u32)?;
+    let db_path = crate::path_from_jni(env, db_data)?;
+    let (wallet, store_conn) = open_at(&db_path, network)?;
+    Ok((network, wallet, store_conn))
+}
+
+/// The height migration transactions are built/planned against — one past the current tip,
+/// matching the old crate's convention (and `migration_engine::Backend`'s own note-selection
+/// target).
+fn target_height(wallet: &Wallet) -> anyhow::Result<BlockHeight> {
+    let tip = wallet
+        .chain_height()
+        .map_err(|e| anyhow!("chain height lookup failed: {}", e))?
+        .ok_or_else(|| anyhow!("wallet has no chain tip yet"))?;
+    Ok(tip + 1)
+}
+
+/// The wallet's real, currently-witnessable anchor height (the same one ordinary, non-migration
+/// sends use, via `get_target_and_anchor_heights`) — NOT just "chain tip minus one", which isn't
+/// necessarily checkpointed (confirmed live: `root_at_checkpoint_id` returned `None` for a raw
+/// `tip - 1` guess). Used as the anchor for preparation transactions, whose `anchor_boundary()` is
+/// `None` (see `try_prove`'s doc comment).
+fn natural_anchor_height(wallet: &Wallet) -> anyhow::Result<BlockHeight> {
+    wallet
+        .get_target_and_anchor_heights(std::num::NonZeroU32::MIN)
+        .map_err(|e| anyhow!("Error fetching anchor height: {}", e))?
+        .map(|(_, anchor)| anchor)
+        .ok_or_else(|| anyhow!("wallet has no anchor height yet; scan required"))
+}
+
+/// Computes a fresh preview plan and caches it (see `migration_plan_cache`'s module doc for why)
+/// so a later commit call signs exactly this plan, not an independently re-randomized one. Also
+/// returns the wallet's current tip, needed as the "now" reference point when encoding transfer
+/// proposals (see `encode_transfer_proposal`'s doc comment for why this matters).
+///
+/// JNI-free — see `open_at`'s doc comment. Every `MIGRATION_DIAG` log line this crate has needed
+/// so far to diagnose a live bug (anchor/witness resolution, schedule spread, note-split
+/// detection) came from here or `migration_finalize`, both callable directly from `cargo test`.
+fn plan_for(
+    network: &Network,
+    wallet: &Wallet,
+    account: AccountUuid,
+    store_conn: &mut Connection,
+) -> anyhow::Result<(MigrationPlan, BlockHeight)> {
+    let backend = Backend::new(wallet, account, None, store_conn)?;
+    let mut rng = OsRng;
+    let migration_plan = engine::plan_migration(network, &backend, &mut rng)
+        .map_err(|e| anyhow!("Error planning migration: {:?}", e))?;
+    let prep = migration_plan.preparation();
+    tracing::debug!(
+        "MIGRATION_DIAG plan: preparation has {} layer(s), {} prep transaction(s) total, {} \
+         direct-funding note(s) (used as-is, no split needed); funding_notes total={} zat over {} \
+         note(s)",
+        prep.layer_count(),
+        prep.transaction_count(),
+        prep.direct_funding_notes().len(),
+        migration_plan
+            .funding_notes()
+            .iter()
+            .map(|z| u64::from(*z))
+            .sum::<u64>(),
+        migration_plan.funding_notes().len(),
+    );
+    for (layer_idx, layer) in prep.layers().iter().enumerate() {
+        for (tx_idx, prep_tx) in layer.iter().enumerate() {
+            tracing::debug!(
+                "MIGRATION_DIAG plan: prep layer={layer_idx} tx={tx_idx} outputs={:?}",
+                prep_tx.outputs(),
+            );
+        }
+    }
+    for &(note_idx, value) in prep.direct_funding_notes() {
+        tracing::debug!(
+            "MIGRATION_DIAG plan: direct-funding wallet note index={note_idx} value={} zat",
+            u64::from(value),
+        );
+    }
+    let tip = wallet
+        .chain_height()
+        .map_err(|e| anyhow!("chain height lookup failed: {}", e))?
+        .ok_or_else(|| anyhow!("wallet has no chain tip yet"))?;
+    for (i, entry) in migration_plan.schedule().iter().enumerate() {
+        tracing::debug!(
+            "MIGRATION_DIAG plan: transfer[{i}] broadcast_height={:?} ({} blocks from tip {:?}) \
+             expiry_height={:?}",
+            entry.broadcast_height(),
+            i64::from(u32::from(entry.broadcast_height())) - i64::from(u32::from(tip)),
+            tip,
+            entry.expiry_height(),
+        );
+    }
+    crate::migration_plan_cache::set(account, migration_plan.clone());
+    Ok((migration_plan, tip))
+}
+
+fn plan(
+    env: &mut JNIEnv,
+    db_data: JString,
+    network_id: jint,
+    account_uuid: JByteArray,
+) -> anyhow::Result<(MigrationPlan, BlockHeight)> {
+    let (network, wallet, mut store_conn) = open(env, db_data, network_id)?;
+    let account = crate::account_id_from_jni(env, account_uuid)?;
+    plan_for(&network, &wallet, account, &mut store_conn)
+}
+
+/// Returns the already-committed migration state if one exists (non-terminal), otherwise commits
+/// the plan cached by the most recent `plan()` call for `account` — erroring if none was cached
+/// (see `migration_plan_cache`'s module doc). Shared by both the in-process-signing and
+/// external-signer commit paths below; `sign` picks which `commit_preparation`/
+/// `build_preparation_unsigned` variant to run, and whether a spending key is available to the
+/// `Backend` while doing so.
+fn commit_or_reuse(
+    network: &Network,
+    wallet: &Wallet,
+    account: AccountUuid,
+    store_conn: &mut Connection,
+    target: BlockHeight,
+    usk: Option<UnifiedSpendingKey>,
+    sign: impl FnOnce(
+        &Network,
+        BlockHeight,
+        &mut Backend<Wallet>,
+        &MigrationPlan,
+        &mut OsRng,
+    ) -> anyhow::Result<(MigrationState, Vec<(MigrationTxId, Vec<u8>)>)>,
+) -> anyhow::Result<(MigrationState, Vec<(MigrationTxId, Vec<u8>)>)> {
+    {
+        let backend = Backend::new(wallet, account, None, store_conn)?;
+        if let Some(state) = backend
+            .get_migration()
+            .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
+        {
+            if !state.is_terminal() {
+                let unsigned = state
+                    .transactions()
+                    .iter()
+                    .filter(|t| matches!(t.state(), MigrationTxState::AwaitingSignature))
+                    .map(|t| (t.id(), t.pczt().clone()))
+                    .collect();
+                return Ok((state, unsigned));
+            }
+        }
+    }
+    let migration_plan = crate::migration_plan_cache::get(account)
+        .ok_or_else(|| anyhow!("No pending migration proposal — call propose/prepare first"))?;
+    let mut backend = Backend::new(wallet, account, usk, store_conn)?;
+    let mut rng = OsRng;
+    let result = sign(network, target, &mut backend, &migration_plan, &mut rng)?;
+    crate::migration_plan_cache::clear(account);
+    Ok(result)
+}
+
+fn encode_migration_progress<'a>(
+    env: &mut JNIEnv<'a>,
+    completed: usize,
+    total: usize,
+    remaining_orchard_value: Zatoshis,
+    next_transfer_ready_at_height: i64,
+) -> jni::errors::Result<JObject<'a>> {
+    env.new_object(
+        JNI_MIGRATION_PROGRESS,
+        "(IIJJ)V",
+        &[
+            JValue::Int(completed as jint),
+            JValue::Int(total as jint),
+            JValue::Long(u64::from(remaining_orchard_value) as i64),
+            JValue::Long(next_transfer_ready_at_height),
+        ],
+    )
+}
+
+/// Derives the old crate's public `MigrationState` sealed-class shape from the new engine's
+/// persisted `MigrationState` (or its absence). This mapping is necessarily approximate: the new
+/// engine plans and commits the note split + transfer schedule together in one step (see
+/// `plan_migration`/`commit_preparation`'s doc comments), so there is no longer a DB-persisted
+/// "split signed, schedule not yet proposed" moment the way the old crate's
+/// `SplitPendingConfirmation`/`ReadyToPropose` states captured — those two collapse into
+/// `NotStarted` here (nothing has been committed yet). Validate this against real testnet
+/// migration flows and adjust if the app-side UI depends on distinguishing them (see spec doc
+/// §7 item — this was flagged as a known open risk before implementation started).
+fn derive_migration_state<'a>(
+    env: &mut JNIEnv<'a>,
+    wallet: &Wallet,
+    account: AccountUuid,
+    persisted: Option<MigrationState>,
+    tip: BlockHeight,
+) -> anyhow::Result<JObject<'a>> {
+    let Some(state) = persisted else {
+        return Ok(env.new_object(format!("{JNI_MIGRATION_STATE}$NotStarted"), "()V", &[])?);
+    };
+
+    if state.is_terminal() {
+        return match state.status() {
+            engine::MigrationStatus::Complete => {
+                Ok(env.new_object(format!("{JNI_MIGRATION_STATE}$Complete"), "()V", &[])?)
+            }
+            engine::MigrationStatus::Failed => {
+                let reason = env.new_object(
+                    format!("{JNI_ATTENTION_REASON}$TransferExpired"),
+                    "()V",
+                    &[],
+                )?;
+                Ok(env.new_object(
+                    format!("{JNI_MIGRATION_STATE}$RequiresAttention"),
+                    format!("(L{JNI_ATTENTION_REASON};)V"),
+                    &[JValue::Object(&reason)],
+                )?)
+            }
+            _ => unreachable!("is_terminal() only returns true for Complete/Failed"),
+        };
+    }
+
+    let transactions = state.transactions();
+    let total = transactions.len();
+    let completed = transactions
+        .iter()
+        .filter(|t| matches!(t.state(), MigrationTxState::Mined { .. }))
+        .count();
+    let remaining_orchard_value = wallet
+        .get_account(account)
+        .map_err(|e| anyhow!("account lookup failed: {}", e))?
+        .and_then(|_| None::<Zatoshis>)
+        .unwrap_or(Zatoshis::ZERO);
+    let next_ready = state.next_broadcastable(tip);
+    let next_transfer_ready_at_height = next_ready
+        .and_then(|id| transactions.iter().find(|t| t.id() == id))
+        .map_or(-1i64, |_| i64::from(u32::from(tip)));
+
+    let progress = encode_migration_progress(
+        env,
+        completed,
+        total,
+        remaining_orchard_value,
+        next_transfer_ready_at_height,
+    )?;
+    Ok(env.new_object(
+        format!("{JNI_MIGRATION_STATE}$InProgress"),
+        format!("(L{JNI_MIGRATION_PROGRESS};)V"),
+        &[JValue::Object(&progress)],
+    )?)
+}
+
+fn encode_note_split_proposal<'a>(
+    env: &mut JNIEnv<'a>,
+    plan: &MigrationPlan,
+) -> jni::errors::Result<JObject<'a>> {
+    let split = plan.note_split();
+    let values: Vec<i64> = split
+        .crossing_values()
+        .iter()
+        .map(|&v| u64::from(v) as i64)
+        .collect();
+    let values_array = env.new_long_array(values.len() as i32)?;
+    env.set_long_array_region(&values_array, 0, &values)?;
+    let fee = u64::from(split.prep_fees()) as i64;
+
+    env.new_object(
+        JNI_NOTE_SPLIT_PROPOSAL,
+        "([JJ)V",
+        &[JValue::Object(&values_array), JValue::Long(fee)],
+    )
+}
+
+fn encode_transfer_id<'a>(
+    env: &mut JNIEnv<'a>,
+    id: MigrationTxId,
+) -> jni::errors::Result<JString<'a>> {
+    env.new_string(u32::from(id).to_string())
+}
+
+fn decode_transfer_id(env: &mut JNIEnv, id: &JString) -> anyhow::Result<MigrationTxId> {
+    let raw = crate::utils::java_string_to_rust(env, id)?;
+    let idx: u32 = raw
+        .parse()
+        .map_err(|e| anyhow!("Invalid transfer id {}: {}", raw, e))?;
+    Ok(MigrationTxId::new(idx))
+}
+
+/// `anchor_height` here is NOT a real commitment-tree anchor (ZIP 374 defers that to proving time
+/// — see module doc point 1) — it's the wallet's tip *at plan time*, used purely as Kotlin's "now"
+/// reference point: `MigrationDurationFormat.estimatedSecondsBetweenHeights(fromHeight=anchorHeight,
+/// toHeight=nextExecutableAfterHeight)` computes the wait as `(nextExecutableAfterHeight -
+/// anchorHeight) * blockIntervalMillis`. Passing the same value for both (as an earlier version of
+/// this function did) makes that delta always zero — confirmed live: every transfer displayed as
+/// due "Now" regardless of its real `broadcast_height`, even though the schedule itself was
+/// correctly spread out (see the `MIGRATION_DIAG plan:` log in `plan()` above).
+fn encode_transfer_proposal<'a>(
+    env: &mut JNIEnv<'a>,
+    id: MigrationTxId,
+    amount: Zatoshis,
+    anchor_height: BlockHeight,
+    schedule_broadcast_height: BlockHeight,
+    schedule_expiry_height: BlockHeight,
+) -> jni::errors::Result<JObject<'a>> {
+    let id = encode_transfer_id(env, id)?;
+    env.new_object(
+        JNI_TRANSFER_PROPOSAL,
+        "(Ljava/lang/String;JJJJ)V",
+        &[
+            JValue::Object(&id),
+            JValue::Long(u64::from(amount) as i64),
+            JValue::Long(i64::from(u32::from(anchor_height))),
+            JValue::Long(i64::from(u32::from(schedule_broadcast_height))),
+            JValue::Long(i64::from(u32::from(schedule_expiry_height))),
+        ],
+    )
+}
+
+fn encode_migration_schedule<'a>(
+    env: &mut JNIEnv<'a>,
+    plan: &MigrationPlan,
+    tip: BlockHeight,
+) -> anyhow::Result<JObject<'a>> {
+    // `funding_notes()`, NOT `note_split().crossing_values()`: the funding notes are the
+    // post-reconciliation values (crossing_values() minus whatever the smallest denominations
+    // dropped to cover preparation fees) and `schedule()`'s doc explicitly pairs "one entry per
+    // funding note" — zipping against crossing_values() instead silently mispairs amounts with
+    // schedule heights whenever reconciliation drops anything (confirmed live: this produced a
+    // suspiciously perfectly-sorted-by-size transfer list, the opposite of ZIP 318 SHUFFLE's
+    // intent, plus every transfer immediately overdue).
+    //
+    // `funding_notes()` values are the *spent* note values (crossing + note_fee_buffer, i.e. what
+    // funds the transfer's own fee) — NOT what actually lands in the destination pool. The app
+    // shows this as the user-facing transfer amount (Slack #ext-zodl-valargroup 2026-07-21: "only
+    // round values on this [confirm] screen", matching the shielding-transaction convention of
+    // displaying the received amount, fee visible only in the transaction detail), so subtract the
+    // constant fee buffer back out to recover the round `{1,2,5}×10ⁿ` crossing value per note.
+    let funding_notes = plan.funding_notes();
+    let note_fee_buffer = plan.note_split().note_fee_buffer();
+    let schedule = plan.schedule();
+    if funding_notes.len() != schedule.len() {
+        return Err(anyhow!(
+            "Migration plan invariant violated: {} funding notes but {} schedule entries",
+            funding_notes.len(),
+            schedule.len()
+        ));
+    }
+    let crossings: Vec<Zatoshis> = funding_notes
+        .iter()
+        .map(|&note| {
+            (note - note_fee_buffer)
+                .expect("every funding note is crossing + note_fee_buffer by construction")
+        })
+        .collect();
+
+    // The real `MigrationTxId` the engine will assign at commit time numbers every preparation
+    // transaction (across all layers) first, THEN transfers in `schedule()` order (confirmed
+    // directly against `commit_preparation_inner` in `zcash_pool_migration_backend::engine`) — so
+    // transfer `i`'s id is `prep_tx_count + i`, not `i`. Getting this wrong doesn't affect Kotlin
+    // (it tracks transfers by array position, not by this id — confirmed directly against
+    // `MigrationPlanRepository`/`MigrationProgressVM`), but the SDK's own `nextDueTransfer`/
+    // `recordTransferResult` round-trip inside this file depends on ids being internally
+    // consistent, so keep them correct regardless.
+    let prep_tx_count: u32 = plan
+        .preparation()
+        .layers()
+        .iter()
+        .map(|layer| layer.len() as u32)
+        .sum();
+
+    let mut proposals = Vec::with_capacity(schedule.len());
+    for (i, (amount, entry)) in crossings.iter().zip(schedule.iter()).enumerate() {
+        proposals.push((
+            MigrationTxId::new(prep_tx_count + i as u32),
+            *amount,
+            entry.broadcast_height(),
+            entry.expiry_height(),
+        ));
+    }
+    // Kotlin renders "Transfer N" from array position, unsorted (confirmed directly against
+    // `MigrationPlan.kt`/`MigrationReviewScreen.kt`/`MigrationProgressScreen.kt` — no sort
+    // anywhere) — so the displayed order must already be chronological (ZIP 318 SHUFFLE means
+    // funding-note order and broadcast order are deliberately NOT the same; without this sort the
+    // UI showed e.g. "Transfer 1" broadcasting after "Transfer 5", confirmed live and flagged as a
+    // real UX problem, not just cosmetic).
+    proposals.sort_by_key(|(_, _, broadcast_height, _)| *broadcast_height);
+
+    let transfers = crate::utils::rust_vec_to_java(
+        env,
+        proposals,
+        JNI_TRANSFER_PROPOSAL,
+        |env, (id, amount, broadcast, expiry)| {
+            encode_transfer_proposal(env, id, amount, tip, broadcast, expiry)
+        },
+    )?;
+
+    // Estimated duration: span from the earliest to the latest scheduled broadcast height, in
+    // hours (75s/block, matching `zcash_protocol::SECONDS_PER_BLOCK`/`BLOCKS_PER_HOUR`).
+    let estimated_duration_hours = schedule
+        .iter()
+        .map(|e| u32::from(e.broadcast_height()))
+        .max()
+        .zip(
+            schedule
+                .iter()
+                .map(|e| u32::from(e.broadcast_height()))
+                .min(),
+        )
+        .map(|(max, min)| max.saturating_sub(min) / BLOCKS_PER_HOUR)
+        .unwrap_or(0);
+
+    Ok(env.new_object(
+        JNI_MIGRATION_SCHEDULE,
+        format!("([L{JNI_TRANSFER_PROPOSAL};I)V"),
+        &[
+            JValue::Object(&transfers),
+            JValue::Int(estimated_duration_hours as jint),
+        ],
+    )?)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_prepareNoteSplitNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+) -> jobject {
+    let res = catch_unwind(&mut env, |env| {
+        let (migration_plan, _tip) = plan(env, db_data, network_id, account_uuid)?;
+        Ok(encode_note_split_proposal(env, &migration_plan)?.into_raw())
+    });
+    unwrap_exc_or(&mut env, res, ptr::null_mut())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_proposeMigrationTransfersNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+    _include_residual: jboolean,
+) -> jobject {
+    let res = catch_unwind(&mut env, |env| {
+        let (migration_plan, tip) = plan(env, db_data, network_id, account_uuid)?;
+        Ok(encode_migration_schedule(env, &migration_plan, tip)?.into_raw())
+    });
+    unwrap_exc_or(&mut env, res, ptr::null_mut())
+}
+
+/// The new engine plans the note split and the transfer schedule together in one
+/// `plan_migration()` call (the split's realized output values ARE `plan.note_split()
+/// .crossing_values()`, which is exactly what `encode_migration_schedule` already derives the
+/// schedule from) — so this and `proposeMigrationTransfersNative` above are now equivalent; kept
+/// as two JNI entry points only so the Kotlin call sites don't need to change. The double-spend
+/// class of bug this function existed to fix in the old crate (schedule computed independently of
+/// the split's realized output) cannot recur here: there is only ever one plan.
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_proposeMigrationTransfersFromSplitNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+    _output_values_zatoshi: JLongArray<'local>,
+    _fee_zatoshi: jlong,
+) -> jobject {
+    let res = catch_unwind(&mut env, |env| {
+        let (migration_plan, tip) = plan(env, db_data, network_id, account_uuid)?;
+        Ok(encode_migration_schedule(env, &migration_plan, tip)?.into_raw())
+    });
+    unwrap_exc_or(&mut env, res, ptr::null_mut())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_proposeImmediateMigrationTransfersNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+) -> jobject {
+    let res = catch_unwind(&mut env, |env| {
+        let (migration_plan, tip) = plan(env, db_data, network_id, account_uuid)?;
+        Ok(encode_migration_schedule(env, &migration_plan, tip)?.into_raw())
+    });
+    unwrap_exc_or(&mut env, res, ptr::null_mut())
+}
+
+/// Whether transaction `tx` is ready to PROVE at `target_height` (`chain_tip + 1`) — a local copy
+/// of `zcash_pool_migration_backend::state`'s private `MigrationState::prove_ready`, using only its
+/// public surface (`deps_mined`, `anchor_boundary`, `scheduled_height`). Duplicated rather than
+/// relying on `MigrationState::next_provable` because that returns only the SINGLE next-ready
+/// transaction — looping it would re-return the same id forever on a transient witness/anchor
+/// failure (see `try_prove`'s doc comment), whereas our JNI contract proves every ready transaction
+/// in one call.
+fn is_prove_ready(
+    state: &MigrationState,
+    tx: &engine::MigrationTransaction,
+    target_height: BlockHeight,
+) -> bool {
+    if !state.deps_mined(tx.depends_on()) {
+        return false;
+    }
+    match tx.anchor_boundary() {
+        Some(boundary) => u32::from(boundary) + 1 < u32::from(target_height),
+        None => tx.scheduled_height() <= target_height,
+    }
+}
+
+/// Attempts to prove one `Signed` migration transaction in place within `state` — installing its
+/// deferred Orchard anchor and spend witness(es) (ZIP 374) and running the prover, via
+/// `zcash_pool_migration_backend`'s own `WalletMigrationProver` (the core-team-maintained
+/// replacement for this crate's former hand-ported `migration_finalize` stopgap; see that module's
+/// removal and `docs` for context). A transfer proves against its own persisted `anchor_boundary`
+/// (read internally by `engine::prove_transfer`); a preparation transaction carries no drawn
+/// boundary and proves against the wallet's current natural anchor instead, matching
+/// `zcash_pool_migration_backend`'s own `prove_chain_sim.rs` integration test.
+///
+/// Returns `Ok(true)` if proved (`state` now has this transaction `Proved`, with the proven PCZT
+/// replacing the stored one), `Ok(false)` if its witness/anchor isn't resolvable yet — the funding
+/// note hasn't been observed as spendable yet, or its checkpoint hasn't been reached or was pruned
+/// (`WalletProveError::UnknownSpentNote`/`AnchorNotFound`/`WitnessNotFound`) — this is the ordinary
+/// transient "not ready yet" condition, not a failure, matching the old stopgap's `Ok(None)`
+/// contract. Any other error is propagated.
+fn try_prove(
+    wallet: &mut Wallet,
+    account: AccountUuid,
+    fvk: orchard::keys::FullViewingKey,
+    state: &mut MigrationState,
+    id: MigrationTxId,
+    kind: MigrationTxKind,
+) -> anyhow::Result<bool> {
+    let anchor = match kind {
+        MigrationTxKind::Transfer { .. } => None,
+        MigrationTxKind::Preparation { .. } => Some(natural_anchor_height(wallet)?),
+    };
+    let mut prover = WalletMigrationProver::new(wallet, account, fvk);
+    let result = match anchor {
+        None => engine::prove_transfer(&mut prover, state, id),
+        Some(anchor) => engine::prove_preparation(&mut prover, state, id, anchor),
+    };
+    match result {
+        Ok(()) => Ok(true),
+        Err(ProveError::Prover(
+            WalletProveError::UnknownSpentNote(_)
+            | WalletProveError::AnchorNotFound(_)
+            | WalletProveError::WitnessNotFound(_),
+        )) => Ok(false),
+        Err(e) => Err(anyhow!(
+            "Error proving migration transaction {:?}: {}",
+            id,
+            e
+        )),
+    }
+}
+
+/// Proves the note split (the layer-0 preparation transaction) via `try_prove`, persists the
+/// resulting `Proved` state, and extracts the now-complete transaction's bytes and txid — shared by
+/// both signing paths (`signNoteSplitNative`'s in-process signing and
+/// `storeSignedNoteSplitPcztNative`'s Keystone external-signer path). Without proving,
+/// `extractBroadcastTxNative` fails with `OrchardParse(MissingAnchor)` on the merely-signed PCZT
+/// (confirmed live: the Keystone path originally skipped this step entirely).
+fn finalize_note_split(
+    wallet: &mut Wallet,
+    account: AccountUuid,
+    store_conn: &mut Connection,
+    state: &mut MigrationState,
+    id: MigrationTxId,
+) -> anyhow::Result<(Vec<u8>, [u8; 32])> {
+    let fvk = {
+        let backend = Backend::new(wallet, account, None, store_conn)?;
+        backend
+            .orchard_fvk()
+            .map_err(|e| anyhow!("Error reading account FVK: {:?}", e))?
+    };
+    let kind = state
+        .transactions()
+        .iter()
+        .find(|t| t.id() == id)
+        .map(|t| t.kind())
+        .ok_or_else(|| anyhow!("Note-split transaction not found in migration state"))?;
+    let proved = try_prove(wallet, account, fvk, state, id, kind)
+        .map_err(|e| anyhow!("Error finalizing note split: {}", e))?;
+    if !proved {
+        return Err(anyhow!(
+            "Note-split transaction is not yet finalizable — its funding note isn't witnessable yet"
+        ));
+    }
+    {
+        let mut backend = Backend::new(wallet, account, None, store_conn)?;
+        backend
+            .replace_migration(state)
+            .map_err(|e| anyhow!("Error persisting migration state: {:?}", e))?;
+    }
+    let tx = state
+        .transactions()
+        .iter()
+        .find(|t| t.id() == id)
+        .expect("just proved above");
+    let bytes = tx.pczt().to_vec();
+    let extracted = pczt::roles::tx_extractor::TransactionExtractor::new(
+        pczt::Pczt::parse(&bytes).map_err(|e| anyhow!("parse proven note-split pczt: {:?}", e))?,
+    )
+    .extract()
+    .map_err(|e| anyhow!("extract proven note-split tx: {:?}", e))?;
+    let txid: [u8; 32] = *extracted.txid().as_ref();
+    Ok((bytes, txid))
+}
+
+/// In-process signing (software key, not Keystone) of the note split, as its own standalone,
+/// immediately-broadcastable transaction — unlike most of this file's other functions this one is
+/// NOT a thin wrapper deferring everything to the background worker.
+///
+/// Commits and signs the WHOLE migration (split + every transfer) in one pass via
+/// `commit_preparation` — the new engine has no partial/staged commit — matching the ZIP 318
+/// "sign now, prove later" contract our old crate also used (see
+/// `docs/superpowers/specs/2026-07-17-migration-sign-now-prove-later-design.md` in zashi-android).
+/// The split's own transaction is then finalized (proved) and extracted immediately, synchronously,
+/// so this function can return a `PreparedTransfer` the caller broadcasts right away — matching the
+/// old JNI contract exactly. The remaining transfer transactions are left `Signed` in the store for
+/// `MigrationWorker`'s normal `finalizeReadyTransfersNative`/`nextDueTransferNative` loop to pick up
+/// later, once they're actually due.
+///
+/// The split is a preparation transaction: even though it spends an already-witnessed wallet note
+/// directly, ZIP 374 still defers its Orchard anchor/witness to proving time like any other
+/// migration transaction (see `try_prove`'s doc comment) — `finalize_note_split` resolves that
+/// against the wallet's current natural anchor.
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_signNoteSplitNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+    _output_values_zatoshi: JLongArray<'local>,
+    _fee_zatoshi: jlong,
+    usk: JByteArray<'local>,
+) -> jobject {
+    let res = catch_unwind(&mut env, |env| {
+        let (network, mut wallet, mut store_conn) = open(env, db_data, network_id)?;
+        let account = crate::account_id_from_jni(env, account_uuid)?;
+        let usk = crate::decode_usk(env, usk)?;
+        let target = target_height(&wallet)?;
+        let (mut state, _unsigned) = commit_or_reuse(
+            &network,
+            &wallet,
+            account,
+            &mut store_conn,
+            target,
+            Some(usk),
+            |network, target, backend, migration_plan, rng| {
+                let state =
+                    engine::commit_preparation(network, target, backend, migration_plan, rng)
+                        .map_err(|e| anyhow!("Error committing migration: {:?}", e))?;
+                Ok((state, Vec::new()))
+            },
+        )?;
+        let split_id = state
+            .transactions()
+            .iter()
+            .find(|t| matches!(t.kind(), MigrationTxKind::Preparation { layer: 0, .. }))
+            .map(|t| t.id())
+            .ok_or_else(|| anyhow!("Migration has no note-split preparation transaction"))?;
+        let (proven_pczt, txid) =
+            finalize_note_split(&mut wallet, account, &mut store_conn, &mut state, split_id)?;
+
+        let id = encode_transfer_id(env, split_id)?;
+        let txid_obj = crate::utils::rust_bytes_to_java(env, &txid)?;
+        let pczt_obj = crate::utils::rust_bytes_to_java(env, &proven_pczt)?;
+        Ok(env
+            .new_object(
+                JNI_PREPARED_TRANSFER,
+                "(Ljava/lang/String;[B[B)V",
+                &[
+                    JValue::Object(&id),
+                    JValue::Object(&txid_obj),
+                    JValue::Object(&pczt_obj),
+                ],
+            )?
+            .into_raw())
+    });
+    unwrap_exc_or(&mut env, res, ptr::null_mut())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_extractBroadcastTxNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    _db_data: JString<'local>,
+    _network_id: jint,
+    _account_uuid: JByteArray<'local>,
+    pczt_bytes: JByteArray<'local>,
+) -> jbyteArray {
+    let res = catch_unwind(&mut env, |env| {
+        let pczt_bytes = crate::utils::java_bytes_to_rust(env, &pczt_bytes)?;
+        let pczt =
+            pczt::Pczt::parse(&pczt_bytes).map_err(|e| anyhow!("Error parsing PCZT: {:?}", e))?;
+        let tx = pczt::roles::tx_extractor::TransactionExtractor::new(pczt)
+            .extract()
+            .map_err(|e| anyhow!("Error extracting transaction: {:?}", e))?;
+        let mut raw = Vec::new();
+        tx.write(&mut raw)
+            .map_err(|e| anyhow!("Error encoding transaction: {}", e))?;
+        Ok(crate::utils::rust_bytes_to_java(env, &raw)?.into_raw())
+    });
+    unwrap_exc_or(&mut env, res, ptr::null_mut())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_recordTransferResultNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+    transfer_id: JString<'local>,
+    result_tag: jint,
+    _retryable: jboolean,
+    tx_id: JByteArray<'local>,
+) {
+    let res = catch_unwind(&mut env, |env| {
+        let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
+        let account = crate::account_id_from_jni(env, account_uuid)?;
+        let id = decode_transfer_id(env, &transfer_id)?;
+        let mut backend = Backend::new(&wallet, account, None, &mut store_conn)?;
+        match result_tag {
+            // Success: record the broadcast txid. `mark_mined` has no old-crate equivalent call
+            // site (the old crate didn't track a separate "mined" event either) — left unwired.
+            0 => {
+                let txid = crate::parse_txid(env, tx_id)?;
+                let mut state = backend
+                    .get_migration()
+                    .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
+                    .ok_or_else(|| anyhow!("No migration in progress"))?;
+                state.mark_broadcast(id, txid);
+                backend
+                    .replace_migration(&state)
+                    .map_err(|e| anyhow!("Error persisting migration state: {:?}", e))
+            }
+            // NetworkError/InvalidNote/Expired: no destructive state transition exists in the new
+            // engine's public API for "this attempt failed, try again later" — the transaction
+            // stays `Signed`/`AwaitingSignature` and `next_step` will offer it again on the next
+            // call. Nothing to persist.
+            1 | 2 | 3 => Ok(()),
+            other => Err(anyhow!("Unknown TransferResult tag: {}", other)),
+        }
+    });
+    unwrap_exc_or(&mut env, res, ())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_migrationStateNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+) -> jobject {
+    let res = catch_unwind(&mut env, |env| {
+        let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
+        let account = crate::account_id_from_jni(env, account_uuid)?;
+        let tip = target_height(&wallet)? - 1;
+        let backend = Backend::new(&wallet, account, None, &mut store_conn)?;
+        let persisted = backend
+            .get_migration()
+            .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?;
+        Ok(derive_migration_state(env, &wallet, account, persisted, tip)?.into_raw())
+    });
+    unwrap_exc_or(&mut env, res, ptr::null_mut())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_migrationProgressNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+) -> jobject {
+    let res = catch_unwind(&mut env, |env| {
+        let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
+        let account = crate::account_id_from_jni(env, account_uuid)?;
+        let tip = target_height(&wallet)? - 1;
+        let backend = Backend::new(&wallet, account, None, &mut store_conn)?;
+        let persisted = backend
+            .get_migration()
+            .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?;
+        Ok(match persisted {
+            Some(state) if !state.is_terminal() => {
+                let transactions = state.transactions();
+                let completed = transactions
+                    .iter()
+                    .filter(|t| matches!(t.state(), MigrationTxState::Mined { .. }))
+                    .count();
+                let next_ready_height = if state.next_broadcastable(tip).is_some() {
+                    i64::from(u32::from(tip))
+                } else {
+                    -1
+                };
+                encode_migration_progress(
+                    env,
+                    completed,
+                    transactions.len(),
+                    Zatoshis::ZERO,
+                    next_ready_height,
+                )?
+                .into_raw()
+            }
+            _ => ptr::null_mut(),
+        })
+    });
+    unwrap_exc_or(&mut env, res, ptr::null_mut())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_isNoteSplitNeededNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+) -> jboolean {
+    let res = catch_unwind(&mut env, |env| {
+        // `note_split().crossing_values()` is the target `{1,2,5}×10ⁿ` denomination breakdown —
+        // it's computed unconditionally whenever a migration is needed at all, so it's NEVER
+        // empty and checking it here always returned true (confirmed live: this forced Kotlin's
+        // `MigrationReviewVM.kt:186 if (sdk.isNoteSplitNeeded())` branch every time, even when the
+        // wallet's existing notes already matched every target denomination exactly via
+        // `direct_funding_notes()` and zero preparation transactions were actually needed —
+        // `submitNoteSplit` then failed with "no note-split preparation transaction" since there
+        // was nothing to sign). The real signal is whether the preparation plan has any
+        // transactions to build at all.
+        let (migration_plan, _tip) = plan(env, db_data, network_id, account_uuid)?;
+        Ok(if migration_plan.preparation().transaction_count() > 0 {
+            JNI_TRUE
+        } else {
+            JNI_FALSE
+        })
+    });
+    unwrap_exc_or(&mut env, res, JNI_FALSE)
+}
+
+/// How many successive migration runs (see `engine::estimate_migration_runs`'s doc) the account's
+/// current Orchard balance would need, given the engine's per-run note cap. Purely a stateless
+/// preview — it has no memory of prior calls or rounds already committed, so callers must call this
+/// fresh every time they need it rather than caching the result across a multi-round campaign (see
+/// zashi-android's `docs/superpowers/specs/2026-07-22-keystone-multi-round-migration-continuation-design.md`).
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_estimateMigrationRunCountNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+) -> jint {
+    let res = catch_unwind(&mut env, |env| {
+        let (network, wallet, mut store_conn) = open(env, db_data, network_id)?;
+        let account = crate::account_id_from_jni(env, account_uuid)?;
+        let backend = Backend::new(&wallet, account, None, &mut store_conn)?;
+        let mut rng = OsRng;
+        let estimate = engine::estimate_migration_runs(&network, &backend, &mut rng)
+            .map_err(|e| anyhow!("Error estimating migration runs: {:?}", e))?;
+        Ok(estimate.run_count() as jint)
+    });
+    unwrap_exc_or(&mut env, res, 0)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_hasOverdueTransfersNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+) -> jboolean {
+    let res = catch_unwind(&mut env, |env| {
+        let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
+        let account = crate::account_id_from_jni(env, account_uuid)?;
+        let tip = target_height(&wallet)? - 1;
+        let backend = Backend::new(&wallet, account, None, &mut store_conn)?;
+        let persisted = backend
+            .get_migration()
+            .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?;
+        Ok(match persisted {
+            Some(state) if !state.is_terminal() => {
+                if state.next_broadcastable(tip).is_some() {
+                    JNI_TRUE
+                } else {
+                    JNI_FALSE
+                }
+            }
+            _ => JNI_FALSE,
+        })
+    });
+    unwrap_exc_or(&mut env, res, JNI_FALSE)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_hasInvalidTransfersNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+) -> jboolean {
+    let res = catch_unwind(&mut env, |env| {
+        let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
+        let account = crate::account_id_from_jni(env, account_uuid)?;
+        let backend = Backend::new(&wallet, account, None, &mut store_conn)?;
+        let persisted = backend
+            .get_migration()
+            .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?;
+        Ok(match persisted {
+            Some(state) => match state.status() {
+                engine::MigrationStatus::Failed => JNI_TRUE,
+                _ => JNI_FALSE,
+            },
+            None => JNI_FALSE,
+        })
+    });
+    unwrap_exc_or(&mut env, res, JNI_FALSE)
+}
+
+#[unsafe(no_mangle)]
+#[allow(clippy::too_many_arguments)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_signAndStoreMigrationScheduleNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+    _ids: JObjectArray<'local>,
+    _amounts_zatoshi: JLongArray<'local>,
+    _anchor_heights: JLongArray<'local>,
+    _next_executable_after_heights: JLongArray<'local>,
+    _expiry_heights: JLongArray<'local>,
+    _estimated_duration_hours: jint,
+    usk: JByteArray<'local>,
+) {
+    let res = catch_unwind(&mut env, |env| {
+        let (network, wallet, mut store_conn) = open(env, db_data, network_id)?;
+        let account = crate::account_id_from_jni(env, account_uuid)?;
+        let usk = crate::decode_usk(env, usk)?;
+        // The Kotlin-supplied schedule arrays are ignored — `commit_preparation` takes a
+        // `MigrationPlan` value directly, not a caller-echoed schedule, and the new engine's plan
+        // types have no public constructor to rebuild one from primitives (verified against
+        // `zcash_pool_migration_backend`'s source, not assumed). Instead of re-deriving a fresh
+        // (differently-randomized) plan here, `commit_or_reuse` signs exactly the plan the most
+        // recent `propose*`/`prepare*` call cached — see `migration_plan_cache`'s module doc for
+        // why that matters (this was a real, discussed regression risk versus the old crate, which
+        // did sign exactly the caller-echoed values).
+        let target = target_height(&wallet)?;
+        commit_or_reuse(
+            &network,
+            &wallet,
+            account,
+            &mut store_conn,
+            target,
+            Some(usk),
+            |network, target, backend, migration_plan, rng| {
+                let state =
+                    engine::commit_preparation(network, target, backend, migration_plan, rng)
+                        .map_err(|e| anyhow!("Error committing migration schedule: {:?}", e))?;
+                Ok((state, Vec::new()))
+            },
+        )?;
+        Ok(())
+    });
+    unwrap_exc_or(&mut env, res, ())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_isSyncRequiredBeforeNextTransferNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+) -> jboolean {
+    // ZIP 318's sync/broadcast decoupling MUST is enforced app-side (`MigrationWorker.kt`'s
+    // `isSyncRequiredBeforeNextTransfer()` check, unaffected by this rewire — see spec doc §6.8),
+    // not by the migration engine itself in either the old or new crate. This function's own
+    // contract (does the engine think a sync is due before the next transfer) has no direct
+    // equivalent surfaced by the new engine's public API; conservatively return false (no
+    // additional engine-side gate) since the app-side check already covers the ZIP 318
+    // requirement independently.
+    let res = catch_unwind(&mut env, |env| {
+        let _ = open(env, db_data, network_id)?;
+        let _ = crate::account_id_from_jni(env, account_uuid)?;
+        Ok(JNI_FALSE)
+    });
+    unwrap_exc_or(&mut env, res, JNI_FALSE)
+}
+
+/// Advances every due, signed transaction's proving (ZIP 374: installs its real anchor + witness
+/// via the `pczt` `Updater` role and runs the `Prover`, via `try_prove` — see its doc comment).
+/// Proving moves each ready transaction `Signed -> Proved` directly in the persisted
+/// `MigrationState` (no separate side table — the engine's own persistence now tracks proven bytes
+/// as part of the transaction itself, replacing this file's former hand-rolled
+/// `migration_proven_cache`). Idempotent: only `Signed` transactions are candidates, so an
+/// already-proven one is naturally skipped on a later call. Returns the count of transactions newly
+/// proven this call, 0 (not an error) if nothing was ready.
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_finalizeReadyTransfersNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+) -> jint {
+    let res = catch_unwind(&mut env, |env| {
+        let (_network, mut wallet, mut store_conn) = open(env, db_data, network_id)?;
+        let account = crate::account_id_from_jni(env, account_uuid)?;
+        let target = target_height(&wallet)?;
+
+        let (mut state, fvk) = {
+            let backend = Backend::new(&wallet, account, None, &mut store_conn)?;
+            let Some(state) = backend
+                .get_migration()
+                .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
+            else {
+                return Ok(0);
+            };
+            if state.is_terminal() {
+                return Ok(0);
+            }
+            let fvk = backend
+                .orchard_fvk()
+                .map_err(|e| anyhow!("Error reading account FVK: {:?}", e))?;
+            (state, fvk)
+        };
+
+        // Collect ready ids/kinds up front (not while iterating `state.transactions()`) since
+        // `try_prove` needs `&mut state` — see `is_prove_ready`'s doc comment for why this doesn't
+        // just loop `MigrationState::next_provable`.
+        let ready: Vec<(MigrationTxId, MigrationTxKind)> = state
+            .transactions()
+            .iter()
+            .filter(|t| {
+                matches!(t.state(), MigrationTxState::Signed) && is_prove_ready(&state, t, target)
+            })
+            .map(|t| (t.id(), t.kind()))
+            .collect();
+
+        let mut finalized_count = 0;
+        for (id, kind) in ready {
+            if try_prove(&mut wallet, account, fvk.clone(), &mut state, id, kind)
+                .map_err(|e| anyhow!("Error proving transfer {:?}: {}", id, e))?
+            {
+                finalized_count += 1;
+            }
+        }
+        if finalized_count > 0 {
+            let mut backend = Backend::new(&wallet, account, None, &mut store_conn)?;
+            backend
+                .replace_migration(&state)
+                .map_err(|e| anyhow!("Error persisting migration state: {:?}", e))?;
+        }
+        Ok(finalized_count)
+    });
+    unwrap_exc_or(&mut env, res, 0)
+}
+
+/// The next transfer that's due, deps-mined, and already proven (see
+/// `finalizeReadyTransfersNative`, which must have run first this session for anything to be
+/// ready) — or `null` if nothing qualifies yet.
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_nextDueTransferNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+) -> jobject {
+    let res = catch_unwind(&mut env, |env| {
+        let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
+        let account = crate::account_id_from_jni(env, account_uuid)?;
+        let tip = target_height(&wallet)? - 1;
+        let backend = Backend::new(&wallet, account, None, &mut store_conn)?;
+        let Some(state) = backend
+            .get_migration()
+            .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
+        else {
+            return Ok(ptr::null_mut());
+        };
+
+        let mut due: Vec<_> = state
+            .transactions()
+            .iter()
+            .filter(|t| {
+                matches!(t.kind(), MigrationTxKind::Transfer { .. })
+                    && matches!(t.state(), MigrationTxState::Proved)
+                    && t.scheduled_height() <= tip
+                    && state.deps_mined(t.depends_on())
+            })
+            .collect();
+        due.sort_by_key(|t| t.scheduled_height());
+
+        let Some(tx) = due.into_iter().next() else {
+            return Ok(ptr::null_mut());
+        };
+        // `Proved` carries the fully witnessed/anchored/proven PCZT bytes (installed by
+        // `finalizeReadyTransfersNative`'s `try_prove`) — extract the txid directly from them, no
+        // separate cache lookup needed.
+        let bytes = tx.pczt();
+        let extracted = pczt::roles::tx_extractor::TransactionExtractor::new(
+            pczt::Pczt::parse(bytes).map_err(|e| anyhow!("parse proven transfer pczt: {:?}", e))?,
+        )
+        .extract()
+        .map_err(|e| anyhow!("extract proven transfer tx: {:?}", e))?;
+        let txid: [u8; 32] = *extracted.txid().as_ref();
+
+        let id = encode_transfer_id(env, tx.id())?;
+        let txid_obj = crate::utils::rust_bytes_to_java(env, &txid)?;
+        let pczt_obj = crate::utils::rust_bytes_to_java(env, bytes)?;
+        Ok(env
+            .new_object(
+                JNI_PREPARED_TRANSFER,
+                "(Ljava/lang/String;[B[B)V",
+                &[
+                    JValue::Object(&id),
+                    JValue::Object(&txid_obj),
+                    JValue::Object(&pczt_obj),
+                ],
+            )?
+            .into_raw())
+    });
+    unwrap_exc_or(&mut env, res, ptr::null_mut())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_restartCurrentMigrationStepNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+    _include_residual: jboolean,
+) -> jobject {
+    let res = catch_unwind(&mut env, |env| {
+        let (migration_plan, tip) = plan(env, db_data, network_id, account_uuid)?;
+        Ok(encode_migration_schedule(env, &migration_plan, tip)?.into_raw())
+    });
+    unwrap_exc_or(&mut env, res, ptr::null_mut())
+}
+
+/// A fixed, well-known lock owner for the "Lock balance" dust-lock feature
+/// (`MigrationSdk.lockRemainingOrchardBalance`) — not a per-proposal lock, so a stable constant
+/// (not `LockOwner::random`) lets re-invoking the feature re-extend the same lock idempotently
+/// (see `WalletWrite::lock_outputs`'s doc comment on same-owner re-locking) and would let a future
+/// "undo" flow release it via this same token.
+const DUST_LOCK_OWNER: LockOwner = LockOwner::new(*b"zashi-migration-dust-lock-owner!");
+
+/// Locks whatever Orchard balance remains spendable for this account (dust below the migratable
+/// threshold, or a residual the user opted out of migrating) so ordinary note selection — sends,
+/// shielding, and any future migration round — excludes it by default (`LockFilter::Policy`
+/// applied at every real selection call site in this crate and `lib.rs`), per
+/// `MigrationSdk.lockRemainingOrchardBalance`'s contract. The lock has no natural expiry for this
+/// use (it should stay locked indefinitely, unlike a proposal's transient lock), so it's set to
+/// the maximum representable height.
+///
+/// Returns the number of notes locked (0 if there was nothing left to lock).
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_lockRemainingOrchardBalanceNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+) -> jint {
+    let res = catch_unwind(&mut env, |env| {
+        let (_network, mut wallet, _store_conn) = open(env, db_data, network_id)?;
+        let account = crate::account_id_from_jni(env, account_uuid)?;
+        let target = target_height(&wallet)?;
+
+        // Unfiltered: this must see (and re-lock) notes this same call already locked on a prior
+        // invocation, not just ones nothing has locked yet — same-owner re-locking is what makes
+        // repeated taps of "Lock balance" idempotent.
+        let received = wallet
+            .select_unspent_notes(
+                account,
+                &[ShieldedPool::Orchard],
+                target.into(),
+                &[],
+                LockFilter::Unfiltered,
+            )
+            .map_err(|e| anyhow!("Error reading remaining Orchard balance: {}", e))?;
+
+        let outputs: Vec<OutputRef> = received
+            .orchard()
+            .iter()
+            .map(|rn| OutputRef::new(*rn.txid(), PoolType::ORCHARD, u32::from(rn.output_index())))
+            .collect();
+        if outputs.is_empty() {
+            return Ok(0);
+        }
+
+        let locked = wallet
+            .lock_outputs(&outputs, DUST_LOCK_OWNER, BlockHeight::from(u32::MAX))
+            .map_err(|e| anyhow!("Error locking remaining Orchard balance: {:?}", e))?;
+        Ok(locked as jint)
+    });
+    unwrap_exc_or(&mut env, res, 0)
+}
+
+/// Lists every account's UUID (16 raw bytes each) in the wallet database, independent of any
+/// migration engine — unaffected by this rewire (never referenced `zcash_pool_migration`).
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_getAccountUuidsNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+) -> jobjectArray {
+    let res = catch_unwind(&mut env, |env| {
+        let network = crate::parse_network(network_id as u32)?;
+        let db = crate::wallet_db(env, network, db_data)?;
+        let account_ids = match db.get_account_ids() {
+            Ok(ids) => ids,
+            Err(zcash_client_sqlite::error::SqliteClientError::DbError(
+                rusqlite::Error::SqliteFailure(_, Some(ref msg)),
+            )) if msg.contains("no such table") => Vec::new(),
+            Err(e) => return Err(anyhow!("Error listing account ids: {}", e)),
+        };
+        let uuid_bytes: Vec<Vec<u8>> = account_ids
+            .iter()
+            .map(|id| id.expose_uuid().as_bytes().to_vec())
+            .collect();
+        Ok(
+            crate::utils::rust_vec_to_java(env, uuid_bytes, "[B", |env, bytes| {
+                crate::utils::rust_bytes_to_java(env, &bytes)
+            })?
+            .into_raw(),
+        )
+    });
+    unwrap_exc_or(&mut env, res, ptr::null_mut())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_pendingTransferProposalNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+) -> jobject {
+    let res = catch_unwind(&mut env, |env| {
+        let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
+        let account = crate::account_id_from_jni(env, account_uuid)?;
+        let tip = target_height(&wallet)? - 1;
+        let backend = Backend::new(&wallet, account, None, &mut store_conn)?;
+        let persisted = backend
+            .get_migration()
+            .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?;
+        Ok(match persisted {
+            Some(state) if !state.is_terminal() => {
+                match state.next_broadcastable(tip).and_then(|id| {
+                    state
+                        .transactions()
+                        .iter()
+                        .find(|t| t.id() == id)
+                        .map(|t| (id, t))
+                }) {
+                    Some((id, tx)) if matches!(tx.kind(), MigrationTxKind::Transfer { .. }) => {
+                        encode_transfer_proposal(
+                            env,
+                            id,
+                            // Amount isn't retained on `MigrationTransaction` (only in the
+                            // original `MigrationPlan`) — 0 until the caller re-derives it from a
+                            // freshly re-planned schedule if it needs the real value here.
+                            Zatoshis::ZERO,
+                            tip,
+                            tip,
+                            tip,
+                        )?
+                        .into_raw()
+                    }
+                    _ => ptr::null_mut(),
+                }
+            }
+            _ => ptr::null_mut(),
+        })
+    });
+    unwrap_exc_or(&mut env, res, ptr::null_mut())
+}
+
+// ----- External signer (Keystone hardware wallet) -----
+
+/// Fetches the account's ZIP 32 seed fingerprint and account index, required to annotate
+/// external-signer (Keystone) migration PCZTs with `spend_zip32_derivation` — see
+/// `migration_keystone::annotate_spend_zip32_derivation`'s doc comment for why this is needed.
+///
+/// Applied as a post-processing step on whatever unsigned PCZT bytes `commit_or_reuse` returns
+/// (freshly built, or reused from an already-committed migration) rather than inside the `sign`
+/// closure passed to it: `commit_or_reuse` only calls that closure on first commit, so annotating
+/// only there would silently skip already-committed migrations (e.g. ones committed before this
+/// annotation existed) on every later re-entry into the Keystone sign screen.
+fn account_zip32_derivation(
+    wallet: &Wallet,
+    account: AccountUuid,
+) -> anyhow::Result<([u8; 32], zip32::AccountId)> {
+    use zcash_client_backend::data_api::Account;
+
+    let account_info = wallet
+        .get_account(account)
+        .map_err(|e| anyhow!("account lookup failed: {}", e))?
+        .ok_or_else(|| anyhow!("Account not found"))?;
+    let derivation = account_info.source().key_derivation().ok_or_else(|| {
+        anyhow!(
+            "Account has no known ZIP 32 seed fingerprint/account index — cannot annotate \
+             migration PCZTs for external-signer batch signing"
+        )
+    })?;
+    Ok((
+        derivation.seed_fingerprint().to_bytes(),
+        derivation.account_index(),
+    ))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_createUnsignedNoteSplitPcztNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+) -> jbyteArray {
+    let res = catch_unwind(&mut env, |env| {
+        let (network, wallet, mut store_conn) = open(env, db_data, network_id)?;
+        let account = crate::account_id_from_jni(env, account_uuid)?;
+        let target = target_height(&wallet)?;
+        let (state, unsigned) = commit_or_reuse(
+            &network,
+            &wallet,
+            account,
+            &mut store_conn,
+            target,
+            None,
+            |network, target, backend, migration_plan, rng| {
+                let (state, unsigned) = engine::build_preparation_unsigned(
+                    network,
+                    target,
+                    backend,
+                    migration_plan,
+                    rng,
+                )
+                .map_err(|e| anyhow!("Error building unsigned migration PCZTs: {:?}", e))?;
+                Ok((
+                    state,
+                    unsigned.into_iter().map(|tx| tx.into_parts()).collect(),
+                ))
+            },
+        )?;
+        let split_id = state
+            .transactions()
+            .iter()
+            .find(|t| matches!(t.kind(), MigrationTxKind::Preparation { layer: 0, .. }))
+            .map(|t| t.id())
+            .ok_or_else(|| anyhow!("Migration plan has no note-split preparation transaction"))?;
+        let (_id, pczt_bytes) = unsigned
+            .into_iter()
+            .find(|(id, _)| *id == split_id)
+            .ok_or_else(|| anyhow!("Migration plan has no note-split preparation transaction"))?;
+        let (seed_fingerprint, account_index) = account_zip32_derivation(&wallet, account)?;
+        let pczt_bytes = crate::migration_keystone::annotate_spend_zip32_derivation(
+            &pczt_bytes,
+            seed_fingerprint,
+            network.coin_type(),
+            account_index,
+        )
+        .map_err(|e| anyhow!("Error annotating note-split PCZT derivation: {:?}", e))?;
+        Ok(crate::utils::rust_bytes_to_java(env, &pczt_bytes)?.into_raw())
+    });
+    unwrap_exc_or(&mut env, res, ptr::null_mut())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_storeSignedNoteSplitPcztNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+    signed_pczt: JByteArray<'local>,
+) -> jobject {
+    let res = catch_unwind(&mut env, |env| {
+        let (_network, mut wallet, mut store_conn) = open(env, db_data, network_id)?;
+        let account = crate::account_id_from_jni(env, account_uuid)?;
+        let signed_pczt_bytes = crate::utils::java_bytes_to_rust(env, &signed_pczt)?;
+        let mut state = {
+            let backend = Backend::new(&wallet, account, None, &mut store_conn)?;
+            backend
+                .get_migration()
+                .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
+                .ok_or_else(|| anyhow!("No migration committed yet"))?
+        };
+        let split_id = state
+            .transactions()
+            .iter()
+            .find(|t| matches!(t.kind(), MigrationTxKind::Preparation { layer: 0, .. }))
+            .map(|t| t.id())
+            .ok_or_else(|| anyhow!("Migration has no note-split preparation transaction"))?;
+        if !state.apply_signature(split_id, signed_pczt_bytes) {
+            return Err(anyhow!("Error applying note-split signature"));
+        }
+        {
+            let mut backend = Backend::new(&wallet, account, None, &mut store_conn)?;
+            backend
+                .replace_migration(&state)
+                .map_err(|e| anyhow!("Error persisting migration state: {:?}", e))?;
+        }
+        // Resolve the deferred witness/anchor and prove before extraction — without this,
+        // `extractBroadcastTxNative` fails with `OrchardParse(MissingAnchor)` on the
+        // merely-signed-but-unproven bytes just applied above (confirmed live).
+        let (proven_pczt, txid) =
+            finalize_note_split(&mut wallet, account, &mut store_conn, &mut state, split_id)?;
+
+        let id = encode_transfer_id(env, split_id)?;
+        let txid_obj = crate::utils::rust_bytes_to_java(env, &txid)?;
+        let pczt_bytes = crate::utils::rust_bytes_to_java(env, &proven_pczt)?;
+        Ok(env
+            .new_object(
+                JNI_PREPARED_TRANSFER,
+                "(Ljava/lang/String;[B[B)V",
+                &[
+                    JValue::Object(&id),
+                    JValue::Object(&txid_obj),
+                    JValue::Object(&pczt_bytes),
+                ],
+            )?
+            .into_raw())
+    });
+    unwrap_exc_or(&mut env, res, ptr::null_mut())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_createUnsignedTransferPcztsNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+    _ids: JObjectArray<'local>,
+    _amounts_zatoshi: JLongArray<'local>,
+    _anchor_heights: JLongArray<'local>,
+    _next_executable_after_heights: JLongArray<'local>,
+    _expiry_heights: JLongArray<'local>,
+    _estimated_duration_hours: jint,
+) -> jobjectArray {
+    let res = catch_unwind(&mut env, |env| {
+        let (network, wallet, mut store_conn) = open(env, db_data, network_id)?;
+        let account = crate::account_id_from_jni(env, account_uuid)?;
+        // Mirrors `createUnsignedNoteSplitPcztNative`: the caller-supplied schedule arrays are
+        // ignored — `commit_or_reuse` signs exactly the plan cached by the preceding
+        // `propose*`/`prepare*` call, or (this being the *second* external-signer call in the
+        // Keystone sequence, after `createUnsignedNoteSplitPcztNative` already committed) just
+        // re-reads what's already persisted, rather than committing a second, independent plan
+        // (which would have hit `CommitError::MigrationInProgress` from the engine anyway).
+        let target = target_height(&wallet)?;
+        let (state, unsigned) = commit_or_reuse(
+            &network,
+            &wallet,
+            account,
+            &mut store_conn,
+            target,
+            None,
+            |network, target, backend, migration_plan, rng| {
+                let (state, unsigned) = engine::build_preparation_unsigned(
+                    network,
+                    target,
+                    backend,
+                    migration_plan,
+                    rng,
+                )
+                .map_err(|e| anyhow!("Error building unsigned migration PCZTs: {:?}", e))?;
+                Ok((
+                    state,
+                    unsigned.into_iter().map(|tx| tx.into_parts()).collect(),
+                ))
+            },
+        )?;
+        let transfer_ids: std::collections::HashSet<MigrationTxId> = state
+            .transactions()
+            .iter()
+            .filter(|t| matches!(t.kind(), MigrationTxKind::Transfer { .. }))
+            .map(|t| t.id())
+            .collect();
+        let (seed_fingerprint, account_index) = account_zip32_derivation(&wallet, account)?;
+        let transfers: Vec<_> = unsigned
+            .into_iter()
+            .filter(|(id, _)| transfer_ids.contains(id))
+            .map(|(id, pczt_bytes)| {
+                let pczt_bytes = crate::migration_keystone::annotate_spend_zip32_derivation(
+                    &pczt_bytes,
+                    seed_fingerprint,
+                    network.coin_type(),
+                    account_index,
+                )
+                .map_err(|e| anyhow!("Error annotating transfer PCZT derivation: {:?}", e))?;
+                Ok::<_, anyhow::Error>((id, pczt_bytes))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        Ok(crate::utils::rust_vec_to_java(
+            env,
+            transfers,
+            JNI_UNSIGNED_TRANSFER_PCZT,
+            |env, (id, pczt_bytes)| {
+                let id = encode_transfer_id(env, id)?;
+                let pczt_bytes = crate::utils::rust_bytes_to_java(env, &pczt_bytes)?;
+                env.new_object(
+                    JNI_UNSIGNED_TRANSFER_PCZT,
+                    "(Ljava/lang/String;[B)V",
+                    &[JValue::Object(&id), JValue::Object(&pczt_bytes)],
+                )
+            },
+        )?
+        .into_raw())
+    });
+    unwrap_exc_or(&mut env, res, ptr::null_mut())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_storeSignedSchedulePcztsNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+    ids: JObjectArray<'local>,
+    pczt_bytes_list: JObjectArray<'local>,
+) {
+    let res = catch_unwind(&mut env, |env| {
+        let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
+        let account = crate::account_id_from_jni(env, account_uuid)?;
+        let count = env.get_array_length(&ids)?;
+        let mut backend = Backend::new(&wallet, account, None, &mut store_conn)?;
+        let mut state = backend
+            .get_migration()
+            .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
+            .ok_or_else(|| anyhow!("No migration committed yet"))?;
+        // Absorbs the new engine's per-transaction `apply_signature` into the old batch-shaped
+        // call Kotlin still makes — see module doc point about the signed-PCZT return path.
+        for i in 0..count {
+            let id_obj = env.get_object_array_element(&ids, i)?;
+            let id = decode_transfer_id(env, &JString::from(id_obj))?;
+            let bytes_obj = env.get_object_array_element(&pczt_bytes_list, i)?;
+            let pczt_bytes = crate::utils::java_bytes_to_rust(env, &JByteArray::from(bytes_obj))?;
+            if !state.apply_signature(id, pczt_bytes) {
+                return Err(anyhow!("Error applying signature for transfer {:?}", id));
+            }
+        }
+        backend
+            .replace_migration(&state)
+            .map_err(|e| anyhow!("Error persisting migration state: {:?}", e))
+    });
+    unwrap_exc_or(&mut env, res, ())
+}
+
+// ----- Keystone batch-signing UR bridge (crate::migration_keystone) -----
+//
+// Pure PCZT/UR operations over caller-held bytes — no wallet database, no migration engine.
+// Unaffected by this rewire.
+
+fn decode_byte_array_list(env: &mut JNIEnv, list: &JObjectArray) -> anyhow::Result<Vec<Vec<u8>>> {
+    let count = env.get_array_length(list)?;
+    let mut out = Vec::with_capacity(count as usize);
+    for i in 0..count {
+        let obj = env.get_object_array_element(list, i)?;
+        out.push(crate::utils::java_bytes_to_rust(
+            env,
+            &JByteArray::from(obj),
+        )?);
+    }
+    Ok(out)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_buildKeystoneSignBatchQrPartsNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    request_id: JByteArray<'local>,
+    split_unsigned: JByteArray<'local>,
+    transfer_unsigned: JObjectArray<'local>,
+    max_fragment_len: jint,
+) -> jobjectArray {
+    let res = catch_unwind(&mut env, |env| {
+        let request_id = crate::utils::java_bytes_to_rust(env, &request_id)?;
+        let split_unsigned = crate::utils::java_nullable_bytes_to_rust(env, &split_unsigned)?;
+        let transfer_unsigned = decode_byte_array_list(env, &transfer_unsigned)?;
+        let parts = crate::migration_keystone::build_sign_batch_qr_parts(
+            request_id,
+            split_unsigned.as_deref(),
+            &transfer_unsigned,
+            max_fragment_len as usize,
+        )
+        .map_err(|e| anyhow!("Error building Keystone sign-batch QR parts: {}", e))?;
+        Ok(
+            crate::utils::rust_vec_to_java(env, parts, "java/lang/String", |env, part| {
+                env.new_string(part)
+            })?
+            .into_raw(),
+        )
+    });
+    unwrap_exc_or(&mut env, res, ptr::null_mut())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_resetKeystoneSignBatchDecoderNative<
+    'local,
+>(
+    _env: JNIEnv<'local>,
+    _: JClass<'local>,
+) {
+    crate::migration_keystone::reset_sign_batch_decoder();
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_decodeKeystoneSignBatchPartNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    part: JString<'local>,
+    expected_request_id: JByteArray<'local>,
+) -> jobject {
+    let res = catch_unwind(&mut env, |env| {
+        let part = crate::utils::java_string_to_rust(env, &part)?;
+        let expected_request_id = crate::utils::java_bytes_to_rust(env, &expected_request_id)?;
+        let result = crate::migration_keystone::decode_sign_batch_part(&part, &expected_request_id)
+            .map_err(|e| anyhow!("Error decoding Keystone sign-batch QR part: {}", e))?;
+        let data = match &result.data {
+            Some(bytes) => crate::utils::rust_bytes_to_java(env, bytes)?.into(),
+            None => JObject::null(),
+        };
+        let firmware_version = match &result.firmware_version {
+            Some(bytes) => crate::utils::rust_bytes_to_java(env, bytes)?.into(),
+            None => JObject::null(),
+        };
+        Ok(env
+            .new_object(
+                JNI_KEYSTONE_BATCH_DECODE_RESULT,
+                "(ZI[B[B)V",
+                &[
+                    JValue::Bool(if result.complete { JNI_TRUE } else { JNI_FALSE }),
+                    JValue::Int(result.progress as jint),
+                    JValue::Object(&data),
+                    JValue::Object(&firmware_version),
+                ],
+            )?
+            .into_raw())
+    });
+    unwrap_exc_or(&mut env, res, ptr::null_mut())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_applyKeystoneBatchSignaturesNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    split_unsigned: JByteArray<'local>,
+    transfer_unsigned: JObjectArray<'local>,
+    batch_sign_response: JByteArray<'local>,
+) -> jobject {
+    let res = catch_unwind(&mut env, |env| {
+        let split_unsigned = crate::utils::java_nullable_bytes_to_rust(env, &split_unsigned)?;
+        let transfer_unsigned = decode_byte_array_list(env, &transfer_unsigned)?;
+        let batch_sign_response = crate::utils::java_bytes_to_rust(env, &batch_sign_response)?;
+        let (split_signed, transfers_signed) = crate::migration_keystone::apply_batch_signatures(
+            split_unsigned.as_deref(),
+            &transfer_unsigned,
+            &batch_sign_response,
+        )
+        .map_err(|e| anyhow!("Error applying Keystone batch signatures: {}", e))?;
+
+        let split_signed_obj = match &split_signed {
+            Some(bytes) => crate::utils::rust_bytes_to_java(env, bytes)?.into(),
+            None => JObject::null(),
+        };
+        let transfers_signed_obj =
+            crate::utils::rust_vec_to_java(env, transfers_signed, "[B", |env, bytes| {
+                crate::utils::rust_bytes_to_java(env, &bytes)
+            })?;
+        Ok(env
+            .new_object(
+                JNI_KEYSTONE_BATCH_SIGNED_PCZTS,
+                format!("([B[[B)V"),
+                &[
+                    JValue::Object(&split_signed_obj),
+                    JValue::Object(&transfers_signed_obj),
+                ],
+            )?
+            .into_raw())
+    });
+    unwrap_exc_or(&mut env, res, ptr::null_mut())
+}
+
+/// Integration tests that exercise the actual migration planning/build/finalize logic directly
+/// against a real wallet SQLite DB file — no JNI, no Android, no Gradle app build, no emulator UI
+/// click-through. Point `MIGRATION_TEST_WALLET_DB` at a copy of a real wallet DB (pull one via
+/// `adb -s emulator-5554 shell "run-as <pkg> cat <path>" > /tmp/wallet_fixture.sqlite3`, path from
+/// the handoff doc's testing-setup notes) to iterate on migration bugs in seconds. Every bug found
+/// live this session (multi-witness resolution, anchor fallback for preparation transactions,
+/// schedule/amount pairing, note-split-needed detection) would have been caught by these tests
+/// without ever launching the app.
+///
+/// Run with, e.g.:
+/// `MIGRATION_TEST_WALLET_DB=/tmp/wallet_fixture.sqlite3 cargo test --package zcash-android-wallet-sdk --lib migration::live_wallet_tests -- --ignored --nocapture`
+/// Copies the fixture DB to a fresh, uniquely-named temp file so each test run starts from a
+/// pristine copy instead of mutating (and being mutated by) the shared fixture on disk — tests
+/// like `build_and_finalize_all_unsigned` and `commit_and_finalize_with_real_signing` both commit
+/// real migration state, and the engine refuses to recommit over an in-progress migration.
+#[cfg(test)]
+fn fresh_test_db_copy(fixture: &std::path::Path) -> std::path::PathBuf {
+    let mut dest = std::env::temp_dir();
+    let unique = format!(
+        "migration_test_{}_{}.sqlite3",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time after epoch")
+            .as_nanos()
+    );
+    dest.push(unique);
+    std::fs::copy(fixture, &dest).expect("copy fixture db to fresh temp path");
+    dest
+}
+
+#[cfg(test)]
+mod live_wallet_tests {
+    use super::*;
+
+    fn fixture_db_path() -> Option<std::path::PathBuf> {
+        std::env::var("MIGRATION_TEST_WALLET_DB")
+            .ok()
+            .map(std::path::PathBuf::from)
+    }
+
+    fn first_account(wallet: &Wallet) -> AccountUuid {
+        wallet
+            .get_account_ids()
+            .expect("list accounts")
+            .into_iter()
+            .next()
+            .expect("wallet has at least one account — restore/sync one first")
+    }
+
+    #[test]
+    #[ignore = "requires MIGRATION_TEST_WALLET_DB pointing at a copy of a real wallet DB"]
+    fn plan_a_real_wallet() {
+        let fixture = fixture_db_path().expect("set MIGRATION_TEST_WALLET_DB");
+        let db_path = fresh_test_db_copy(&fixture);
+        let network = Network::TestNetwork;
+        let (wallet, mut store_conn) = open_at(&db_path, network).expect("open wallet");
+        let account = first_account(&wallet);
+
+        let (plan, tip) = plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
+
+        println!(
+            "tip={tip:?} funding_notes={} prep_layers={} prep_txs={} direct_funding={}",
+            plan.funding_notes().len(),
+            plan.preparation().layer_count(),
+            plan.preparation().transaction_count(),
+            plan.preparation().direct_funding_notes().len(),
+        );
+        for entry in plan.schedule() {
+            let delta = i64::from(u32::from(entry.broadcast_height())) - i64::from(u32::from(tip));
+            println!(
+                "broadcast_height={:?} ({delta} blocks from tip) expiry={:?}",
+                entry.broadcast_height(),
+                entry.expiry_height(),
+            );
+        }
+    }
+
+    // `build_and_finalize_all_unsigned` (tested `build_preparation_unsigned`'s deliberately-UNSIGNED
+    // PCZTs against our old hand-rolled `migration_finalize::finalize_transaction`, which didn't
+    // care whether a PCZT was signed — it just resolved the witness/anchor and let extraction fail
+    // on the missing signature) was REMOVED when this crate adopted
+    // `zcash_pool_migration_backend`'s own `WalletMigrationProver`/`engine::prove_transfer`/
+    // `prove_preparation` (see `try_prove`'s doc comment). Those require the transaction to be
+    // `MigrationTxState::Signed` (`ProveError::NotReady` otherwise) — an UNSIGNED transaction from
+    // `build_preparation_unsigned` is `AwaitingSignature`, so it is correctly rejected before ever
+    // reaching witness/anchor resolution, not after (a stricter, better safety property than our old
+    // stopgap had, but one this test's exact premise can no longer exercise). The witness/anchor
+    // resolution logic this test covered now lives in `WalletMigrationProver` (core-team-owned,
+    // exercised by its own `zcash_pool_migration_backend/tests/prove_chain_sim.rs`); our own
+    // `commit_and_finalize_with_real_signing` below still covers the full real-signing → prove path
+    // end to end against our wallet adapter.
+}
+
+/// Full-loop test (plan → in-process sign/commit → finalize) exercising real signing via
+/// `commit_preparation`, still entirely local/offline: `commit_preparation` only builds and signs
+/// PCZTs against the wallet DB copy, `finalize_transaction` only installs anchor/witness and
+/// proves. Neither does any network I/O — nothing here is ever broadcast or submitted anywhere.
+/// Needs a real `UnifiedSpendingKey`, provided via `MIGRATION_TEST_SEED_PHRASE` (a BIP-39 mnemonic,
+/// account 0) — never logged or persisted by this test.
+#[cfg(test)]
+mod live_wallet_signing_tests {
+    use super::*;
+    use zcash_client_backend::data_api::Account;
+
+    #[test]
+    #[ignore = "requires MIGRATION_TEST_WALLET_DB and MIGRATION_TEST_SEED_PHRASE"]
+    fn commit_and_finalize_with_real_signing() {
+        let fixture = std::env::var("MIGRATION_TEST_WALLET_DB")
+            .map(std::path::PathBuf::from)
+            .expect("set MIGRATION_TEST_WALLET_DB");
+        let db_path = fresh_test_db_copy(&fixture);
+        let phrase = std::env::var("MIGRATION_TEST_SEED_PHRASE")
+            .expect("set MIGRATION_TEST_SEED_PHRASE (BIP-39 mnemonic, space-separated words)");
+        let network = Network::TestNetwork;
+        let (mut wallet, mut store_conn) = open_at(&db_path, network).expect("open wallet");
+        let account = wallet
+            .get_account_ids()
+            .expect("list accounts")
+            .into_iter()
+            .next()
+            .expect("wallet has at least one account");
+
+        let mnemonic = bip0039::Mnemonic::<bip0039::English>::from_phrase(phrase.trim())
+            .expect("valid BIP-39 mnemonic");
+        let seed = mnemonic.to_seed("");
+        let usk = UnifiedSpendingKey::from_seed(&network, &seed, zip32::AccountId::ZERO)
+            .expect("derive USK from seed for account 0");
+
+        // Sanity check the derived key actually matches this wallet's account before doing
+        // anything else — a mismatched seed/account index would otherwise fail confusingly deep
+        // inside signing instead of here, with a clear message.
+        let derived_ufvk = usk.to_unified_full_viewing_key();
+        let wallet_account = wallet
+            .get_account(account)
+            .expect("account lookup")
+            .expect("account exists");
+        let wallet_ufvk = wallet_account.ufvk().expect("account has a UFVK");
+        assert_eq!(
+            derived_ufvk.encode(&network),
+            wallet_ufvk.encode(&network),
+            "derived USK's UFVK doesn't match the wallet's stored UFVK for this account — check \
+             the seed phrase and/or account index (this test assumes account 0)"
+        );
+
+        let (migration_plan, tip) =
+            plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
+        let target = tip + 1;
+
+        let mut state = {
+            let mut backend = Backend::new(&wallet, account, Some(usk), &mut store_conn)
+                .expect("account exists for migration store");
+            let mut rng = OsRng;
+            engine::commit_preparation(&network, target, &mut backend, &migration_plan, &mut rng)
+                .expect(
+                    "commit_preparation (in-process signing — local only, no network/broadcast)",
+                )
+        };
+        println!(
+            "{} transaction(s) committed and signed",
+            state.transactions().len()
+        );
+
+        let fvk = {
+            let backend = Backend::new(&wallet, account, None, &mut store_conn)
+                .expect("account exists for migration store");
+            backend.orchard_fvk().expect("fvk")
+        };
+
+        let ids_and_kinds: Vec<(MigrationTxId, MigrationTxKind)> = state
+            .transactions()
+            .iter()
+            .map(|t| (t.id(), t.kind()))
+            .collect();
+        let mut finalized = 0;
+        let mut transient = 0;
+        for (id, kind) in ids_and_kinds {
+            match try_prove(&mut wallet, account, fvk.clone(), &mut state, id, kind) {
+                Ok(true) => {
+                    finalized += 1;
+                    println!(
+                        "id={id:?} kind={kind:?} finalized (built+proven locally only — this \
+                         test never submits anything to the network)",
+                    );
+                }
+                Ok(false) => {
+                    transient += 1;
+                    println!("id={id:?} kind={kind:?} not yet finalizable (transient)");
+                }
+                Err(e) => panic!("id={id:?} kind={kind:?} FAILED: {e}"),
+            }
+        }
+        println!("{finalized} finalized, {transient} transient — nothing broadcast");
+    }
+
+    /// Regression test for the Keystone/external-signer note-split crash (confirmed live:
+    /// `extractBroadcastTxNative` failed with `OrchardParse(MissingAnchor)`) —
+    /// `storeSignedNoteSplitPcztNative` applied the external signature but never resolved the
+    /// split's deferred witness/anchor before returning the PCZT for extraction. This exercises
+    /// the same shape as that JNI function (`build_preparation_unsigned` -> sign the split
+    /// out-of-process, matching what handing a redacted PCZT to Keystone and getting it back
+    /// signed looks like -> `apply_signature` -> `finalize_note_split`) via its shared, JNI-free
+    /// `finalize_note_split` helper, then extracts the result exactly like
+    /// `extractBroadcastTxNative` does, to prove the crash is actually fixed end to end, not just
+    /// that `finalize_note_split` returns `Ok`.
+    #[test]
+    #[ignore = "requires MIGRATION_TEST_WALLET_DB and MIGRATION_TEST_SEED_PHRASE"]
+    fn store_signed_note_split_resolves_anchor_before_extraction() {
+        let fixture = std::env::var("MIGRATION_TEST_WALLET_DB")
+            .map(std::path::PathBuf::from)
+            .expect("set MIGRATION_TEST_WALLET_DB");
+        let db_path = fresh_test_db_copy(&fixture);
+        let phrase = std::env::var("MIGRATION_TEST_SEED_PHRASE")
+            .expect("set MIGRATION_TEST_SEED_PHRASE (BIP-39 mnemonic, space-separated words)");
+        let network = Network::TestNetwork;
+        let (mut wallet, mut store_conn) = open_at(&db_path, network).expect("open wallet");
+        let account = wallet
+            .get_account_ids()
+            .expect("list accounts")
+            .into_iter()
+            .next()
+            .expect("wallet has at least one account");
+
+        let mnemonic = bip0039::Mnemonic::<bip0039::English>::from_phrase(phrase.trim())
+            .expect("valid BIP-39 mnemonic");
+        let seed = mnemonic.to_seed("");
+        let usk = UnifiedSpendingKey::from_seed(&network, &seed, zip32::AccountId::ZERO)
+            .expect("derive USK from seed for account 0");
+
+        let (migration_plan, tip) =
+            plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
+        let target = tip + 1;
+
+        // Mirrors `createUnsignedNoteSplitPcztNative`: build unsigned, leaving every transaction
+        // (including the split) `AwaitingSignature` — nothing is signed by this call.
+        let (mut state, unsigned) = {
+            let mut backend = Backend::new(&wallet, account, None, &mut store_conn)
+                .expect("account exists for migration store");
+            let mut rng = OsRng;
+            engine::build_preparation_unsigned(
+                &network,
+                target,
+                &mut backend,
+                &migration_plan,
+                &mut rng,
+            )
+            .expect("build_preparation_unsigned")
+        };
+        let split_id = state
+            .transactions()
+            .iter()
+            .find(|t| matches!(t.kind(), MigrationTxKind::Preparation { layer: 0, .. }))
+            .map(|t| t.id())
+            .expect("migration has a note-split preparation transaction");
+        let (_id, unsigned_split_bytes) = unsigned
+            .into_iter()
+            .map(|tx| tx.into_parts())
+            .find(|(id, _)| *id == split_id)
+            .expect("unsigned split pczt");
+
+        // Sign out-of-process, exactly as an external signer (Keystone) would: this produces a
+        // signed-but-unproven PCZT, still missing its witness/anchor — the same shape
+        // `storeSignedNoteSplitPcztNative` receives back from Kotlin after a real Keystone round
+        // trip.
+        let ask = orchard::keys::SpendAuthorizingKey::from(usk.orchard());
+        let unsigned_pczt =
+            pczt::Pczt::parse(&unsigned_split_bytes).expect("parse unsigned split pczt");
+        let signed_pczt = zcash_pool_migration_backend::build::sign_pczt(unsigned_pczt, &ask)
+            .expect("sign split pczt out-of-process");
+        let signed_bytes = signed_pczt
+            .serialize()
+            .expect("serialize signed split pczt");
+
+        // Mirrors `storeSignedNoteSplitPcztNative`: apply the externally-obtained signature, then
+        // resolve anchor/witness and prove via the fixed `finalize_note_split` helper.
+        assert!(
+            state.apply_signature(split_id, signed_bytes),
+            "apply_signature should accept the freshly-signed split pczt"
+        );
+        let (proven_pczt, txid) =
+            finalize_note_split(&mut wallet, account, &mut store_conn, &mut state, split_id)
+                .expect(
+                    "finalize_note_split should resolve the anchor, not fail with MissingAnchor",
+                );
+
+        // Mirrors `extractBroadcastTxNative` exactly — this is what previously crashed with
+        // `OrchardParse(MissingAnchor)` on the un-finalized bytes.
+        let parsed = pczt::Pczt::parse(&proven_pczt).expect("parse proven split pczt");
+        let tx = pczt::roles::tx_extractor::TransactionExtractor::new(parsed)
+            .extract()
+            .expect("extract broadcast tx from finalized split pczt");
+        assert_eq!(
+            *tx.txid().as_ref(),
+            txid,
+            "extracted txid should match finalize_note_split's"
+        );
+        println!(
+            "note-split finalized and extracted via the Keystone/external-signer path: txid={}",
+            hex::encode(txid)
+        );
+    }
+}
+
+/// Edge-case / state-machine integration tests against a real wallet DB copy. Unlike
+/// `live_wallet_tests`/`live_wallet_signing_tests` (which exercise the happy path), these probe
+/// what happens on re-entry, restart, and multi-account use — the moments a real app hits that a
+/// single linear test run never does. Pure `MigrationState` logic (`apply_signature`,
+/// `next_step`, `mark_broadcast`/`mark_mined`, terminal-status handling) is already unit-tested in
+/// `zcash_pool_migration_backend::state`, so it is not duplicated here; these tests are only for
+/// behavior that needs a real wallet DB, real accounts, or our own JNI-adapter code
+/// (`commit_or_reuse`, `Backend`) to observe.
+///
+/// Run with `--test-threads=1`: each test independently copies the (large, ~8.5MB) fixture file
+/// via `fresh_test_db_copy`, and running several of these copies concurrently (cargo's default
+/// parallel test execution) has been observed to occasionally corrupt one thread's read with a
+/// spurious `DatabaseCorrupt "database disk image is malformed"` — not a real bug in the code
+/// under test, confirmed by rerunning the same test alone. Serializing avoids it.
+#[cfg(test)]
+mod live_wallet_edge_case_tests {
+    use super::*;
+    use secrecy::SecretVec;
+    use zcash_client_backend::data_api::chain::ChainState;
+    use zcash_client_backend::data_api::{AccountBirthday, WalletWrite};
+    use zcash_primitives::block::BlockHash;
+
+    fn fixture_db_path() -> std::path::PathBuf {
+        std::env::var("MIGRATION_TEST_WALLET_DB")
+            .map(std::path::PathBuf::from)
+            .expect("set MIGRATION_TEST_WALLET_DB")
+    }
+
+    fn first_account(wallet: &Wallet) -> AccountUuid {
+        wallet
+            .get_account_ids()
+            .expect("list accounts")
+            .into_iter()
+            .next()
+            .expect("wallet has at least one account — restore/sync one first")
+    }
+
+    /// Creates a second, synthetic, permanently-unfunded account in `wallet` — not derived from
+    /// the real test seed, and never scanned for funds — purely to have a second `AccountUuid` in
+    /// the same wallet DB. `seed_byte` just needs to differ per call so two synthetic accounts in
+    /// one test don't collide with each other.
+    fn create_synthetic_account(wallet: &mut Wallet, seed_byte: u8, name: &str) -> AccountUuid {
+        let tip = wallet
+            .chain_height()
+            .expect("chain height")
+            .expect("wallet has a chain tip");
+        let birthday =
+            AccountBirthday::from_parts(ChainState::empty(tip, BlockHash([0; 32])), None);
+        let seed = SecretVec::new(vec![seed_byte; 32]);
+        let (account, _usk) = wallet
+            .create_account(name, &seed, &birthday, None)
+            .expect("create synthetic account");
+        account
+    }
+
+    fn sign_unsigned(
+        network: &Network,
+        target: BlockHeight,
+        backend: &mut Backend<Wallet>,
+        plan: &MigrationPlan,
+        rng: &mut OsRng,
+    ) -> anyhow::Result<(MigrationState, Vec<(MigrationTxId, Vec<u8>)>)> {
+        let (state, unsigned) =
+            engine::build_preparation_unsigned(network, target, backend, plan, rng)
+                .map_err(|e| anyhow!("build_preparation_unsigned: {:?}", e))?;
+        Ok((
+            state,
+            unsigned.into_iter().map(|tx| tx.into_parts()).collect(),
+        ))
+    }
+
+    /// Demonstrates the SINGLETON_ID cross-account collision directly (see
+    /// `project_core_migration_swap` memory / spec doc §6.3): `pool_migrations`/
+    /// `pool_migration_transactions` have no `account_id` column, and `Backend::get_migration`/
+    /// `replace_migration` (`migration_engine.rs`) pass straight through to the store without
+    /// filtering by `self.account` — confirmed directly in that impl, not assumed. This is a bug
+    /// in OUR OWN adapter, not just a documented upstream limitation: any JNI call for account B
+    /// (`migrationStateNative`, `commit_or_reuse`, ...) reads/writes account A's committed
+    /// migration whenever one exists in the same wallet DB.
+    #[test]
+    #[ignore = "requires MIGRATION_TEST_WALLET_DB"]
+    fn singleton_id_collision_between_accounts() {
+        let db_path = fresh_test_db_copy(&fixture_db_path());
+        let network = Network::TestNetwork;
+        let (mut wallet, mut store_conn) = open_at(&db_path, network).expect("open wallet");
+        let account_a = first_account(&wallet);
+        let account_b = create_synthetic_account(&mut wallet, 0x42, "edge-case-account-b");
+        assert_ne!(account_a, account_b);
+
+        // Plan + commit an (unsigned) migration for account A only — account B is never touched.
+        let (plan_a, tip) =
+            plan_for(&network, &wallet, account_a, &mut store_conn).expect("plan_for account_a");
+        let target = tip + 1;
+        {
+            let mut backend_a = Backend::new(&wallet, account_a, None, &mut store_conn)
+                .expect("account exists for migration store");
+            let mut rng = OsRng;
+            engine::build_preparation_unsigned(&network, target, &mut backend_a, &plan_a, &mut rng)
+                .expect("commit account_a's migration");
+        }
+
+        // Asking for account B's migration state goes through the exact same code path
+        // (`migrationStateNative`/`commit_or_reuse` do this) — it must see nothing, since B has
+        // no migration of its own. Instead it leaks A's.
+        let backend_b = Backend::new(&wallet, account_b, None, &mut store_conn)
+            .expect("account exists for migration store");
+        let leaked = backend_b
+            .get_migration()
+            .expect("read migration state for account_b");
+        match leaked {
+            Some(state) if !state.transactions().is_empty() => {
+                println!(
+                    "CONFIRMED BUG: account_b's Backend::get_migration() returned {} \
+                     transaction(s) that belong to account_a. pool_migrations has no \
+                     account_id column, and Backend::{{get,put}}_migration ignore \
+                     self.account — every account in a wallet DB shares one migration slot.",
+                    state.transactions().len()
+                );
+            }
+            Some(_) => {
+                panic!("unexpected: got a migration state for account_b with no transactions")
+            }
+            None => panic!(
+                "SINGLETON_ID collision not reproduced — account_b correctly saw no migration. \
+                 If this starts failing, the collision may have been fixed; update \
+                 project_core_migration_swap memory and this test accordingly."
+            ),
+        }
+    }
+
+    /// `commit_or_reuse` (our own adapter, used by every commit-shaped JNI function) must REUSE
+    /// an already-committed migration on a second call for the same account/plan, not error and
+    /// not silently rebuild (which would orphan or double-sign the first commit's PCZTs). This is
+    /// the realistic re-entry case: the app returns to the migration review screen and the user
+    /// taps "commit" again (e.g. after a process restart before any signature was applied).
+    #[test]
+    #[ignore = "requires MIGRATION_TEST_WALLET_DB"]
+    fn commit_or_reuse_returns_existing_state_without_recommitting() {
+        let db_path = fresh_test_db_copy(&fixture_db_path());
+        let network = Network::TestNetwork;
+        let (wallet, mut store_conn) = open_at(&db_path, network).expect("open wallet");
+        let account = first_account(&wallet);
+
+        let (_plan, tip) = plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
+        let target = tip + 1;
+
+        let (state1, unsigned1) = commit_or_reuse(
+            &network,
+            &wallet,
+            account,
+            &mut store_conn,
+            target,
+            None,
+            sign_unsigned,
+        )
+        .expect("first commit_or_reuse call commits");
+        assert!(
+            !unsigned1.is_empty(),
+            "expected unsigned preparation/transfer PCZTs on first commit"
+        );
+
+        // Re-plan, as the app does whenever it re-renders the review screen — this must not
+        // itself disturb the already-committed migration.
+        plan_for(&network, &wallet, account, &mut store_conn).expect("re-plan after commit");
+
+        let (state2, unsigned2) = commit_or_reuse(
+            &network,
+            &wallet,
+            account,
+            &mut store_conn,
+            target,
+            None,
+            sign_unsigned,
+        )
+        .expect("second commit_or_reuse call must reuse, not error");
+
+        assert_eq!(
+            state1.transactions().len(),
+            state2.transactions().len(),
+            "reused state must have the same transaction set"
+        );
+        assert_eq!(
+            unsigned1.len(),
+            unsigned2.len(),
+            "reuse must return the SAME already-awaiting-signature PCZTs, not rebuild new ones"
+        );
+        for (a, b) in state1
+            .transactions()
+            .iter()
+            .zip(state2.transactions().iter())
+        {
+            assert_eq!(a.id(), b.id());
+            assert_eq!(
+                a.pczt(),
+                b.pczt(),
+                "reuse must not rebuild/re-sign a transaction — a rebuilt layer 0 would double-\
+                 spend the same wallet notes, and a rebuilt already-broadcast tx would be orphaned"
+            );
+        }
+    }
+
+    /// Calling the raw engine directly (bypassing our `commit_or_reuse` reuse guard) a second
+    /// time over an already-committed, non-terminal migration must fail with
+    /// `CommitError::MigrationInProgress` — this is the exact condition `commit_or_reuse` relies
+    /// on to decide "reuse instead of recommit", so it's worth pinning down directly rather than
+    /// only indirectly through that wrapper.
+    #[test]
+    #[ignore = "requires MIGRATION_TEST_WALLET_DB"]
+    fn raw_recommit_over_committed_migration_is_rejected() {
+        let db_path = fresh_test_db_copy(&fixture_db_path());
+        let network = Network::TestNetwork;
+        let (wallet, mut store_conn) = open_at(&db_path, network).expect("open wallet");
+        let account = first_account(&wallet);
+
+        let (plan, tip) = plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
+        let target = tip + 1;
+        {
+            let mut backend = Backend::new(&wallet, account, None, &mut store_conn)
+                .expect("account exists for migration store");
+            let mut rng = OsRng;
+            engine::build_preparation_unsigned(&network, target, &mut backend, &plan, &mut rng)
+                .expect("first commit");
+        }
+
+        let mut backend = Backend::new(&wallet, account, None, &mut store_conn)
+            .expect("account exists for migration store");
+        let mut rng = OsRng;
+        let result =
+            engine::build_preparation_unsigned(&network, target, &mut backend, &plan, &mut rng);
+        assert!(
+            matches!(result, Err(engine::CommitError::MigrationInProgress)),
+            "recommitting over a non-terminal migration must fail with MigrationInProgress, not \
+             silently rebuild: got {result:?}"
+        );
+    }
+
+    /// Simulates the app process being killed and restarted mid-migration: commit a migration,
+    /// drop every handle to the wallet/DB connections, then reopen fresh ones against the same
+    /// on-disk file (exactly what `MigrationRustBackend`'s JNI functions do on every call — no
+    /// persistent connection is kept between them) and confirm the committed state round-trips
+    /// intact and `next_step` still gives a sane answer.
+    #[test]
+    #[ignore = "requires MIGRATION_TEST_WALLET_DB"]
+    fn migration_state_persists_across_reopened_connection() {
+        let db_path = fresh_test_db_copy(&fixture_db_path());
+        let network = Network::TestNetwork;
+
+        let committed_ids: Vec<MigrationTxId> = {
+            let (wallet, mut store_conn) = open_at(&db_path, network).expect("open wallet");
+            let account = first_account(&wallet);
+            let (plan, tip) =
+                plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
+            let target = tip + 1;
+            let mut backend = Backend::new(&wallet, account, None, &mut store_conn)
+                .expect("account exists for migration store");
+            let mut rng = OsRng;
+            let (state, _unsigned) =
+                engine::build_preparation_unsigned(&network, target, &mut backend, &plan, &mut rng)
+                    .expect("commit");
+            state.transactions().iter().map(|t| t.id()).collect()
+            // wallet / store_conn / backend all drop here — simulates process death.
+        };
+
+        let (wallet2, mut store_conn2) = open_at(&db_path, network).expect("reopen wallet");
+        let account = first_account(&wallet2);
+        let backend2 = Backend::new(&wallet2, account, None, &mut store_conn2)
+            .expect("account exists for migration store");
+        let reloaded = backend2
+            .get_migration()
+            .expect("read migration state")
+            .expect("migration state must persist across a fresh connection to the same DB file");
+        let reloaded_ids: Vec<MigrationTxId> =
+            reloaded.transactions().iter().map(|t| t.id()).collect();
+        assert_eq!(
+            committed_ids, reloaded_ids,
+            "reopening the DB connection must not lose or reorder committed migration transactions"
+        );
+
+        let tip2 = wallet2.chain_height().expect("chain height").expect("tip");
+        let step = reloaded.next_step(tip2 + 1);
+        println!("next_step after simulated restart: {step:?}");
+    }
+
+    /// `plan_migration` is documented as pure/read-only ("nothing is built, signed, or
+    /// persisted") — confirm that holds even once a migration is already committed: re-planning
+    /// (e.g. the app re-rendering the review screen) must keep succeeding and must keep returning
+    /// the same funding notes, since nothing was broadcast and the wallet's spendable set hasn't
+    /// actually changed yet.
+    #[test]
+    #[ignore = "requires MIGRATION_TEST_WALLET_DB"]
+    fn plan_migration_is_read_only_after_commit() {
+        let db_path = fresh_test_db_copy(&fixture_db_path());
+        let network = Network::TestNetwork;
+        let (wallet, mut store_conn) = open_at(&db_path, network).expect("open wallet");
+        let account = first_account(&wallet);
+
+        let (plan_before, _tip) =
+            plan_for(&network, &wallet, account, &mut store_conn).expect("plan before commit");
+        let target = target_height(&wallet).expect("target height");
+        {
+            let mut backend = Backend::new(&wallet, account, None, &mut store_conn)
+                .expect("account exists for migration store");
+            let mut rng = OsRng;
+            engine::build_preparation_unsigned(
+                &network,
+                target,
+                &mut backend,
+                &plan_before,
+                &mut rng,
+            )
+            .expect("commit");
+        }
+
+        let (plan_after, _tip2) = plan_for(&network, &wallet, account, &mut store_conn)
+            .expect("plan_migration must remain callable after a migration is committed");
+
+        assert_eq!(
+            plan_before.funding_notes(),
+            plan_after.funding_notes(),
+            "nothing was broadcast, so the wallet's spendable set — and therefore the plan — \
+             must be unchanged"
+        );
+    }
+
+    /// An account with zero spendable Orchard notes must fail planning cleanly
+    /// (`MigrationError::NothingToMigrate`), not panic or return a degenerate empty-but-Ok plan —
+    /// this is the state every freshly created or already-fully-migrated account is in.
+    #[test]
+    #[ignore = "requires MIGRATION_TEST_WALLET_DB"]
+    fn planning_an_account_with_no_funds_errors_cleanly() {
+        let db_path = fresh_test_db_copy(&fixture_db_path());
+        let network = Network::TestNetwork;
+        let (mut wallet, mut store_conn) = open_at(&db_path, network).expect("open wallet");
+        let account_b = create_synthetic_account(&mut wallet, 0x43, "edge-case-empty-account");
+
+        let backend = Backend::new(&wallet, account_b, None, &mut store_conn)
+            .expect("account exists for migration store");
+        let mut rng = OsRng;
+        let result = engine::plan_migration(&network, &backend, &mut rng);
+        assert!(
+            matches!(result, Err(engine::MigrationError::NothingToMigrate)),
+            "an account with zero spendable Orchard notes must fail cleanly with \
+             NothingToMigrate, not panic or return a bogus plan: got {result:?}"
+        );
+    }
+}

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -21,17 +21,20 @@
 //!    `zcash_pool_migration_backend`'s own `WalletMigrationProver`/`engine::prove_transfer`/
 //!    `prove_preparation` — adopted 2026-07-23, replacing this file's former hand-ported
 //!    `migration_finalize.rs` stopgap (removed) now that core provides the equivalent built-in.
-//! 3. The commit functions (`signNoteSplitNative`, `signAndStoreMigrationScheduleNative`,
-//!    `createUnsignedNoteSplitPcztNative`, `createUnsignedTransferPcztsNative`) ignore the
-//!    Kotlin-supplied schedule arrays and instead sign the plan cached by the most recent
-//!    `propose*`/`prepare*` call, via `commit_or_reuse`/`migration_plan_cache` — see that module's
-//!    doc comment for why (the new engine's plan types have no public constructor to rebuild one
-//!    from primitives, verified directly, not assumed).
+//! 3. Plan details never cross the JNI boundary inward. Each `propose*`/`prepare*` call caches
+//!    its plan Rust-side under an opaque `PlanHandle` (returned to Kotlin as the proposal
+//!    object's `proposalHandle` field, for display alongside the schedule), and the commit
+//!    functions (`signNoteSplitNative`, `signAndStoreMigrationScheduleNative`,
+//!    `createUnsignedNoteSplitPcztNative`, `createUnsignedTransferPcztsNative`) take ONLY that
+//!    handle back — `commit_or_reuse`/`migration_plan_cache` then sign exactly the identified
+//!    plan or error if it was superseded by a later proposal. (Rebuilding a plan from
+//!    caller-echoed primitives is impossible anyway: the new engine's plan types have no public
+//!    constructor — verified directly, not assumed.)
 
 use anyhow::anyhow;
 use jni::{
     JNIEnv,
-    objects::{JByteArray, JClass, JLongArray, JObject, JObjectArray, JString, JValue},
+    objects::{JByteArray, JClass, JObject, JObjectArray, JString, JValue},
     sys::{JNI_FALSE, JNI_TRUE, jboolean, jbyteArray, jint, jlong, jobject, jobjectArray},
 };
 use prost::Message;
@@ -261,15 +264,17 @@ fn natural_anchor_height(wallet: &Wallet) -> anyhow::Result<BlockHeight> {
         .ok_or_else(|| anyhow!("wallet has no anchor height yet; scan required"))
 }
 
-/// Computes a fresh preview plan and caches it (see `migration_plan_cache`'s module doc for why)
-/// so a later commit call signs exactly this plan, not an independently re-randomized one. Also
-/// returns the wallet's current tip, needed as the "now" reference point when encoding transfer
-/// proposals (see `encode_transfer_proposal`'s doc comment for why this matters).
+/// Computes a fresh preview plan WITHOUT caching it — the read-only building block shared by
+/// `plan_for` (which caches, for proposals the user will be shown and may commit) and by pure
+/// peek queries like `isNoteSplitNeededNative` (which must NOT cache: replacing the cached plan
+/// would invalidate the handle of a proposal the user is currently reviewing). Also returns the
+/// wallet's current tip, needed as the "now" reference point when encoding transfer proposals
+/// (see `encode_transfer_proposal`'s doc comment for why this matters).
 ///
 /// JNI-free — see `open_at`'s doc comment. Every `MIGRATION_DIAG` log line this crate has needed
 /// so far to diagnose a live bug (anchor/witness resolution, schedule spread, note-split
 /// detection) came from here or `migration_finalize`, both callable directly from `cargo test`.
-fn plan_for(
+fn compute_plan(
     network: &Network,
     wallet: &Wallet,
     account: AccountUuid,
@@ -322,8 +327,26 @@ fn plan_for(
             entry.expiry_height(),
         );
     }
-    crate::migration_plan_cache::set(account, migration_plan.clone());
     Ok((migration_plan, tip))
+}
+
+/// Computes a fresh preview plan via `compute_plan` and caches it under a fresh
+/// [`migration_plan_cache::PlanHandle`] (see that module's doc for why), so a later commit call —
+/// which must echo the handle back — signs exactly this plan, not an independently re-randomized
+/// one.
+fn plan_for(
+    network: &Network,
+    wallet: &Wallet,
+    account: AccountUuid,
+    store_conn: &mut Connection,
+) -> anyhow::Result<(
+    MigrationPlan,
+    BlockHeight,
+    crate::migration_plan_cache::PlanHandle,
+)> {
+    let (migration_plan, tip) = compute_plan(network, wallet, account, store_conn)?;
+    let handle = crate::migration_plan_cache::set(account, migration_plan.clone());
+    Ok((migration_plan, tip, handle))
 }
 
 fn plan(
@@ -331,24 +354,32 @@ fn plan(
     db_data: JString,
     network_id: jint,
     account_uuid: JByteArray,
-) -> anyhow::Result<(MigrationPlan, BlockHeight)> {
+) -> anyhow::Result<(
+    MigrationPlan,
+    BlockHeight,
+    crate::migration_plan_cache::PlanHandle,
+)> {
     let (network, wallet, mut store_conn) = open(env, db_data, network_id)?;
     let account = crate::account_id_from_jni(env, account_uuid)?;
     plan_for(&network, &wallet, account, &mut store_conn)
 }
 
 /// Returns the already-committed migration state if one exists (non-terminal), otherwise commits
-/// the plan cached by the most recent `plan()` call for `account` — erroring if none was cached
-/// (see `migration_plan_cache`'s module doc). Shared by both the in-process-signing and
-/// external-signer commit paths below; `sign` picks which `commit_preparation`/
-/// `build_preparation_unsigned` variant to run, and whether a spending key is available to the
-/// `Backend` while doing so.
+/// the cached plan that `plan_handle` identifies — erroring if no plan is cached or if a later
+/// `propose*`/`prepare*` call replaced the plan the caller was shown (see `migration_plan_cache`'s
+/// module doc: the handle gate is what guarantees a commit can only sign the exact plan the user
+/// reviewed). On the reuse path the handle is not consulted: the commitment already happened —
+/// with a handle-verified plan — and is durable, so there is nothing left the handle could
+/// protect. Shared by both the in-process-signing and external-signer commit paths below; `sign`
+/// picks which `commit_preparation`/`build_preparation_unsigned` variant to run, and whether a
+/// spending key is available to the `Backend` while doing so.
 fn commit_or_reuse(
     network: &Network,
     wallet: &Wallet,
     account: AccountUuid,
     store_conn: &mut Connection,
     target: BlockHeight,
+    plan_handle: crate::migration_plan_cache::PlanHandle,
     usk: Option<UnifiedSpendingKey>,
     sign: impl FnOnce(
         &Network,
@@ -375,8 +406,7 @@ fn commit_or_reuse(
             }
         }
     }
-    let migration_plan = crate::migration_plan_cache::get(account)
-        .ok_or_else(|| anyhow!("No pending migration proposal — call propose/prepare first"))?;
+    let migration_plan = crate::migration_plan_cache::get(account, plan_handle)?;
     let mut backend = Backend::new(wallet, account, usk, store_conn)?;
     let mut rng = OsRng;
     let result = sign(network, target, &mut backend, &migration_plan, &mut rng)?;
@@ -477,6 +507,7 @@ fn derive_migration_state<'a>(
 fn encode_note_split_proposal<'a>(
     env: &mut JNIEnv<'a>,
     plan: &MigrationPlan,
+    plan_handle: crate::migration_plan_cache::PlanHandle,
 ) -> jni::errors::Result<JObject<'a>> {
     let split = plan.note_split();
     let values: Vec<i64> = split
@@ -490,8 +521,12 @@ fn encode_note_split_proposal<'a>(
 
     env.new_object(
         JNI_NOTE_SPLIT_PROPOSAL,
-        "([JJ)V",
-        &[JValue::Object(&values_array), JValue::Long(fee)],
+        "([JJJ)V",
+        &[
+            JValue::Object(&values_array),
+            JValue::Long(fee),
+            JValue::Long(plan_handle as i64),
+        ],
     )
 }
 
@@ -544,6 +579,7 @@ fn encode_migration_schedule<'a>(
     env: &mut JNIEnv<'a>,
     plan: &MigrationPlan,
     tip: BlockHeight,
+    plan_handle: crate::migration_plan_cache::PlanHandle,
 ) -> anyhow::Result<JObject<'a>> {
     // `funding_notes()`, NOT `note_split().crossing_values()`: the funding notes are the
     // post-reconciliation values (crossing_values() minus whatever the smallest denominations
@@ -635,10 +671,11 @@ fn encode_migration_schedule<'a>(
 
     Ok(env.new_object(
         JNI_MIGRATION_SCHEDULE,
-        format!("([L{JNI_TRANSFER_PROPOSAL};I)V"),
+        format!("([L{JNI_TRANSFER_PROPOSAL};IJ)V"),
         &[
             JValue::Object(&transfers),
             JValue::Int(estimated_duration_hours as jint),
+            JValue::Long(plan_handle as i64),
         ],
     )?)
 }
@@ -654,8 +691,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     account_uuid: JByteArray<'local>,
 ) -> jobject {
     let res = catch_unwind(&mut env, |env| {
-        let (migration_plan, _tip) = plan(env, db_data, network_id, account_uuid)?;
-        Ok(encode_note_split_proposal(env, &migration_plan)?.into_raw())
+        let (migration_plan, _tip, plan_handle) = plan(env, db_data, network_id, account_uuid)?;
+        Ok(encode_note_split_proposal(env, &migration_plan, plan_handle)?.into_raw())
     });
     unwrap_exc_or(&mut env, res, ptr::null_mut())
 }
@@ -672,8 +709,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     _include_residual: jboolean,
 ) -> jobject {
     let res = catch_unwind(&mut env, |env| {
-        let (migration_plan, tip) = plan(env, db_data, network_id, account_uuid)?;
-        Ok(encode_migration_schedule(env, &migration_plan, tip)?.into_raw())
+        let (migration_plan, tip, plan_handle) = plan(env, db_data, network_id, account_uuid)?;
+        Ok(encode_migration_schedule(env, &migration_plan, tip, plan_handle)?.into_raw())
     });
     unwrap_exc_or(&mut env, res, ptr::null_mut())
 }
@@ -681,10 +718,13 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
 /// The new engine plans the note split and the transfer schedule together in one
 /// `plan_migration()` call (the split's realized output values ARE `plan.note_split()
 /// .crossing_values()`, which is exactly what `encode_migration_schedule` already derives the
-/// schedule from) — so this and `proposeMigrationTransfersNative` above are now equivalent; kept
-/// as two JNI entry points only so the Kotlin call sites don't need to change. The double-spend
-/// class of bug this function existed to fix in the old crate (schedule computed independently of
-/// the split's realized output) cannot recur here: there is only ever one plan.
+/// schedule from) — so unlike `proposeMigrationTransfersNative` above, this does NOT plan afresh:
+/// it encodes the schedule of the exact cached plan `proposal_handle` identifies (the one whose
+/// split the user was just shown by `prepareNoteSplitNative`), erroring if that plan is missing
+/// or superseded. Re-planning here — as an earlier version did — would silently swap in a
+/// differently-randomized plan between the split display and the schedule display. The returned
+/// schedule carries the SAME handle: split view, schedule view, and eventual commit all refer to
+/// one plan.
 #[unsafe(no_mangle)]
 pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_proposeMigrationTransfersFromSplitNative<
     'local,
@@ -694,12 +734,18 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     db_data: JString<'local>,
     network_id: jint,
     account_uuid: JByteArray<'local>,
-    _output_values_zatoshi: JLongArray<'local>,
-    _fee_zatoshi: jlong,
+    proposal_handle: jlong,
 ) -> jobject {
     let res = catch_unwind(&mut env, |env| {
-        let (migration_plan, tip) = plan(env, db_data, network_id, account_uuid)?;
-        Ok(encode_migration_schedule(env, &migration_plan, tip)?.into_raw())
+        let (_network, wallet, _store_conn) = open(env, db_data, network_id)?;
+        let account = crate::account_id_from_jni(env, account_uuid)?;
+        let plan_handle = proposal_handle as u64;
+        let migration_plan = crate::migration_plan_cache::get(account, plan_handle)?;
+        let tip = wallet
+            .chain_height()
+            .map_err(|e| anyhow!("chain height lookup failed: {}", e))?
+            .ok_or_else(|| anyhow!("wallet has no chain tip yet"))?;
+        Ok(encode_migration_schedule(env, &migration_plan, tip, plan_handle)?.into_raw())
     });
     unwrap_exc_or(&mut env, res, ptr::null_mut())
 }
@@ -895,8 +941,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     db_data: JString<'local>,
     network_id: jint,
     account_uuid: JByteArray<'local>,
-    _output_values_zatoshi: JLongArray<'local>,
-    _fee_zatoshi: jlong,
+    proposal_handle: jlong,
     usk: JByteArray<'local>,
 ) -> jobject {
     let res = catch_unwind(&mut env, |env| {
@@ -910,6 +955,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
             account,
             &mut store_conn,
             target,
+            proposal_handle as u64,
             Some(usk),
             |network, target, backend, migration_plan, rng| {
                 let state =
@@ -1138,7 +1184,13 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         // `submitNoteSplit` then failed with "no note-split preparation transaction" since there
         // was nothing to sign). The real signal is whether the preparation plan has any
         // transactions to build at all.
-        let (migration_plan, _tip) = plan(env, db_data, network_id, account_uuid)?;
+        //
+        // `compute_plan`, NOT `plan`: this is a pure peek — caching its throwaway plan would
+        // invalidate the handle of any proposal the user is currently reviewing (see
+        // `migration_plan_cache`'s module doc).
+        let (network, wallet, mut store_conn) = open(env, db_data, network_id)?;
+        let account = crate::account_id_from_jni(env, account_uuid)?;
+        let (migration_plan, _tip) = compute_plan(&network, &wallet, account, &mut store_conn)?;
         Ok(if migration_plan.preparation().transaction_count() > 0 {
             JNI_TRUE
         } else {
@@ -1241,26 +1293,19 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     db_data: JString<'local>,
     network_id: jint,
     account_uuid: JByteArray<'local>,
-    _ids: JObjectArray<'local>,
-    _amounts_zatoshi: JLongArray<'local>,
-    _anchor_heights: JLongArray<'local>,
-    _next_executable_after_heights: JLongArray<'local>,
-    _expiry_heights: JLongArray<'local>,
-    _estimated_duration_hours: jint,
+    proposal_handle: jlong,
     usk: JByteArray<'local>,
 ) {
     let res = catch_unwind(&mut env, |env| {
         let (network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let usk = crate::decode_usk(env, usk)?;
-        // The Kotlin-supplied schedule arrays are ignored — `commit_preparation` takes a
-        // `MigrationPlan` value directly, not a caller-echoed schedule, and the new engine's plan
-        // types have no public constructor to rebuild one from primitives (verified against
-        // `zcash_pool_migration_backend`'s source, not assumed). Instead of re-deriving a fresh
-        // (differently-randomized) plan here, `commit_or_reuse` signs exactly the plan the most
-        // recent `propose*`/`prepare*` call cached — see `migration_plan_cache`'s module doc for
-        // why that matters (this was a real, discussed regression risk versus the old crate, which
-        // did sign exactly the caller-echoed values).
+        // No schedule fields cross the boundary here — `commit_preparation` takes a
+        // `MigrationPlan` value directly, and the plan's details never leave the Rust side:
+        // `proposal_handle` identifies the cached plan whose schedule the user was shown, and
+        // `commit_or_reuse` signs exactly that plan or errors (see `migration_plan_cache`'s
+        // module doc — this closes the sign-what-the-user-never-saw hazard of the previous
+        // latest-plan-wins cache contract).
         let target = target_height(&wallet)?;
         commit_or_reuse(
             &network,
@@ -1268,6 +1313,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
             account,
             &mut store_conn,
             target,
+            proposal_handle as u64,
             Some(usk),
             |network, target, backend, migration_plan, rng| {
                 let state =
@@ -1537,8 +1583,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     _include_residual: jboolean,
 ) -> jobject {
     let res = catch_unwind(&mut env, |env| {
-        let (migration_plan, tip) = plan(env, db_data, network_id, account_uuid)?;
-        Ok(encode_migration_schedule(env, &migration_plan, tip)?.into_raw())
+        let (migration_plan, tip, plan_handle) = plan(env, db_data, network_id, account_uuid)?;
+        Ok(encode_migration_schedule(env, &migration_plan, tip, plan_handle)?.into_raw())
     });
     unwrap_exc_or(&mut env, res, ptr::null_mut())
 }
@@ -1896,6 +1942,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     db_data: JString<'local>,
     network_id: jint,
     account_uuid: JByteArray<'local>,
+    proposal_handle: jlong,
 ) -> jbyteArray {
     let res = catch_unwind(&mut env, |env| {
         let (network, wallet, mut store_conn) = open(env, db_data, network_id)?;
@@ -1907,6 +1954,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
             account,
             &mut store_conn,
             target,
+            proposal_handle as u64,
             None,
             |network, target, backend, migration_plan, rng| {
                 let (state, unsigned) = engine::build_preparation_unsigned(
@@ -2016,19 +2064,14 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     db_data: JString<'local>,
     network_id: jint,
     account_uuid: JByteArray<'local>,
-    _ids: JObjectArray<'local>,
-    _amounts_zatoshi: JLongArray<'local>,
-    _anchor_heights: JLongArray<'local>,
-    _next_executable_after_heights: JLongArray<'local>,
-    _expiry_heights: JLongArray<'local>,
-    _estimated_duration_hours: jint,
+    proposal_handle: jlong,
 ) -> jobjectArray {
     let res = catch_unwind(&mut env, |env| {
         let (network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
-        // Mirrors `createUnsignedNoteSplitPcztNative`: the caller-supplied schedule arrays are
-        // ignored — `commit_or_reuse` signs exactly the plan cached by the preceding
-        // `propose*`/`prepare*` call, or (this being the *second* external-signer call in the
+        // Mirrors `createUnsignedNoteSplitPcztNative`: no schedule fields cross the boundary —
+        // `commit_or_reuse` builds exactly the cached plan `proposal_handle` identifies (erroring
+        // if it's missing or superseded), or (this being the *second* external-signer call in the
         // Keystone sequence, after `createUnsignedNoteSplitPcztNative` already committed) just
         // re-reads what's already persisted, rather than committing a second, independent plan
         // (which would have hit `CommitError::MigrationInProgress` from the engine anyway).
@@ -2039,6 +2082,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
             account,
             &mut store_conn,
             target,
+            proposal_handle as u64,
             None,
             |network, target, backend, migration_plan, rng| {
                 let (state, unsigned) = engine::build_preparation_unsigned(
@@ -2334,7 +2378,8 @@ mod live_wallet_tests {
         let (wallet, mut store_conn) = open_at(&db_path, network).expect("open wallet");
         let account = first_account(&wallet);
 
-        let (plan, tip) = plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
+        let (plan, tip, _handle) =
+            plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
 
         println!(
             "tip={tip:?} funding_notes={} prep_layers={} prep_txs={} direct_funding={}",
@@ -2420,7 +2465,7 @@ mod live_wallet_signing_tests {
              the seed phrase and/or account index (this test assumes account 0)"
         );
 
-        let (migration_plan, tip) =
+        let (migration_plan, tip, _handle) =
             plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
         let target = tip + 1;
 
@@ -2557,7 +2602,7 @@ mod live_wallet_signing_tests {
         let usk = UnifiedSpendingKey::from_seed(&network, &seed, zip32::AccountId::ZERO)
             .expect("derive USK from seed for account 0");
 
-        let (migration_plan, tip) =
+        let (migration_plan, tip, _handle) =
             plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
         let target = tip + 1;
 
@@ -2740,7 +2785,7 @@ mod live_wallet_edge_case_tests {
         assert_ne!(account_a, account_b);
 
         // Plan + commit an (unsigned) migration for account A only — account B is never touched.
-        let (plan_a, tip) =
+        let (plan_a, tip, _handle) =
             plan_for(&network, &wallet, account_a, &mut store_conn).expect("plan_for account_a");
         let target = tip + 1;
         {
@@ -2800,7 +2845,8 @@ mod live_wallet_edge_case_tests {
         // state unconditionally (no prior-state precondition, confirmed in
         // `zcash_pool_migration_backend::state`), so an `AwaitingSignature` transaction from
         // `build_preparation_unsigned` works fine here without needing real signing.
-        let (plan, tip) = plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
+        let (plan, tip, _handle) =
+            plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
         let target = tip + 1;
         let mut state = {
             let mut backend = Backend::new(&wallet, account, None, &mut store_conn)
@@ -2878,7 +2924,8 @@ mod live_wallet_edge_case_tests {
         let (wallet, mut store_conn) = open_at(&db_path, network).expect("open wallet");
         let account = first_account(&wallet);
 
-        let (_plan, tip) = plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
+        let (_plan, tip, handle) =
+            plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
         let target = tip + 1;
 
         let (state1, unsigned1) = commit_or_reuse(
@@ -2887,6 +2934,7 @@ mod live_wallet_edge_case_tests {
             account,
             &mut store_conn,
             target,
+            handle,
             None,
             sign_unsigned,
         )
@@ -2900,12 +2948,16 @@ mod live_wallet_edge_case_tests {
         // itself disturb the already-committed migration.
         plan_for(&network, &wallet, account, &mut store_conn).expect("re-plan after commit");
 
+        // Deliberately passes the ORIGINAL handle, which the re-plan above superseded: on the
+        // reuse path the handle must NOT be consulted (the commitment already happened, with a
+        // handle-verified plan) — a stale handle only blocks a FRESH commit.
         let (state2, unsigned2) = commit_or_reuse(
             &network,
             &wallet,
             account,
             &mut store_conn,
             target,
+            handle,
             None,
             sign_unsigned,
         )
@@ -2936,6 +2988,64 @@ mod live_wallet_edge_case_tests {
         }
     }
 
+    /// The plan-handle gate closing the approve-X-sign-Y hazard: a FRESH commit must refuse a
+    /// handle that a later `propose*`/`prepare*` call superseded (the caller would otherwise sign
+    /// a re-randomized schedule the user never reviewed), must refuse an unknown handle when
+    /// nothing is cached, and must succeed with the handle of the currently cached plan.
+    #[test]
+    #[ignore = "requires MIGRATION_TEST_WALLET_DB"]
+    fn fresh_commit_requires_the_current_plan_handle() {
+        use crate::migration_plan_cache::PlanLookupError;
+
+        let db_path = fresh_test_db_copy(&fixture_db_path());
+        let network = Network::TestNetwork;
+        let (wallet, mut store_conn) = open_at(&db_path, network).expect("open wallet");
+        let account = first_account(&wallet);
+
+        let (_plan1, tip, stale_handle) =
+            plan_for(&network, &wallet, account, &mut store_conn).expect("first plan");
+        let (_plan2, _tip2, current_handle) =
+            plan_for(&network, &wallet, account, &mut store_conn).expect("superseding plan");
+        let target = tip + 1;
+
+        let err = commit_or_reuse(
+            &network,
+            &wallet,
+            account,
+            &mut store_conn,
+            target,
+            stale_handle,
+            None,
+            sign_unsigned,
+        )
+        .expect_err("committing with a superseded handle must be rejected");
+        assert_eq!(
+            err.downcast_ref::<PlanLookupError>(),
+            Some(&PlanLookupError::Superseded),
+            "expected Superseded, got: {err:?}"
+        );
+
+        let (_state, unsigned) = commit_or_reuse(
+            &network,
+            &wallet,
+            account,
+            &mut store_conn,
+            target,
+            current_handle,
+            None,
+            sign_unsigned,
+        )
+        .expect("committing with the current handle succeeds");
+        assert!(!unsigned.is_empty());
+
+        // The successful commit consumed the cache — a would-be second fresh commit (were the
+        // committed state not already reusable) now reports Missing, not Superseded.
+        assert!(matches!(
+            crate::migration_plan_cache::get(account, current_handle),
+            Err(PlanLookupError::Missing)
+        ));
+    }
+
     /// Calling the raw engine directly (bypassing our `commit_or_reuse` reuse guard) a second
     /// time over an already-committed, non-terminal migration must fail with
     /// `CommitError::MigrationInProgress` — this is the exact condition `commit_or_reuse` relies
@@ -2949,7 +3059,8 @@ mod live_wallet_edge_case_tests {
         let (wallet, mut store_conn) = open_at(&db_path, network).expect("open wallet");
         let account = first_account(&wallet);
 
-        let (plan, tip) = plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
+        let (plan, tip, _handle) =
+            plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
         let target = tip + 1;
         {
             let mut backend = Backend::new(&wallet, account, None, &mut store_conn)
@@ -2985,7 +3096,7 @@ mod live_wallet_edge_case_tests {
         let committed_ids: Vec<MigrationTxId> = {
             let (wallet, mut store_conn) = open_at(&db_path, network).expect("open wallet");
             let account = first_account(&wallet);
-            let (plan, tip) =
+            let (plan, tip, _handle) =
                 plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
             let target = tip + 1;
             let mut backend = Backend::new(&wallet, account, None, &mut store_conn)
@@ -3031,7 +3142,7 @@ mod live_wallet_edge_case_tests {
         let (wallet, mut store_conn) = open_at(&db_path, network).expect("open wallet");
         let account = first_account(&wallet);
 
-        let (plan_before, _tip) =
+        let (plan_before, _tip, _handle) =
             plan_for(&network, &wallet, account, &mut store_conn).expect("plan before commit");
         let target = target_height(&wallet).expect("target height");
         {
@@ -3048,7 +3159,7 @@ mod live_wallet_edge_case_tests {
             .expect("commit");
         }
 
-        let (plan_after, _tip2) = plan_for(&network, &wallet, account, &mut store_conn)
+        let (plan_after, _tip2, _handle2) = plan_for(&network, &wallet, account, &mut store_conn)
             .expect("plan_migration must remain callable after a migration is committed");
 
         assert_eq!(

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -34,6 +34,7 @@ use jni::{
     objects::{JByteArray, JClass, JLongArray, JObject, JObjectArray, JString, JValue},
     sys::{JNI_FALSE, JNI_TRUE, jboolean, jbyteArray, jint, jlong, jobject, jobjectArray},
 };
+use prost::Message;
 use rand::rngs::OsRng;
 use rusqlite::{Connection, OptionalExtension};
 use std::ptr;
@@ -78,7 +79,7 @@ const JNI_KEYSTONE_BATCH_DECODE_RESULT: &str =
 const JNI_KEYSTONE_BATCH_SIGNED_PCZTS: &str =
     "cash/z/ecc/android/sdk/internal/model/migration/JniKeystoneBatchSignedPczts";
 
-type Wallet = zcash_client_sqlite::WalletDb<Connection, Network, SystemClock, OsRng>;
+pub(crate) type Wallet = zcash_client_sqlite::WalletDb<Connection, Network, SystemClock, OsRng>;
 
 /// Opens a fresh wallet-read connection plus a second, independent connection for the migration
 /// store (same on-disk file — SQLite supports multiple connections to one file; mirrors the old
@@ -622,8 +623,20 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     unwrap_exc_or(&mut env, res, ptr::null_mut())
 }
 
+/// IMMEDIATE mode's proposal entry point. Unlike `proposeMigrationTransfersNative` (which plans
+/// the AUTOMATIC-mode, shuffled N-transfer engine plan via `zcash_pool_migration_backend`), this
+/// bypasses the engine entirely: it builds an ordinary send-max proposal sweeping every spendable
+/// Orchard note into the account's own Ironwood receiver
+/// (`migration_engine::propose_immediate_send_max`). Nothing here reads or writes the persisted
+/// `MigrationState` — there is no plan to cache, commit, or reconcile, so this call has no
+/// interaction with `proposeMigrationTransfersNative`/`commit*`/`finalize*`'s shared state at all.
+///
+/// Returns the proposal encoded exactly like `RustBackend.proposeTransfer` encodes an ordinary
+/// send (`proto::proposal::Proposal::from_standard_proposal(..).encode_to_vec()`), so the Kotlin
+/// side can decode it with the same `Proposal.parseFrom` path an ordinary send already uses —
+/// deliberately not a new, migration-specific encoding.
 #[unsafe(no_mangle)]
-pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_proposeImmediateMigrationTransfersNative<
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_proposeImmediateSendMaxNative<
     'local,
 >(
     mut env: JNIEnv<'local>,
@@ -631,10 +644,19 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     db_data: JString<'local>,
     network_id: jint,
     account_uuid: JByteArray<'local>,
-) -> jobject {
+) -> jbyteArray {
     let res = catch_unwind(&mut env, |env| {
-        let (migration_plan, tip) = plan(env, db_data, network_id, account_uuid)?;
-        Ok(encode_migration_schedule(env, &migration_plan, tip)?.into_raw())
+        let (network, mut wallet, _store_conn) = open(env, db_data, network_id)?;
+        let account = crate::account_id_from_jni(env, account_uuid)?;
+        let proposal =
+            crate::migration_engine::propose_immediate_send_max(&network, &mut wallet, account)?;
+        Ok(crate::utils::rust_bytes_to_java(
+            env,
+            zcash_client_backend::proto::proposal::Proposal::from_standard_proposal(&proposal)
+                .encode_to_vec()
+                .as_ref(),
+        )?
+        .into_raw())
     });
     unwrap_exc_or(&mut env, res, ptr::null_mut())
 }
@@ -2246,6 +2268,59 @@ mod live_wallet_signing_tests {
             }
         }
         println!("{finalized} finalized, {transient} transient — nothing broadcast");
+    }
+
+    /// Proves IMMEDIATE mode's proposal is an ordinary send-max, not the shuffled N-transfer
+    /// engine plan AUTOMATIC mode commits: a single step, drawing only Orchard-pool inputs (no
+    /// transparent, no Sapling). Read-only (a proposal, never committed/signed), so — unlike
+    /// `commit_and_finalize_with_real_signing` above — this needs no `MIGRATION_TEST_SEED_PHRASE`
+    /// and never touches persisted `MigrationState`.
+    #[test]
+    #[ignore = "requires MIGRATION_TEST_WALLET_DB"]
+    fn immediate_send_max_sweeps_orchard_only_single_tx() {
+        let fixture = std::env::var("MIGRATION_TEST_WALLET_DB")
+            .map(std::path::PathBuf::from)
+            .expect("set MIGRATION_TEST_WALLET_DB");
+        let db_path = fresh_test_db_copy(&fixture);
+        let network = Network::TestNetwork;
+        let (mut wallet, _store_conn) = open_at(&db_path, network).expect("open wallet");
+        let account = wallet
+            .get_account_ids()
+            .expect("list accounts")
+            .into_iter()
+            .next()
+            .expect("wallet has at least one account — restore/sync one first");
+
+        let proposal =
+            crate::migration_engine::propose_immediate_send_max(&network, &mut wallet, account)
+                .expect("propose_immediate_send_max");
+
+        // Single step, single transaction — the whole point of send-max vs. the N-transfer
+        // engine plan.
+        assert_eq!(proposal.steps().len(), 1);
+        let step = &proposal.steps().head;
+
+        // Every input drawn is Orchard-pool: no transparent inputs swept at all, ...
+        assert!(
+            step.transparent_inputs().is_empty(),
+            "send-max sweep must not include transparent inputs: {:?}",
+            step.transparent_inputs()
+        );
+        // ... and every shielded input is specifically Orchard (no Sapling swept).
+        let shielded = step
+            .shielded_inputs()
+            .expect("send-max sweep should draw on shielded (Orchard) inputs");
+        for note in shielded.notes() {
+            assert_eq!(
+                note.note().pool(),
+                ShieldedPool::Orchard,
+                "send-max sweep must be Orchard-only, found a note in another pool"
+            );
+        }
+        println!(
+            "immediate send-max proposal: 1 step, {} shielded input(s), all Orchard",
+            shielded.notes().len()
+        );
     }
 
     /// Regression test for the Keystone/external-signer note-split crash (confirmed live:

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -912,6 +912,45 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     unwrap_exc_or(&mut env, res, ())
 }
 
+/// Reconciles mined-ness against the wallet's own transaction history before returning migration
+/// state, so `InProgress`/`Complete` derivation reflects broadcast truth instead of staying stuck at
+/// whatever `mark_broadcast` last recorded. The engine's own contract intentionally leaves mining
+/// detection to the caller (`state.rs` module doc: "the state machine's only job is to ORDER the
+/// broadcasts") — this is that caller-side reconciliation, run at read time rather than a background
+/// job, matching the iOS SDK's own `derive_state` reconciliation approach.
+fn read_reconciled(
+    wallet: &Wallet,
+    backend: &mut Backend<Wallet>,
+) -> anyhow::Result<Option<MigrationState>> {
+    let mut state = match backend
+        .get_migration()
+        .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
+    {
+        Some(s) => s,
+        None => return Ok(None),
+    };
+    let mut newly_mined = Vec::new();
+    for tx in state.transactions() {
+        if let MigrationTxState::Broadcast { txid } = tx.state() {
+            if let Some(height) = wallet
+                .get_tx_height(txid)
+                .map_err(|e| anyhow!("Error reading tx height for {:?}: {:?}", txid, e))?
+            {
+                newly_mined.push((tx.id(), height));
+            }
+        }
+    }
+    if !newly_mined.is_empty() {
+        for (id, height) in newly_mined {
+            state.mark_mined(id, height);
+        }
+        backend
+            .replace_migration(&state)
+            .map_err(|e| anyhow!("Error persisting reconciled migration state: {:?}", e))?;
+    }
+    Ok(Some(state))
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_migrationStateNative<
     'local,
@@ -926,10 +965,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let tip = target_height(&wallet)? - 1;
-        let backend = Backend::new(&wallet, account, None, &mut store_conn)?;
-        let persisted = backend
-            .get_migration()
-            .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?;
+        let mut backend = Backend::new(&wallet, account, None, &mut store_conn)?;
+        let persisted = read_reconciled(&wallet, &mut backend)?;
         Ok(derive_migration_state(env, &wallet, account, persisted, tip)?.into_raw())
     });
     unwrap_exc_or(&mut env, res, ptr::null_mut())
@@ -949,10 +986,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let tip = target_height(&wallet)? - 1;
-        let backend = Backend::new(&wallet, account, None, &mut store_conn)?;
-        let persisted = backend
-            .get_migration()
-            .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?;
+        let mut backend = Backend::new(&wallet, account, None, &mut store_conn)?;
+        let persisted = read_reconciled(&wallet, &mut backend)?;
         Ok(match persisted {
             Some(state) if !state.is_terminal() => {
                 let transactions = state.transactions();
@@ -1051,10 +1086,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let tip = target_height(&wallet)? - 1;
-        let backend = Backend::new(&wallet, account, None, &mut store_conn)?;
-        let persisted = backend
-            .get_migration()
-            .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?;
+        let mut backend = Backend::new(&wallet, account, None, &mut store_conn)?;
+        let persisted = read_reconciled(&wallet, &mut backend)?;
         Ok(match persisted {
             Some(state) if !state.is_terminal() => {
                 if state.next_broadcastable(tip).is_some() {
@@ -1082,10 +1115,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     let res = catch_unwind(&mut env, |env| {
         let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
-        let backend = Backend::new(&wallet, account, None, &mut store_conn)?;
-        let persisted = backend
-            .get_migration()
-            .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?;
+        let mut backend = Backend::new(&wallet, account, None, &mut store_conn)?;
+        let persisted = read_reconciled(&wallet, &mut backend)?;
         Ok(match persisted {
             Some(state) => match state.status() {
                 engine::MigrationStatus::Failed => JNI_TRUE,
@@ -1271,11 +1302,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let tip = target_height(&wallet)? - 1;
-        let backend = Backend::new(&wallet, account, None, &mut store_conn)?;
-        let Some(state) = backend
-            .get_migration()
-            .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
-        else {
+        let mut backend = Backend::new(&wallet, account, None, &mut store_conn)?;
+        let Some(state) = read_reconciled(&wallet, &mut backend)? else {
             return Ok(ptr::null_mut());
         };
 
@@ -1595,10 +1623,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let tip = target_height(&wallet)? - 1;
-        let backend = Backend::new(&wallet, account, None, &mut store_conn)?;
-        let persisted = backend
-            .get_migration()
-            .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?;
+        let mut backend = Backend::new(&wallet, account, None, &mut store_conn)?;
+        let persisted = read_reconciled(&wallet, &mut backend)?;
         Ok(match persisted {
             Some(state) if !state.is_terminal() => {
                 match state.next_broadcastable(tip).and_then(|id| {
@@ -2376,6 +2402,7 @@ mod live_wallet_edge_case_tests {
     use zcash_client_backend::data_api::chain::ChainState;
     use zcash_client_backend::data_api::{AccountBirthday, WalletWrite};
     use zcash_primitives::block::BlockHash;
+    use zcash_protocol::TxId;
 
     fn fixture_db_path() -> std::path::PathBuf {
         std::env::var("MIGRATION_TEST_WALLET_DB")
@@ -2390,6 +2417,24 @@ mod live_wallet_edge_case_tests {
             .into_iter()
             .next()
             .expect("wallet has at least one account — restore/sync one first")
+    }
+
+    /// Finds a real, already-mined transaction's txid in the fixture wallet DB, so a test can
+    /// simulate `WalletRead::get_tx_height` returning `Some(_)` for a migration transaction
+    /// without actually broadcasting anything and waiting for it to mine. `Wallet` (`WalletDb`)
+    /// keeps its own `rusqlite::Connection` private, so this queries the wallet's
+    /// `transactions` table directly through the migration store's own second connection to the
+    /// same on-disk file — the same raw-query pattern `debugRescheduleTransfersNative` already
+    /// uses against this DB.
+    fn a_mined_txid_in_fixture(store_conn: &Connection) -> TxId {
+        let txid_bytes: [u8; 32] = store_conn
+            .query_row(
+                "SELECT txid FROM transactions WHERE mined_height IS NOT NULL LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .expect("fixture wallet DB has at least one mined transaction");
+        TxId::from_bytes(txid_bytes)
     }
 
     /// Creates a second, synthetic, permanently-unfunded account in `wallet` — not derived from
@@ -2483,6 +2528,91 @@ mod live_wallet_edge_case_tests {
                  project_core_migration_swap memory and this test accordingly."
             ),
         }
+    }
+
+    /// `mark_mined` (`MigrationState::mark_mined`) is never called anywhere in this file's JNI
+    /// glue, so `InProgress`/`Complete` derivation never actually advanced past whatever
+    /// `mark_broadcast` last recorded — confirmed directly, not assumed (see
+    /// `recordTransferResultNative`'s own comment on this). `read_reconciled` is the fix: it
+    /// checks every `Broadcast` transaction against the wallet's own transaction history at read
+    /// time and promotes it to `Mined` (persisting the promotion) whenever the wallet already
+    /// knows a mined height for it.
+    #[test]
+    #[ignore = "requires MIGRATION_TEST_WALLET_DB"]
+    fn mark_mined_reconciles_on_read() {
+        let db_path = fresh_test_db_copy(&fixture_db_path());
+        let network = Network::TestNetwork;
+        let (wallet, mut store_conn) = open_at(&db_path, network).expect("open wallet");
+        let account = first_account(&wallet);
+
+        // Commit a migration, then manually drive one of its transactions to `Broadcast` using a
+        // real, already-mined txid from the fixture wallet DB — `mark_broadcast`/`mark_mined` set
+        // state unconditionally (no prior-state precondition, confirmed in
+        // `zcash_pool_migration_backend::state`), so an `AwaitingSignature` transaction from
+        // `build_preparation_unsigned` works fine here without needing real signing.
+        let (plan, tip) = plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
+        let target = tip + 1;
+        let mut state = {
+            let mut backend = Backend::new(&wallet, account, None, &mut store_conn)
+                .expect("account exists for migration store");
+            let mut rng = OsRng;
+            let (state, _unsigned) =
+                engine::build_preparation_unsigned(&network, target, &mut backend, &plan, &mut rng)
+                    .expect("commit migration");
+            state
+        };
+        let some_tx_id = state.transactions()[0].id();
+        let mined_txid = a_mined_txid_in_fixture(&store_conn);
+        state.mark_broadcast(some_tx_id, mined_txid);
+
+        let mut backend = Backend::new(&wallet, account, None, &mut store_conn)
+            .expect("account exists for migration store");
+        backend
+            .replace_migration(&state)
+            .expect("persist manually-advanced state");
+
+        // Before reconciliation, a raw read still shows Broadcast, not Mined.
+        let raw = backend
+            .get_migration()
+            .expect("read migration state")
+            .expect("migration state committed");
+        assert!(matches!(
+            raw.transactions()
+                .iter()
+                .find(|t| t.id() == some_tx_id)
+                .unwrap()
+                .state(),
+            MigrationTxState::Broadcast { .. }
+        ));
+
+        // read_reconciled() should promote it to Mined without any explicit mark_mined call here.
+        let reconciled = read_reconciled(&wallet, &mut backend)
+            .expect("read_reconciled")
+            .expect("migration state committed");
+        let reconciled_tx = reconciled
+            .transactions()
+            .iter()
+            .find(|t| t.id() == some_tx_id)
+            .unwrap();
+        assert!(matches!(
+            reconciled_tx.state(),
+            MigrationTxState::Mined { .. }
+        ));
+
+        // And the reconciliation persisted: a fresh raw read now also shows Mined.
+        let raw_again = backend
+            .get_migration()
+            .expect("read migration state")
+            .expect("migration state committed");
+        assert!(matches!(
+            raw_again
+                .transactions()
+                .iter()
+                .find(|t| t.id() == some_tx_id)
+                .unwrap()
+                .state(),
+            MigrationTxState::Mined { .. }
+        ));
     }
 
     /// `commit_or_reuse` (our own adapter, used by every commit-shaped JNI function) must REUSE

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -424,16 +424,14 @@ fn encode_migration_progress<'a>(
     env: &mut JNIEnv<'a>,
     completed: usize,
     total: usize,
-    remaining_orchard_value: Zatoshis,
     next_transfer_ready_at_height: i64,
 ) -> jni::errors::Result<JObject<'a>> {
     env.new_object(
         JNI_MIGRATION_PROGRESS,
-        "(IIJJ)V",
+        "(IIJ)V",
         &[
             JValue::Int(completed as jint),
             JValue::Int(total as jint),
-            JValue::Long(u64::from(remaining_orchard_value) as i64),
             JValue::Long(next_transfer_ready_at_height),
         ],
     )
@@ -450,8 +448,6 @@ fn encode_migration_progress<'a>(
 /// §7 item — this was flagged as a known open risk before implementation started).
 fn derive_migration_state<'a>(
     env: &mut JNIEnv<'a>,
-    wallet: &Wallet,
-    account: AccountUuid,
     persisted: Option<MigrationState>,
     tip: BlockHeight,
 ) -> anyhow::Result<JObject<'a>> {
@@ -486,11 +482,6 @@ fn derive_migration_state<'a>(
         .iter()
         .filter(|t| matches!(t.state(), MigrationTxState::Mined { .. }))
         .count();
-    let remaining_orchard_value = wallet
-        .get_account(account)
-        .map_err(|e| anyhow!("account lookup failed: {}", e))?
-        .and_then(|_| None::<Zatoshis>)
-        .unwrap_or(Zatoshis::ZERO);
     let next_ready = state.next_broadcastable(tip);
     let next_transfer_ready_at_height = next_ready
         .and_then(|id| transactions.iter().find(|t| t.id() == id))
@@ -500,7 +491,6 @@ fn derive_migration_state<'a>(
         env,
         completed,
         total,
-        remaining_orchard_value,
         next_transfer_ready_at_height,
     )?;
     Ok(env.new_object(
@@ -1122,7 +1112,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let tip = target_height(&wallet)? - 1;
         let mut backend = Backend::new(&wallet, account, None, &mut store_conn)?;
         let persisted = read_reconciled(&wallet, &mut backend)?;
-        Ok(derive_migration_state(env, &wallet, account, persisted, tip)?.into_raw())
+        Ok(derive_migration_state(env, persisted, tip)?.into_raw())
     });
     unwrap_exc_or(&mut env, res, ptr::null_mut())
 }
@@ -1159,7 +1149,6 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                     env,
                     completed,
                     transactions.len(),
-                    Zatoshis::ZERO,
                     next_ready_height,
                 )?
                 .into_raw()

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -86,6 +86,12 @@ const JNI_KEYSTONE_BATCH_DECODE_RESULT: &str =
 const JNI_KEYSTONE_BATCH_SIGNED_PCZTS: &str =
     "cash/z/ecc/android/sdk/internal/model/migration/JniKeystoneBatchSignedPczts";
 
+/// The zatoshi value below which a leftover post-migration Orchard balance is treated as dust
+/// rather than a residual worth migrating in its own (non-round-number, more identifiable)
+/// transfer. 100,000 zatoshi = 0.001 ZEC. A fixed protocol-level constant, not derived from wallet
+/// or account state, so it needs no database access to read.
+pub const MIGRATION_DUST_THRESHOLD_ZATOSHI: u64 = 100_000;
+
 pub(crate) type Wallet = zcash_client_sqlite::WalletDb<Connection, Network, SystemClock, OsRng>;
 
 /// Opens a fresh wallet-read connection plus a second, independent connection for the migration
@@ -1898,6 +1904,20 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         })
     });
     unwrap_exc_or(&mut env, res, ptr::null_mut())
+}
+
+/// A pure constant read — [`MIGRATION_DUST_THRESHOLD_ZATOSHI`] is a fixed protocol-level value,
+/// not derived from any wallet or account state, so unlike every other export in this file this
+/// needs no `db_data`/`network_id`/account argument and can't fail or panic (no `catch_unwind` /
+/// `unwrap_exc_or` needed).
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_migrationDustThresholdZatoshiNative<
+    'local,
+>(
+    _env: JNIEnv<'local>,
+    _: JClass<'local>,
+) -> jlong {
+    MIGRATION_DUST_THRESHOLD_ZATOSHI as jlong
 }
 
 // ----- External signer (Keystone hardware wallet) -----

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -72,6 +72,10 @@ const JNI_TRANSFER_PROPOSAL: &str =
     "cash/z/ecc/android/sdk/internal/model/migration/JniTransferProposal";
 const JNI_MIGRATION_SCHEDULE: &str =
     "cash/z/ecc/android/sdk/internal/model/migration/JniMigrationSchedule";
+const JNI_MIGRATION_TRANSFER_STATE: &str =
+    "cash/z/ecc/android/sdk/internal/model/migration/JniMigrationTransferState";
+const JNI_MIGRATION_TRANSFER_STATES: &str =
+    "cash/z/ecc/android/sdk/internal/model/migration/JniMigrationTransferStates";
 const JNI_UNSIGNED_TRANSFER_PCZT: &str =
     "cash/z/ecc/android/sdk/internal/model/migration/JniUnsignedTransferPczt";
 const JNI_KEYSTONE_BATCH_DECODE_RESULT: &str =
@@ -100,6 +104,83 @@ fn open_at(db_path: &std::path::Path, network: Network) -> anyhow::Result<(Walle
     // call, see `lib.rs`), not by this crate — no separate init call needed here.
     ensure_migration_schema_current(&store_conn)?;
     Ok((wallet, store_conn))
+}
+
+/// The lowest `anchor_boundary` height still needed by any account's migration transactions that
+/// have not yet reached `Broadcast`/`Mined` — i.e. still need proving or broadcasting — across
+/// every account in the wallet at `db_path`.
+///
+/// This is the typed reference implementation of the anchor-retention floor fed into
+/// `EngineConfig::anchor_retention_height` at every Slipstream sync-session (re)start — see
+/// `backend-lib/slipstream-jni/src/lib.rs`'s `min_pending_migration_anchor_boundary` and
+/// `start_session` for the actual wired call site and the full pruning-bug rationale
+/// (`zcash_client_backend`'s block-persistence path otherwise prunes a checkpoint out from under
+/// a not-yet-proved migration transfer, ZIP 374, failing with `Query(NotContained(..))`).
+///
+/// `slipstream-jni` does NOT call this function directly: `backend-lib`'s own `Cargo.toml`
+/// already depends on `slipstream-jni` (`slipstream-jni = { path = "slipstream-jni" }`, to merge
+/// its JNI exports into one `libzcashlc.so`), so the reverse edge needed to call from
+/// `slipstream-jni` into this crate would be a cyclic package dependency — impossible regardless
+/// of the two crates' separate `[workspace]` roots. `slipstream-jni` instead runs an equivalent
+/// raw SQL query directly against `orchard_ironwood_migrations`/
+/// `orchard_ironwood_migration_transactions` (see that function's doc comment). This function is
+/// kept anyway as the typed, `PoolMigrationRead`-based reference this crate can unit-test against
+/// a real wallet DB (`live_wallet_edge_case_tests`-style, gated on `MIGRATION_TEST_WALLET_DB`) to
+/// verify the raw-SQL mirror stays correct, and as the natural call site if this crate ever grows
+/// its own direct consumer of the value (e.g. a debug JNI export). Hence `#[allow(dead_code)]`
+/// below: nothing in this crate's non-test code calls it today.
+///
+/// Preparation transactions are excluded (`anchor_boundary() == None`): they anchor to a freshly
+/// current tip at prove time (see `natural_anchor_height`'s doc comment), not a boundary drawn in
+/// advance, so they never need retroactive protection.
+///
+/// Returns `Ok(None)` if there's no in-progress migration in any account, or every transaction
+/// needing a boundary has already broadcast/mined.
+///
+/// Deliberately kept as a plain `anyhow::Result` (matching every other function in this file, e.g.
+/// `plan_for`), rather than swallowing errors internally: this function has no JNI boundary of its
+/// own to report through, so any caller is responsible for treating an `Err` as "no retention
+/// floor" — logging and falling back to `None` — since a wallet DB read glitch here must never
+/// block sync from starting (see the `slipstream-jni` call site for that fallback in practice).
+#[allow(dead_code)]
+pub(crate) fn min_pending_anchor_boundary(
+    db_path: &std::path::Path,
+    network: Network,
+) -> anyhow::Result<Option<u32>> {
+    let (wallet, mut store_conn) = open_at(db_path, network)?;
+    let account_ids = wallet
+        .get_account_ids()
+        .map_err(|e| anyhow!("Error listing account ids: {}", e))?;
+
+    let mut min_height: Option<BlockHeight> = None;
+    for account in account_ids {
+        let backend = Backend::new(&wallet, account, None, &mut store_conn)?;
+        let Some(state) = backend.get_migration().map_err(|e| {
+            anyhow!(
+                "Error reading migration state for account {:?}: {:?}",
+                account,
+                e
+            )
+        })?
+        else {
+            continue;
+        };
+        if state.is_terminal() {
+            continue;
+        }
+        for tx in state.transactions() {
+            if matches!(
+                tx.state(),
+                MigrationTxState::Broadcast { .. } | MigrationTxState::Mined { .. }
+            ) {
+                continue;
+            }
+            if let Some(boundary) = tx.anchor_boundary() {
+                min_height = Some(min_height.map_or(boundary, |existing| existing.min(boundary)));
+            }
+        }
+    }
+    Ok(min_height.map(u32::from))
 }
 
 /// Self-heals `orchard_ironwood_migration_transactions` against a wallet created between two
@@ -1364,6 +1445,86 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     unwrap_exc_or(&mut env, res, ptr::null_mut())
 }
 
+/// The live, persisted status of every committed transfer transaction — reads straight from the
+/// migration store's current `scheduled_height`/state columns, so it reflects any reschedule
+/// (production `rescheduleOverdueTransfer()` or the debug-only `debugRescheduleTransfersNative`)
+/// immediately, unlike the app's own `MigrationPlanRepository` cache (populated once, at
+/// propose/commit time, and only ever updated by whichever caller remembers to write through it).
+/// Returns `null` if there's no in-progress migration.
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_migrationTransferStatesNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+) -> jobject {
+    let res = catch_unwind(&mut env, |env| {
+        let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
+        let account = crate::account_id_from_jni(env, account_uuid)?;
+        let tip = target_height(&wallet)? - 1;
+        let backend = Backend::new(&wallet, account, None, &mut store_conn)?;
+        let Some(state) = backend
+            .get_migration()
+            .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
+        else {
+            return Ok(ptr::null_mut());
+        };
+
+        // Keyed by the transfer's real, stable MigrationTxId — NOT `transfer_crossing()` (the
+        // funding-note/crossing index). The app's displayed "Transfer N" position comes from
+        // sorting the ORIGINAL proposal by broadcast_height (see `encode_migration_schedule`),
+        // while the engine assigns real tx ids in crossing/schedule() order at commit time —
+        // ZIP 318 deliberately shuffles those two orderings apart, so they permanently disagree.
+        // The app now carries this same id on its cached `MigrationTransfer.id` (see
+        // `MigrationSchedule.toMigrationPlan`), which is the only stable key the two sides share.
+        let transfers: Vec<(MigrationTxId, bool, BlockHeight)> = state
+            .transactions()
+            .iter()
+            .filter(|t| matches!(t.kind(), MigrationTxKind::Transfer { .. }))
+            .map(|t| {
+                let is_sent = matches!(
+                    t.state(),
+                    MigrationTxState::Broadcast { .. } | MigrationTxState::Mined { .. }
+                );
+                (t.id(), is_sent, t.scheduled_height())
+            })
+            .collect();
+
+        let jtransfers = crate::utils::rust_vec_to_java(
+            env,
+            transfers,
+            JNI_MIGRATION_TRANSFER_STATE,
+            |env, (id, is_sent, scheduled_height)| {
+                let id = encode_transfer_id(env, id)?;
+                env.new_object(
+                    JNI_MIGRATION_TRANSFER_STATE,
+                    "(Ljava/lang/String;ZJ)V",
+                    &[
+                        JValue::Object(&id),
+                        JValue::Bool(is_sent as jboolean),
+                        JValue::Long(i64::from(u32::from(scheduled_height))),
+                    ],
+                )
+            },
+        )?;
+
+        Ok(env
+            .new_object(
+                JNI_MIGRATION_TRANSFER_STATES,
+                format!("([L{JNI_MIGRATION_TRANSFER_STATE};J)V"),
+                &[
+                    JValue::Object(&jtransfers),
+                    JValue::Long(i64::from(u32::from(tip))),
+                ],
+            )?
+            .into_raw())
+    });
+    unwrap_exc_or(&mut env, res, ptr::null_mut())
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_restartCurrentMigrationStepNative<
     'local,
@@ -1520,20 +1681,33 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
 /// scheduling`'s module doc: this is a deliberate anti-correlation choice, not a technical
 /// requirement). Not exposed to production users.
 ///
-/// Only `scheduled_height` (which gates BROADCAST — see `next_broadcastable`) is touched; nothing
-/// about proving, anchors, or dependency-mining is bypassed:
-/// - A transfer's `anchor_boundary` (drawn at commit time) is left exactly as the engine chose it.
-///   It settles (becomes provable) on its own once the chain tip passes it by one block — that
-///   boundary is already a historical, already-mined block when drawn, so this is normally within
-///   about one block regardless of this override, not something this function needs to touch.
+/// Both `scheduled_height` (which gates BROADCAST — see `next_broadcastable`) AND `anchor_boundary`
+/// (which gates PROVING — see `is_prove_ready`) are rewritten; dependency-mining is not touched or
+/// bypassed:
+/// - A transfer's `anchor_boundary`, as originally drawn at commit time
+///   (`scheduling::draw_anchor_boundary`), is a boundary in the past relative to the chain tip
+///   *at commit time* — normally already passed by the time the transfer's (much later,
+///   ZIP-318-delayed) `scheduled_height` arrives. This override exists precisely because
+///   `debugRescheduleTransfers` moves `scheduled_height` to now, while the original
+///   `anchor_boundary` stays wherever it was drawn — confirmed live: the original boundary can
+///   still be ~70-1800 blocks AHEAD of the current synced tip, since it was never meant to be
+///   reached this soon. Left alone, `is_prove_ready` (`boundary + 1 < target_height`) would keep
+///   failing regardless of how close `scheduled_height` is. So every rescheduled transfer's
+///   `anchor_boundary` is also rewritten, to `natural_anchor_height` — the SAME anchor ordinary
+///   non-migration sends use (guaranteed checkpointed/witnessed). NOT a full `BOUNDARY_MODULUS`
+///   bucket back like `draw_anchor_boundary` draws in production (that bucketing is a privacy
+///   measure, irrelevant here, and lands outside the checkpoint retention window — confirmed live
+///   via `AnchorNotFound`), and NOT a hand-picked "tip minus N" guess either (also not guaranteed
+///   checkpointed — see `natural_anchor_height`'s own doc comment) — so proving can proceed as
+///   soon as `finalizeReadyTransfers` next runs.
 /// - Transfers do NOT depend on each other (confirmed directly: `MigrationTransaction::depends_on`
 ///   for a `Transfer` never lists another transfer's id, only the single preparation transaction
 ///   that minted its own funding note, if any) — so every transfer can be staggered independently;
 ///   there is no need to wait for transfer N to broadcast before N+1 becomes due.
 /// - A transfer whose funding note comes from an actual note-split (preparation) transaction still
 ///   genuinely cannot broadcast until that preparation transaction is MINED (`deps_mined`) — this
-///   function does not and cannot bypass that; it only affects how soon a transfer becomes due
-///   once its real dependencies are satisfied.
+///   function does not and cannot bypass that; it only affects how soon a transfer becomes due and
+///   provable once its real dependencies are satisfied.
 ///
 /// Every not-yet-broadcast/mined TRANSFER (preparation transactions are left alone) is
 /// rescheduled to `tip + FIRST_DELAY_BLOCKS + i * STRIDE_BLOCKS`, in `i` = the transfers' existing
@@ -1561,6 +1735,15 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let (_network, wallet, store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let target = target_height(&wallet)?;
+        // The wallet's real, currently-witnessable anchor — NOT a hand-picked "tip minus N" guess.
+        // A full BOUNDARY_MODULUS (144-block) bucket back, like the real engine's
+        // draw_anchor_boundary draws, falls outside the checkpoint/witness retention window
+        // (confirmed live: AnchorNotFound at tip-256); a smaller ad-hoc offset (tip-5) isn't
+        // guaranteed checkpointed either — natural_anchor_height's own doc comment warns about
+        // this exact class of mistake ("NOT just chain tip minus one, which isn't necessarily
+        // checkpointed"). This is the same anchor ordinary non-migration sends use, so it's
+        // guaranteed available.
+        let debug_anchor_boundary = u32::from(natural_anchor_height(&wallet)?);
 
         let migration_id: Option<i64> = store_conn
             .query_row(
@@ -1593,11 +1776,28 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
 
         for (i, tx_id) in tx_ids.iter().enumerate() {
             let new_height = u32::from(target) + FIRST_DELAY_BLOCKS + (i as u32) * STRIDE_BLOCKS;
+            // `is_prove_ready` (`finalizeReadyTransfers`) gates purely on `anchor_boundary`, NOT on
+            // `scheduled_height` — so rewriting every transfer's anchor here would make ALL of them
+            // prove-ready in the same `finalizeReadyTransfers` call (confirmed live: 12 real Halo2
+            // proofs run back-to-back under one MIGRATION_DB_ACCESS_MUTEX hold, ~4-5 minutes,
+            // starving a concurrent "Send Now" tap the whole time — not a hang, just an unrealistic
+            // proving batch this debug tool itself created). Only the earliest-due transfer (i==0,
+            // this loop's existing scheduled_height-ascending order) gets a valid anchor; the rest
+            // keep their original, still-in-the-future one, matching production's natural
+            // one-becomes-ready-at-a-time shape. Re-invoke this debug action once this transfer
+            // broadcasts to unlock the next one.
+            let anchor_boundary = if i == 0 {
+                Some(debug_anchor_boundary)
+            } else {
+                None
+            };
             store_conn
                 .execute(
                     "UPDATE orchard_ironwood_migration_transactions \
-                     SET scheduled_height = ?1 WHERE migration_id = ?2 AND tx_id = ?3",
-                    rusqlite::params![new_height, migration_id, tx_id],
+                     SET scheduled_height = ?1, \
+                         anchor_boundary = COALESCE(?2, anchor_boundary) \
+                     WHERE migration_id = ?3 AND tx_id = ?4",
+                    rusqlite::params![new_height, anchor_boundary, migration_id, tx_id],
                 )
                 .map_err(|e| anyhow!("Error rescheduling transfer {tx_id}: {}", e))?;
         }

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -1178,31 +1178,6 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     unwrap_exc_or(&mut env, res, ())
 }
 
-#[unsafe(no_mangle)]
-pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_isSyncRequiredBeforeNextTransferNative<
-    'local,
->(
-    mut env: JNIEnv<'local>,
-    _: JClass<'local>,
-    db_data: JString<'local>,
-    network_id: jint,
-    account_uuid: JByteArray<'local>,
-) -> jboolean {
-    // ZIP 318's sync/broadcast decoupling MUST is enforced app-side (`MigrationWorker.kt`'s
-    // `isSyncRequiredBeforeNextTransfer()` check, unaffected by this rewire — see spec doc §6.8),
-    // not by the migration engine itself in either the old or new crate. This function's own
-    // contract (does the engine think a sync is due before the next transfer) has no direct
-    // equivalent surfaced by the new engine's public API; conservatively return false (no
-    // additional engine-side gate) since the app-side check already covers the ZIP 318
-    // requirement independently.
-    let res = catch_unwind(&mut env, |env| {
-        let _ = open(env, db_data, network_id)?;
-        let _ = crate::account_id_from_jni(env, account_uuid)?;
-        Ok(JNI_FALSE)
-    });
-    unwrap_exc_or(&mut env, res, JNI_FALSE)
-}
-
 /// Advances every due, signed transaction's proving (ZIP 374: installs its real anchor + witness
 /// via the `pczt` `Updater` role and runs the `Prover`, via `try_prove` — see its doc comment).
 /// Proving moves each ready transaction `Signed -> Proved` directly in the persisted

--- a/backend-lib/src/main/rust/migration_engine.rs
+++ b/backend-lib/src/main/rust/migration_engine.rs
@@ -12,18 +12,25 @@
 //! one, and `zcash_pool_migration_backend::engine::build_preparation_unsigned` never calls it (only
 //! `commit_preparation`'s in-process-signing path does).
 
+use std::convert::Infallible;
+
 use rusqlite::Connection;
 
 use incrementalmerkletree::Position;
-use orchard::keys::{FullViewingKey, SpendAuthorizingKey};
+use orchard::keys::{FullViewingKey, Scope, SpendAuthorizingKey};
 use orchard::note::Note as OrchardNote;
+use zcash_client_backend::address::Receiver;
+use zcash_client_backend::data_api::MaxSpendMode;
 use zcash_client_backend::data_api::wallet::TargetHeight;
 use zcash_client_backend::data_api::wallet::input_selection::{LockFilter, LockedInputPolicy};
+use zcash_client_backend::data_api::wallet::{ConfirmationsPolicy, propose_send_max_transfer};
 use zcash_client_backend::data_api::{Account, InputSource, WalletRead};
+use zcash_client_backend::fees::StandardFeeRule;
 use zcash_client_backend::keys::UnifiedSpendingKey;
+use zcash_client_backend::proposal::Proposal;
 use zcash_client_sqlite::AccountUuid;
 use zcash_protocol::ShieldedPool;
-use zcash_protocol::consensus::BlockHeight;
+use zcash_protocol::consensus::{BlockHeight, Network, Parameters};
 use zcash_protocol::value::Zatoshis;
 
 use zcash_client_sqlite::pool_migration::orchard_ironwood::PoolMigrations;
@@ -31,6 +38,8 @@ use zcash_pool_migration_backend::engine::{
     MigrationBackend, MigrationCrypto, MigrationState, MigrationTxId, MigrationTxState,
     PoolMigrationRead, PoolMigrationWrite,
 };
+
+use crate::migration::Wallet;
 
 type SpendableNote = (OrchardNote, Position, u64);
 
@@ -220,4 +229,58 @@ where
             .update_transaction(id, state)
             .map_err(|e| anyhow::anyhow!("updating migration transaction failed: {e:?}"))
     }
+}
+
+/// Builds an ordinary send-max proposal sweeping every spendable Orchard note into the account's
+/// own Ironwood receiver — bypassing `zcash_pool_migration_backend` entirely. Unlike AUTOMATIC
+/// mode's `plan_migration`/`commit_preparation`/`commit_or_reuse` path, this function never reads
+/// or writes the persisted `MigrationState`: there is nothing to reconcile, no `is_immediate`
+/// flag, no consumed-run bookkeeping, because the engine's `InProgress`/`Complete` derivation
+/// (which only ever looks at `PoolMigrationRead::get_migration`) is simply never invoked for an
+/// immediate run. IMMEDIATE is a synchronous, foreground, user-driven send — behaviorally
+/// identical to an ordinary send once this proposal exists; the caller is expected to build/sign/
+/// submit it exactly like any other `propose_transfer` result (see `migration.rs`'s
+/// `proposeImmediateSendMaxNative`, which encodes the returned `Proposal` with the same
+/// `proto::proposal::Proposal::from_standard_proposal` path an ordinary send already uses).
+///
+/// The destination is the account's own internal Ironwood receiver. Ironwood shares the Orchard
+/// receiver encoding end to end (confirmed in `zcash_keys::address::Address::can_receive_as`:
+/// `PoolType::Shielded(ShieldedPool::Orchard | ShieldedPool::Ironwood)` both match an Orchard
+/// receiver) — there is no separate "Ironwood address" type, so deriving
+/// `orchard_fvk.address_at(0u32, Scope::Internal)` and wrapping it as `Receiver::Orchard` before
+/// encoding to a `ZcashAddress` is both correct and exactly how
+/// `zcash_pool_migration_backend::build::build_transfer_pczt` derives a migration transfer's own
+/// crossing destination (its `recipient = orchard_fvk.address_at(0u32, Scope::Internal)`) — this
+/// reuses that same derivation, not a second one.
+pub fn propose_immediate_send_max(
+    params: &Network,
+    wallet: &mut Wallet,
+    account: AccountUuid,
+) -> anyhow::Result<Proposal<StandardFeeRule, <Wallet as InputSource>::NoteRef>> {
+    let orchard_fvk = wallet
+        .get_account(account)
+        .map_err(|e| anyhow::anyhow!("account lookup failed: {e}"))?
+        .ok_or_else(|| anyhow::anyhow!("unknown account"))?
+        .ufvk()
+        .and_then(|ufvk| ufvk.orchard())
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("account has no Orchard full viewing key"))?;
+
+    let ironwood_receiver = orchard_fvk.address_at(0u32, Scope::Internal);
+    let recipient = Receiver::Orchard(ironwood_receiver).to_zcash_address(params.network_type());
+
+    propose_send_max_transfer::<_, _, _, Infallible>(
+        wallet,
+        params,
+        account,
+        &[ShieldedPool::Orchard],
+        &StandardFeeRule::Zip317,
+        recipient,
+        None, // no memo
+        MaxSpendMode::MaxSpendable,
+        ConfirmationsPolicy::default(),
+        &LockedInputPolicy::Exclude,
+        None, // no note locking for the immediate sweep itself
+    )
+    .map_err(|e| anyhow::anyhow!("Error proposing immediate send-max: {:?}", e))
 }

--- a/backend-lib/src/main/rust/migration_engine.rs
+++ b/backend-lib/src/main/rust/migration_engine.rs
@@ -1,0 +1,223 @@
+//! Adapter wiring the Android wallet database into `zcash_pool_migration_backend`'s
+//! `MigrationBackend`/`MigrationCrypto`/`PoolMigrationRead`/`PoolMigrationWrite` traits.
+//!
+//! This is deliberately a separate, thinner adapter than `zcash_pool_migration_backend::wallet::
+//! WalletMigration`: that type's constructor requires a `UnifiedSpendingKey` unconditionally
+//! (its `orchard_fvk()` is derived from the usk), but several JNI entry points in `migration.rs`
+//! only ever plan or build unsigned PCZTs (no usk available at that call site — mirroring the old
+//! `zcash_pool_migration` crate, which likewise derived the FVK from the account's stored UFVK,
+//! not from a spending key). `Backend::usk` is therefore optional: every method needed for
+//! planning/building unsigned PCZTs (`orchard_fvk`, `resolve_wallet_note`,
+//! `spendable_orchard_note_values`, `chain_tip_height`) works without it; only `sign()` requires
+//! one, and `zcash_pool_migration_backend::engine::build_preparation_unsigned` never calls it (only
+//! `commit_preparation`'s in-process-signing path does).
+
+use rusqlite::Connection;
+
+use incrementalmerkletree::Position;
+use orchard::keys::{FullViewingKey, SpendAuthorizingKey};
+use orchard::note::Note as OrchardNote;
+use zcash_client_backend::data_api::wallet::TargetHeight;
+use zcash_client_backend::data_api::wallet::input_selection::{LockFilter, LockedInputPolicy};
+use zcash_client_backend::data_api::{Account, InputSource, WalletRead};
+use zcash_client_backend::keys::UnifiedSpendingKey;
+use zcash_client_sqlite::AccountUuid;
+use zcash_protocol::ShieldedPool;
+use zcash_protocol::consensus::BlockHeight;
+use zcash_protocol::value::Zatoshis;
+
+use zcash_client_sqlite::pool_migration::orchard_ironwood::PoolMigrations;
+use zcash_pool_migration_backend::engine::{
+    MigrationBackend, MigrationCrypto, MigrationState, MigrationTxId, MigrationTxState,
+    PoolMigrationRead, PoolMigrationWrite,
+};
+
+type SpendableNote = (OrchardNote, Position, u64);
+
+/// The migration adapter's `Backend`/`MigrationCrypto`/`PoolMigrationRead`/`PoolMigrationWrite`
+/// error type. Everything is folded into `anyhow::Error` (matching the rest of this JNI glue's
+/// idiom) rather than the parameterized error type `WalletMigration` uses, since this adapter is
+/// only ever instantiated over one concrete wallet type.
+pub type EngineError = anyhow::Error;
+
+/// A migration backend over the Android SDK's own wallet database, an account, an optional
+/// spending key (required only for in-process signing), and a `PoolMigrations` store borrow.
+pub struct Backend<'a, W> {
+    wallet: &'a W,
+    account: AccountUuid,
+    usk: Option<UnifiedSpendingKey>,
+    store: PoolMigrations<&'a mut Connection>,
+}
+
+impl<'a, W> Backend<'a, W>
+where
+    W: WalletRead<AccountId = AccountUuid> + InputSource<AccountId = AccountUuid>,
+    <W as WalletRead>::Error: std::error::Error + Send + Sync + 'static,
+    <W as InputSource>::Error: std::error::Error + Send + Sync + 'static,
+{
+    /// Fails if `account` has no row in the wallet's `accounts` table (the store is now scoped to
+    /// the account row, not a per-wallet singleton — see `PoolMigrations::for_account`).
+    pub fn new(
+        wallet: &'a W,
+        account: AccountUuid,
+        usk: Option<UnifiedSpendingKey>,
+        conn: &'a mut Connection,
+    ) -> Result<Self, EngineError> {
+        let store = PoolMigrations::for_account(conn, account)
+            .map_err(|e| anyhow::anyhow!("opening pool-migration store failed: {e:?}"))?;
+        Ok(Self {
+            wallet,
+            account,
+            usk,
+            store,
+        })
+    }
+
+    fn selection_target(&self) -> Result<TargetHeight, EngineError> {
+        let tip = self
+            .wallet
+            .chain_height()
+            .map_err(|e| anyhow::anyhow!("chain height lookup failed: {e}"))?
+            .ok_or_else(|| anyhow::anyhow!("wallet has no chain tip yet"))?;
+        Ok(TargetHeight::from(u32::from(tip) + 1))
+    }
+
+    /// The account's spendable Orchard notes as `(note, tree position, value)`, sorted by tree
+    /// position so an index is stable across calls within one JNI invocation (matches
+    /// `WalletMigration`'s own ordering contract, which the engine relies on).
+    fn spendable_orchard(&self) -> Result<Vec<SpendableNote>, EngineError> {
+        let target = self.selection_target()?;
+        // Exclude notes locked by another in-flight proposal (e.g. a concurrent foreground send)
+        // rather than ignoring locks — migration actually spends these notes, so racing a locked
+        // one would double-spend against whatever proposal is holding it.
+        let received = self
+            .wallet
+            .select_unspent_notes(
+                self.account,
+                &[ShieldedPool::Orchard],
+                target,
+                &[],
+                LockFilter::Policy(&LockedInputPolicy::Exclude),
+            )
+            .map_err(|e| anyhow::anyhow!("selecting spendable Orchard notes failed: {e}"))?;
+        let mut notes: Vec<SpendableNote> = received
+            .orchard()
+            .iter()
+            .map(|rn| {
+                let note = *rn.note();
+                let value = note.value().inner();
+                (note, rn.note_commitment_tree_position(), value)
+            })
+            .collect();
+        notes.sort_by_key(|(_, pos, _)| *pos);
+        Ok(notes)
+    }
+}
+
+impl<'a, W> MigrationBackend for Backend<'a, W>
+where
+    W: WalletRead<AccountId = AccountUuid> + InputSource<AccountId = AccountUuid>,
+    <W as WalletRead>::Error: std::error::Error + Send + Sync + 'static,
+    <W as InputSource>::Error: std::error::Error + Send + Sync + 'static,
+{
+    type Error = EngineError;
+
+    fn spendable_orchard_note_values(&self) -> Result<Vec<Zatoshis>, Self::Error> {
+        self.spendable_orchard()?
+            .into_iter()
+            .enumerate()
+            .map(|(i, (_, _, value))| {
+                Zatoshis::from_u64(value)
+                    .map_err(|_| anyhow::anyhow!("spendable note {i} has an invalid value"))
+            })
+            .collect()
+    }
+
+    fn chain_tip_height(&self) -> Result<BlockHeight, Self::Error> {
+        self.wallet
+            .chain_height()
+            .map_err(|e| anyhow::anyhow!("chain height lookup failed: {e}"))?
+            .ok_or_else(|| anyhow::anyhow!("wallet has no chain tip yet"))
+    }
+}
+
+impl<'a, W> MigrationCrypto for Backend<'a, W>
+where
+    W: WalletRead<AccountId = AccountUuid> + InputSource<AccountId = AccountUuid>,
+    <W as WalletRead>::Error: std::error::Error + Send + Sync + 'static,
+    <W as InputSource>::Error: std::error::Error + Send + Sync + 'static,
+{
+    type Error = EngineError;
+
+    /// Derived from the account's stored Orchard UFVK (not from `self.usk`) so this works whether
+    /// or not a spending key was provided — matches the old `zcash_pool_migration` crate's
+    /// `account_orchard_fvk` helper.
+    fn orchard_fvk(&self) -> Result<FullViewingKey, Self::Error> {
+        let account = self
+            .wallet
+            .get_account(self.account)
+            .map_err(|e| anyhow::anyhow!("account lookup failed: {e}"))?
+            .ok_or_else(|| anyhow::anyhow!("unknown account"))?;
+        account
+            .ufvk()
+            .and_then(|ufvk| ufvk.orchard())
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("account has no Orchard full viewing key"))
+    }
+
+    fn resolve_wallet_note(&self, index: usize) -> Result<OrchardNote, Self::Error> {
+        let notes = self.spendable_orchard()?;
+        let &(note, _, _) = notes
+            .get(index)
+            .ok_or_else(|| anyhow::anyhow!("no spendable note at index {index}"))?;
+        Ok(note)
+    }
+
+    fn sign(&self, pczt: pczt::Pczt) -> Result<pczt::Pczt, Self::Error> {
+        let usk = self
+            .usk
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("no spending key available for in-process signing"))?;
+        let ask = SpendAuthorizingKey::from(usk.orchard());
+        zcash_pool_migration_backend::build::sign_pczt(pczt, &ask)
+            .map_err(|e| anyhow::anyhow!("signing the migration PCZT failed: {e:?}"))
+    }
+}
+
+impl<'a, W> PoolMigrationRead for Backend<'a, W>
+where
+    W: WalletRead<AccountId = AccountUuid> + InputSource<AccountId = AccountUuid>,
+    <W as WalletRead>::Error: std::error::Error + Send + Sync + 'static,
+    <W as InputSource>::Error: std::error::Error + Send + Sync + 'static,
+{
+    type Error = EngineError;
+
+    fn get_migration(&self) -> Result<Option<MigrationState>, Self::Error> {
+        self.store
+            .get_migration()
+            .map_err(|e| anyhow::anyhow!("reading persisted migration failed: {e:?}"))
+    }
+}
+
+impl<'a, W> PoolMigrationWrite for Backend<'a, W>
+where
+    W: WalletRead<AccountId = AccountUuid> + InputSource<AccountId = AccountUuid>,
+    <W as WalletRead>::Error: std::error::Error + Send + Sync + 'static,
+    <W as InputSource>::Error: std::error::Error + Send + Sync + 'static,
+{
+    fn replace_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error> {
+        self.store
+            .replace_migration(state)
+            .map_err(|e| anyhow::anyhow!("persisting migration failed: {e:?}"))
+    }
+
+    fn update_transaction(
+        &mut self,
+        id: MigrationTxId,
+        state: MigrationTxState,
+    ) -> Result<(), Self::Error> {
+        self.store
+            .update_transaction(id, state)
+            .map_err(|e| anyhow::anyhow!("updating migration transaction failed: {e:?}"))
+    }
+}

--- a/backend-lib/src/main/rust/migration_keystone.rs
+++ b/backend-lib/src/main/rust/migration_keystone.rs
@@ -1,0 +1,551 @@
+//! Keystone (hardware-wallet) batch-signing UR bridge for the Orchard migration flow.
+//!
+//! Bypasses the compiled `keystone-sdk-android` AAR (stale — single-PCZT only, no batch API) by
+//! depending directly on `ur-registry`/`ur` (see `Cargo.toml`'s comment), mirroring the pattern
+//! `chainapsis/vizor-wallet` already uses for its own Keystone integration. The batching
+//! primitive itself is `pczt::roles::signer::batch::{BatchSignRequest, BatchSignResponse}` — not
+//! Keystone-specific; these crates only provide the outer UR/CBOR/QR envelope
+//! (`ZcashSignBatch`/`ZcashBatchSigResult`, registry types `"zcash-sign-batch"`/
+//! `"zcash-batch-sig-result"`).
+//!
+//! `BatchSignResponse`'s signatures are aligned by *position*, not by any id embedded in the
+//! wire format — callers here are responsible for retaining the same (split, then transfers-in-
+//! schedule-order) ordering between [`build_sign_batch_qr_parts`] and [`apply_batch_signatures`].
+//! The unsigned PCZT bytes are passed back into `apply_batch_signatures` by the Kotlin caller
+//! (which already holds them, from the `createUnsignedNoteSplitPczt`/`createUnsignedTransferPczts`
+//! calls that produced them) rather than retained as Rust-side session state — the only
+//! genuinely stateful piece here is the multi-frame QR *decode* accumulation, which inherently
+//! spans multiple JNI calls (one per scanned camera frame).
+
+use std::sync::Mutex;
+
+use pczt::roles::signer::batch::{BatchSignRequest, BatchSignResponse};
+use pczt::roles::signer::{Signer, SpendAuthSignature};
+use ur_registry::traits::RegistryItem;
+use ur_registry::zcash::zcash_batch_sig_result::ZcashBatchSigResult;
+use ur_registry::zcash::zcash_sign_batch::ZcashSignBatch;
+
+/// Annotates every not-yet-signed Orchard/Ironwood spend action in an IO-finalized migration
+/// PCZT with the account's ZIP 32 derivation path, so an external signer (Keystone) can derive
+/// its own full viewing key and recognize which of its accounts a spend belongs to.
+///
+/// `zcash_pool_migration_backend`'s builders (`build_prep_tx`/`build_transfer_pczt`) never set
+/// this metadata — they only run the shared `Creator`/`IoFinalizer` plumbing, with no `Updater`
+/// step for spend derivation (unlike `zcash_client_backend::data_api::wallet::create_pczt_from_proposal`,
+/// which sets it for ordinary sends). Combined with [`build_sign_batch_qr_parts`]'s batch
+/// redaction correctly clearing the wire `spend_fvk` (the device is expected to derive its own),
+/// an un-annotated migration PCZT gives Keystone no way to identify the account at all, which
+/// fails on-device with "None of inputs belongs to the provided account".
+///
+/// A dummy padding spend that `IoFinalizer` already self-signed carries a `spend_auth_sig` at
+/// this point and is left alone (its throwaway key needs no derivation, and this crate's
+/// [`build_sign_batch_qr_parts`] clears its `spend_auth_sig` for the batch anyway); every action
+/// still awaiting a real signature — a real spend, or a wallet-controlled zero-value spend
+/// paired with a change output — gets the derivation.
+pub fn annotate_spend_zip32_derivation(
+    pczt_bytes: &[u8],
+    seed_fingerprint: [u8; 32],
+    coin_type: u32,
+    account_index: zip32::AccountId,
+) -> anyhow::Result<Vec<u8>> {
+    use pczt::roles::updater::Updater;
+
+    let derivation_path = [
+        zip32::ChildIndex::hardened(32).index(),
+        zip32::ChildIndex::hardened(coin_type).index(),
+        zip32::ChildIndex::hardened(u32::from(account_index)).index(),
+    ];
+
+    let pczt = pczt::parse(pczt_bytes).map_err(|e| anyhow::anyhow!("parse pczt: {e:?}"))?;
+    let updated = Updater::new(pczt)
+        .update_orchard_with(|mut updater| {
+            annotate_unsigned_actions(&mut updater, seed_fingerprint, &derivation_path)
+        })
+        .map_err(|e| anyhow::anyhow!("annotate orchard spend derivation: {e:?}"))?
+        .update_ironwood_with(|mut updater| {
+            annotate_unsigned_actions(&mut updater, seed_fingerprint, &derivation_path)
+        })
+        .map_err(|e| anyhow::anyhow!("annotate ironwood spend derivation: {e:?}"))?
+        .finish();
+
+    updated
+        .serialize()
+        .map_err(|e| anyhow::anyhow!("serialize pczt: {e:?}"))
+}
+
+fn annotate_unsigned_actions(
+    updater: &mut orchard::pczt::Updater<'_>,
+    seed_fingerprint: [u8; 32],
+    derivation_path: &[u32],
+) -> Result<(), orchard::pczt::UpdaterError> {
+    let unsigned_indices: Vec<usize> = updater
+        .bundle()
+        .actions()
+        .iter()
+        .enumerate()
+        .filter_map(|(index, action)| action.spend().spend_auth_sig().is_none().then_some(index))
+        .collect();
+    for index in unsigned_indices {
+        let derivation =
+            orchard::pczt::Zip32Derivation::parse(seed_fingerprint, derivation_path.to_vec())
+                .expect("valid ZIP 32 derivation");
+        updater.update_action_with(index, |mut action_updater| {
+            action_updater.set_spend_zip32_derivation(derivation);
+            Ok(())
+        })?;
+    }
+    Ok(())
+}
+
+/// Builds the animated multi-part QR frames for a Keystone batch-signing request covering the
+/// optional note-split PCZT and every schedule transfer's unsigned PCZT, in that order.
+///
+/// Every PCZT is passed through
+/// [`redact_pczt_for_batch_signer`](zcash_client_backend::data_api::wallet::redact_pczt_for_batch_signer)
+/// before being added to the request. The wallet's own IO-finalizer already puts `spend_auth_sig`
+/// on every dummy/wallet-controlled Orchard and Ironwood spend when the unsigned PCZT is built —
+/// but the Keystone batch-signing firmware rejects any batch request containing a pre-existing
+/// Orchard/Ironwood `spend_auth_sig` outright ("Invalid pczt, Zcash batch request must not
+/// contain Orchard spend authorization signatures"). Redacting clears those (plus the spend FVK,
+/// which the device derives itself) so only what the batch signer protocol expects reaches the
+/// wire; the caller's retained, unredacted PCZT bytes (`split_unsigned`/`transfer_unsigned`) are
+/// what [`apply_batch_signatures`] applies the returned signatures back onto.
+///
+/// `request_id` is an opaque correlation token (e.g. a UUID's bytes) round-tripped by the device
+/// and checked in [`decode_sign_batch_part`] to reject a scan of an unrelated/stale response.
+pub fn build_sign_batch_qr_parts(
+    request_id: Vec<u8>,
+    split_unsigned: Option<&[u8]>,
+    transfer_unsigned: &[Vec<u8>],
+    max_fragment_len: usize,
+) -> anyhow::Result<Vec<String>> {
+    use zcash_client_backend::data_api::wallet::redact_pczt_for_batch_signer;
+
+    let mut pczts = Vec::with_capacity(transfer_unsigned.len() + 1);
+    if let Some(split) = split_unsigned {
+        let parsed = pczt::parse(split).map_err(|e| anyhow::anyhow!("parse split pczt: {e:?}"))?;
+        pczts.push(redact_pczt_for_batch_signer(&parsed));
+    }
+    for bytes in transfer_unsigned {
+        let parsed =
+            pczt::parse(bytes).map_err(|e| anyhow::anyhow!("parse transfer pczt: {e:?}"))?;
+        pczts.push(redact_pczt_for_batch_signer(&parsed));
+    }
+
+    let request = BatchSignRequest::new(pczts);
+    let data = request
+        .serialize()
+        .map_err(|e| anyhow::anyhow!("serialize batch sign request: {e:?}"))?;
+    let batch = ZcashSignBatch::new(request_id, data);
+    let cbor: Vec<u8> = batch
+        .try_into()
+        .map_err(|e| anyhow::anyhow!("cbor-encode zcash-sign-batch: {e:?}"))?;
+
+    let mut encoder = ur::Encoder::new(
+        &cbor,
+        max_fragment_len,
+        ZcashSignBatch::get_registry_type().get_type(),
+    )
+    .map_err(|e| anyhow::anyhow!("ur encoder: {e}"))?;
+    let count = encoder.fragment_count();
+    let mut parts = Vec::with_capacity(count);
+    for _ in 0..count {
+        parts.push(
+            encoder
+                .next_part()
+                .map_err(|e| anyhow::anyhow!("ur next_part: {e}"))?
+                .to_uppercase(),
+        );
+    }
+    Ok(parts)
+}
+
+/// In-flight multi-part `zcash-batch-sig-result` scan session. `None` means no session in
+/// flight — mirrors `chainapsis/vizor-wallet`'s `UR_SESSION`/`UrSession` pattern for the same
+/// reason: a JNI call per scanned QR frame has nowhere else to keep fountain-decoder state.
+static DECODE_SESSION: Mutex<Option<ur::Decoder>> = Mutex::new(None);
+
+/// The result of feeding one scanned QR frame to [`decode_sign_batch_part`].
+pub struct DecodePartResult {
+    pub complete: bool,
+    pub progress: u32,
+    /// The serialized `BatchSignResponse` bytes, once `complete` — feed into
+    /// [`apply_batch_signatures`].
+    pub data: Option<Vec<u8>>,
+    /// The signing device's raw `[major, minor, build]` firmware version, once `complete` — the
+    /// `zcash-batch-sig-result` envelope's own field 3 (see keystone-sdk-rust's
+    /// `ZcashBatchSigResult::get_firmware_version`), not anything recovered from the resulting
+    /// signed PCZT bytes. The batch response is signatures-only (no PCZT is echoed back — see
+    /// [`build_sign_batch_qr_parts`]'s doc comment), so this is the *only* place a batch-signed
+    /// migration can learn the device's firmware version; a PCZT-proprietary-field scan (the
+    /// mechanism the single-transaction Keystone sign flow's firmware stamp relies on) always
+    /// comes back empty here, since [`apply_batch_signatures`] reconstructs the "signed" PCZT from
+    /// the caller's own retained unsigned bytes plus these signatures, never from device-returned
+    /// PCZT bytes.
+    pub firmware_version: Option<[u8; 3]>,
+}
+
+/// Discards any in-flight multi-part scan session. Callers should invoke this on scan-screen
+/// entry so a new attempt always starts from a clean slate regardless of how a previous attempt
+/// ended (cancel, back button, mid-stream error).
+pub fn reset_sign_batch_decoder() {
+    if let Ok(mut guard) = DECODE_SESSION.lock() {
+        *guard = None;
+    }
+}
+
+/// Feeds one scanned QR frame into the active (or a freshly started) decode session, pinned to
+/// the `"zcash-batch-sig-result"` UR type. `expected_request_id` must match the decoded
+/// `ZcashBatchSigResult`'s own request id once complete, or this returns an error (a scan of an
+/// unrelated/stale response) instead of silently accepting it.
+pub fn decode_sign_batch_part(
+    part: &str,
+    expected_request_id: &[u8],
+) -> anyhow::Result<DecodePartResult> {
+    let part_lower = part.to_lowercase();
+    let mut guard = DECODE_SESSION
+        .lock()
+        .map_err(|_| anyhow::anyhow!("decode session lock poisoned"))?;
+
+    if guard.is_none() {
+        let (kind, cbor) =
+            ur::decode(&part_lower).map_err(|e| anyhow::anyhow!("ur decode: {e}"))?;
+        match kind {
+            ur::ur::Kind::SinglePart => return finish_decode(cbor, expected_request_id),
+            ur::ur::Kind::MultiPart => {
+                let mut decoder = ur::Decoder::default();
+                decoder
+                    .receive(&part_lower)
+                    .map_err(|e| anyhow::anyhow!("ur receive: {e}"))?;
+                let progress = decoder.progress();
+                *guard = Some(decoder);
+                return Ok(DecodePartResult {
+                    complete: false,
+                    progress: progress as u32,
+                    data: None,
+                    firmware_version: None,
+                });
+            }
+        }
+    }
+
+    if let Err(e) = guard.as_mut().unwrap().receive(&part_lower) {
+        *guard = None;
+        return Err(anyhow::anyhow!("ur receive: {e}"));
+    }
+
+    if guard.as_ref().unwrap().complete() {
+        let message = guard
+            .as_mut()
+            .unwrap()
+            .message()
+            .map_err(|e| anyhow::anyhow!("ur message: {e}"))?;
+        *guard = None;
+        let cbor = message.ok_or_else(|| anyhow::anyhow!("decoder complete but no message"))?;
+        return finish_decode(cbor, expected_request_id);
+    }
+
+    let progress = guard.as_ref().unwrap().progress();
+    Ok(DecodePartResult {
+        complete: false,
+        progress: progress as u32,
+        data: None,
+        firmware_version: None,
+    })
+}
+
+fn finish_decode(cbor: Vec<u8>, expected_request_id: &[u8]) -> anyhow::Result<DecodePartResult> {
+    let result = ZcashBatchSigResult::try_from(cbor)
+        .map_err(|e| anyhow::anyhow!("cbor-decode zcash-batch-sig-result: {e:?}"))?;
+    if result.get_request_id() != expected_request_id {
+        return Err(anyhow::anyhow!(
+            "zcash-batch-sig-result request id does not match the outstanding sign request"
+        ));
+    }
+    Ok(DecodePartResult {
+        complete: true,
+        progress: 100,
+        data: Some(result.get_data().to_vec()),
+        firmware_version: Some(*result.get_firmware_version()),
+    })
+}
+
+/// Applies a decoded `BatchSignResponse` back to the retained unsigned PCZTs — in the exact
+/// split-then-transfers order they were passed to [`build_sign_batch_qr_parts`] — producing
+/// signed-but-unproven PCZT bytes for each. These are the same shape `store_signed_note_split_pczt`/
+/// `store_signed_schedule_pczts` already expect from the software-signing composition (they
+/// combine this with the staged *proven* original internally) — no other change needed there.
+///
+/// Returns an error if the response's signature-set count doesn't match the number of PCZTs sent.
+pub fn apply_batch_signatures(
+    split_unsigned: Option<&[u8]>,
+    transfer_unsigned: &[Vec<u8>],
+    batch_sign_response: &[u8],
+) -> anyhow::Result<(Option<Vec<u8>>, Vec<Vec<u8>>)> {
+    let response = BatchSignResponse::parse(batch_sign_response)
+        .map_err(|e| anyhow::anyhow!("parse batch sign response: {e:?}"))?;
+    let signatures = response.signatures();
+    let expected = transfer_unsigned.len() + usize::from(split_unsigned.is_some());
+    if signatures.len() != expected {
+        return Err(anyhow::anyhow!(
+            "batch sign response has {} signature set(s), expected {expected}",
+            signatures.len(),
+        ));
+    }
+
+    let mut idx = 0;
+    let split_signed = match split_unsigned {
+        Some(bytes) => {
+            let signed = apply_signatures_to_one(bytes, &signatures[idx])?;
+            idx += 1;
+            Some(signed)
+        }
+        None => None,
+    };
+
+    let mut transfers_signed = Vec::with_capacity(transfer_unsigned.len());
+    for bytes in transfer_unsigned {
+        transfers_signed.push(apply_signatures_to_one(bytes, &signatures[idx])?);
+        idx += 1;
+    }
+
+    Ok((split_signed, transfers_signed))
+}
+
+fn apply_signatures_to_one(
+    unsigned_bytes: &[u8],
+    sigs: &[SpendAuthSignature],
+) -> anyhow::Result<Vec<u8>> {
+    let pczt =
+        pczt::parse(unsigned_bytes).map_err(|e| anyhow::anyhow!("parse unsigned pczt: {e:?}"))?;
+    let mut signer = Signer::new(pczt).map_err(|e| anyhow::anyhow!("signer init: {e:?}"))?;
+    for sig in sigs {
+        signer
+            .apply_orchard_spend_auth_signature(sig)
+            .map_err(|e| anyhow::anyhow!("apply spend auth signature: {e:?}"))?;
+    }
+    signer
+        .finish()
+        .serialize()
+        .map_err(|e| anyhow::anyhow!("serialize signed pczt: {e:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use orchard::keys::{FullViewingKey, Scope, SpendingKey};
+    use orchard::value::NoteValue;
+    use pczt::roles::creator::Creator;
+    use pczt::roles::io_finalizer::IoFinalizer;
+    use rand::rngs::OsRng;
+    use shardtree::ShardTree;
+    use shardtree::store::memory::MemoryShardStore;
+    use ur_registry::zcash::zcash_sign_batch::ZcashSignBatch;
+    use zcash_note_encryption::try_note_decryption;
+    use zcash_primitives::transaction::builder::{BuildConfig, Builder, PcztResult};
+    use zcash_primitives::transaction::fees::zip317;
+    use zcash_protocol::consensus::{BlockHeight, Network};
+    use zcash_protocol::memo::{Memo, MemoBytes};
+    use zcash_protocol::value::Zatoshis;
+
+    /// Builds a real, IO-finalized single-Orchard-pool PCZT (one spend, one output),
+    /// mirroring the shape the real migration pipeline hands to
+    /// [`build_sign_batch_qr_parts`]: since the transaction has fewer real actions than
+    /// Orchard's default padding minimum, the Orchard builder inserts a dummy padding
+    /// action, and `IoFinalizer` self-signs that dummy spend (see `pczt::roles::io_finalizer`'s
+    /// "dummy spends will have been signed" note) — producing exactly the kind of
+    /// pre-existing `spend_auth_sig` the Keystone batch firmware rejects.
+    fn build_single_pool_orchard_pczt() -> Vec<u8> {
+        let mut rng = OsRng;
+        let sk = SpendingKey::from_zip32_seed(&[11u8; 32], 1, zip32::AccountId::ZERO)
+            .expect("valid Orchard ZIP 32 spending key");
+        let fvk = FullViewingKey::from(&sk);
+        let ivk = fvk.to_ivk(Scope::Internal);
+        let ovk = fvk.to_ovk(Scope::Internal);
+        let recipient = fvk.address_at(0u32, Scope::Internal);
+
+        // Pretend we already received a note to spend.
+        let value = NoteValue::from_raw(1_000_000);
+        let note = {
+            let bundle_version = orchard::bundle::BundleVersion::orchard_v2();
+            let mut builder = orchard::builder::Builder::new(
+                orchard::builder::BundleType::DEFAULT,
+                bundle_version,
+                bundle_version.default_flags(),
+                orchard::Anchor::empty_tree(),
+            )
+            .expect("orchard builder");
+            builder
+                .add_output(None, recipient, value, Memo::Empty.encode().into_bytes())
+                .expect("add output");
+            let (bundle, meta) = builder
+                .build::<i64>(&mut rng)
+                .expect("build orchard bundle")
+                .expect("non-empty bundle");
+            let action = bundle
+                .actions()
+                .get(meta.output_action_index(0).expect("output action index"))
+                .expect("action present");
+            let domain = orchard::note_encryption::OrchardDomain::for_action(action);
+            let (note, _, _) =
+                try_note_decryption(&domain, &ivk.prepare(), action).expect("decrypt own output");
+            note
+        };
+
+        // Single-leaf tree for the spend's witness/anchor.
+        let (anchor, merkle_path) = {
+            let cmx: orchard::note::ExtractedNoteCommitment = note.commitment().into();
+            let leaf = orchard::tree::MerkleHashOrchard::from_cmx(&cmx);
+            let mut tree = ShardTree::<_, 32, 16>::new(
+                MemoryShardStore::<orchard::tree::MerkleHashOrchard, u32>::empty(),
+                100,
+            );
+            tree.append(leaf, incrementalmerkletree::Retention::Marked)
+                .expect("append leaf");
+            tree.checkpoint(9_999_999).expect("checkpoint");
+            let position = 0.into();
+            let merkle_path = tree
+                .witness_at_checkpoint_depth(position, 0)
+                .expect("witness lookup")
+                .expect("witness present");
+            let anchor = merkle_path.root(leaf);
+            (anchor.into(), merkle_path.into())
+        };
+
+        // Well past TestNetwork's NU5 (Orchard) activation, comfortably before NU6.
+        let target_height = BlockHeight::from_u32(1_900_000);
+        let mut builder: Builder<Network, ()> = Builder::new(
+            Network::TestNetwork,
+            target_height,
+            BuildConfig::Standard {
+                sapling_anchor: None,
+                orchard_anchor: Some(anchor),
+                ironwood_anchor: None,
+                orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
+                ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+            },
+        );
+        builder
+            .add_orchard_spend::<zip317::FeeRule>(fvk.clone(), note, merkle_path)
+            .expect("add spend");
+        builder
+            .add_orchard_output::<zip317::FeeRule>(
+                Some(ovk),
+                recipient,
+                // 1_000_000 in - 10_000 ZIP-317 fee (2 grace actions x 5_000 marginal fee).
+                Zatoshis::const_from_u64(990_000),
+                MemoBytes::empty(),
+            )
+            .expect("add output");
+
+        let PcztResult { pczt_parts, .. } = builder
+            .build_for_pczt(OsRng, &zip317::FeeRule::standard())
+            .expect("build_for_pczt");
+
+        let base = Creator::build_from_parts(pczt_parts).expect("creator");
+        let base = IoFinalizer::new(base).finalize_io().expect("io finalize");
+        base.serialize().expect("serialize")
+    }
+
+    #[test]
+    fn build_sign_batch_qr_parts_strips_preexisting_orchard_spend_auth_sig() {
+        let unsigned = build_single_pool_orchard_pczt();
+
+        // Sanity-check the premise: the IO-finalized PCZT already carries a dummy
+        // spend_auth_sig before redaction — this is what regressed without the fix.
+        let parsed = pczt::parse(&unsigned).expect("parse base pczt");
+        assert!(
+            parsed
+                .orchard()
+                .actions()
+                .iter()
+                .any(|action| action.spend().spend_auth_sig().is_some()),
+            "test setup must produce a pre-signed dummy Orchard spend",
+        );
+
+        let parts = build_sign_batch_qr_parts(
+            b"test-request-id".to_vec(),
+            Some(&unsigned),
+            &[],
+            // Large enough that the whole request fits in a single UR frame.
+            1_000_000,
+        )
+        .expect("build_sign_batch_qr_parts");
+        assert_eq!(parts.len(), 1, "expected a single QR frame");
+
+        // `ur::Encoder` always emits the indexed multi-part wire format, even for a
+        // single fragment, so decode via `ur::Decoder` rather than assuming
+        // `ur::ur::Kind::SinglePart`.
+        let mut decoder = ur::Decoder::default();
+        decoder
+            .receive(&parts[0].to_lowercase())
+            .expect("ur receive");
+        assert!(
+            decoder.complete(),
+            "single fragment should complete decoding"
+        );
+        let cbor = decoder
+            .message()
+            .expect("ur message")
+            .expect("decoder complete but no message");
+        let batch = ZcashSignBatch::try_from(cbor).expect("cbor-decode zcash-sign-batch");
+        let request = BatchSignRequest::parse(batch.get_data()).expect("parse batch sign request");
+
+        assert_eq!(request.pczts().len(), 1);
+        for action in request.pczts()[0].orchard().actions() {
+            assert!(
+                action.spend().spend_auth_sig().is_none(),
+                "batch request must not contain a pre-existing Orchard spend_auth_sig",
+            );
+        }
+    }
+
+    #[test]
+    fn annotate_spend_zip32_derivation_sets_derivation_only_on_unsigned_actions() {
+        let unsigned = build_single_pool_orchard_pczt();
+        let base = pczt::parse(&unsigned).expect("parse base pczt");
+        // Sanity-check the premise: neither action carries a derivation path yet.
+        for action in base.orchard().actions() {
+            assert!(
+                !format!("{:?}", action.spend()).contains("zip32_derivation: Some"),
+                "test setup must start without any spend zip32_derivation set",
+            );
+        }
+
+        let seed_fingerprint = [42u8; 32];
+        let coin_type = 1; // testnet
+        let account_index = zip32::AccountId::ZERO;
+        let annotated =
+            annotate_spend_zip32_derivation(&unsigned, seed_fingerprint, coin_type, account_index)
+                .expect("annotate_spend_zip32_derivation");
+
+        let parsed = pczt::parse(&annotated).expect("parse annotated pczt");
+        let actions = parsed.orchard().actions();
+        assert_eq!(actions.len(), base.orchard().actions().len());
+
+        let mut unsigned_count = 0;
+        let mut signed_count = 0;
+        for (base_action, action) in base.orchard().actions().iter().zip(actions.iter()) {
+            let has_derivation = format!("{:?}", action.spend()).contains("zip32_derivation: Some");
+            if base_action.spend().spend_auth_sig().is_some() {
+                // Already-signed (dummy) spends are left alone.
+                signed_count += 1;
+                assert!(
+                    !has_derivation,
+                    "an already-signed dummy spend must not get a derivation path",
+                );
+            } else {
+                unsigned_count += 1;
+                assert!(
+                    has_derivation,
+                    "a real, still-unsigned spend must get a derivation path",
+                );
+            }
+        }
+        assert_eq!(
+            unsigned_count, 1,
+            "expected exactly one real unsigned spend"
+        );
+        assert_eq!(signed_count, 1, "expected exactly one dummy signed spend");
+    }
+}

--- a/backend-lib/src/main/rust/migration_plan_cache.rs
+++ b/backend-lib/src/main/rust/migration_plan_cache.rs
@@ -1,0 +1,58 @@
+//! In-process cache of the most recent `MigrationPlan` per account, bridging the gap between
+//! `plan_migration()` (a pure, unpersisted preview — see its doc comment) and the commit
+//! functions (`commit_preparation`/`build_preparation_unsigned`) that need that exact same plan
+//! value later.
+//!
+//! Unlike this file's neighbors, this is NOT backed by the wallet SQLite database: the new
+//! engine's `MigrationPlan` (and its `NoteSplitPlan`/`PreparationPlan` fields) has no `serde`
+//! support and no public constructor — the only way to obtain one is calling `plan_migration()`
+//! itself (verified directly against `zcash_pool_migration_backend`'s source, not assumed), so it
+//! can't be round-tripped through our own persistence the way `migration_finalize`'s proven-pczt
+//! cache is. Instead this holds it in memory, in a process-lifetime static — valid because the
+//! app's entire "review a migration proposal, then confirm/sign it" flow happens on one screen, in
+//! one app-process lifetime (confirmed with the user), never across a process restart.
+//!
+//! If the plan is missing when a commit function needs it (e.g. the process was killed between
+//! propose and sign), that function surfaces a clear "call propose first" error rather than
+//! silently recomputing a fresh, differently-randomized plan — recomputing would mean signing a
+//! migration whose schedule the user never actually saw or approved (ZIP 318's scheduling draws
+//! fresh randomness on every `plan_migration()` call, so two calls essentially never produce an
+//! identical schedule even with unchanged wallet state).
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+use zcash_client_sqlite::AccountUuid;
+use zcash_pool_migration_backend::engine::MigrationPlan;
+
+fn store() -> &'static Mutex<HashMap<AccountUuid, MigrationPlan>> {
+    static STORE: OnceLock<Mutex<HashMap<AccountUuid, MigrationPlan>>> = OnceLock::new();
+    STORE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Records the most recently previewed plan for `account`, replacing any previous one (matches
+/// the old crate's "each propose call replaces any prior unconsumed proposal" semantics).
+pub fn set(account: AccountUuid, plan: MigrationPlan) {
+    store()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(account, plan);
+}
+
+/// Returns a clone of the cached plan for `account`, if any.
+pub fn get(account: AccountUuid) -> Option<MigrationPlan> {
+    store()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(&account)
+        .cloned()
+}
+
+/// Drops the cached plan for `account` — called once it's been committed, since the durable,
+/// authoritative copy from that point on is what `PoolMigrationRead::get_migration()` persists.
+pub fn clear(account: AccountUuid) {
+    store()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .remove(&account);
+}

--- a/backend-lib/src/main/rust/migration_plan_cache.rs
+++ b/backend-lib/src/main/rust/migration_plan_cache.rs
@@ -3,49 +3,95 @@
 //! functions (`commit_preparation`/`build_preparation_unsigned`) that need that exact same plan
 //! value later.
 //!
+//! Every cached plan is identified by an opaque, randomly drawn [`PlanHandle`], returned to the
+//! caller alongside the plan and carried through the JNI proposal objects
+//! (`JniNoteSplitProposal.proposalHandle`/`JniMigrationSchedule.proposalHandle`). A commit call
+//! passes the handle back, and [`get`] refuses to release a plan under any other handle — so a
+//! commit can only ever sign the exact plan the caller was shown, never one that a later
+//! `propose*`/`prepare*` call happened to cache in the meantime (ZIP 318's scheduling draws fresh
+//! randomness on every `plan_migration()` call, so two plans essentially never agree even with
+//! unchanged wallet state; without the handle gate this was a real sign-what-the-user-never-saw
+//! hazard).
+//!
 //! Unlike this file's neighbors, this is NOT backed by the wallet SQLite database: the new
 //! engine's `MigrationPlan` (and its `NoteSplitPlan`/`PreparationPlan` fields) has no `serde`
 //! support and no public constructor — the only way to obtain one is calling `plan_migration()`
 //! itself (verified directly against `zcash_pool_migration_backend`'s source, not assumed), so it
 //! can't be round-tripped through our own persistence the way `migration_finalize`'s proven-pczt
-//! cache is. Instead this holds it in memory, in a process-lifetime static — valid because the
+//! cache was. Instead this holds it in memory, in a process-lifetime static — valid because the
 //! app's entire "review a migration proposal, then confirm/sign it" flow happens on one screen, in
 //! one app-process lifetime (confirmed with the user), never across a process restart.
-//!
-//! If the plan is missing when a commit function needs it (e.g. the process was killed between
-//! propose and sign), that function surfaces a clear "call propose first" error rather than
-//! silently recomputing a fresh, differently-randomized plan — recomputing would mean signing a
-//! migration whose schedule the user never actually saw or approved (ZIP 318's scheduling draws
-//! fresh randomness on every `plan_migration()` call, so two calls essentially never produce an
-//! identical schedule even with unchanged wallet state).
 
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
 
+use rand::RngCore;
+use rand::rngs::OsRng;
 use zcash_client_sqlite::AccountUuid;
 use zcash_pool_migration_backend::engine::MigrationPlan;
 
-fn store() -> &'static Mutex<HashMap<AccountUuid, MigrationPlan>> {
-    static STORE: OnceLock<Mutex<HashMap<AccountUuid, MigrationPlan>>> = OnceLock::new();
+/// Opaque identifier of one cached [`MigrationPlan`]. Drawn fresh (randomly) for every plan, so a
+/// handle from an earlier proposal can never accidentally match a later one.
+pub type PlanHandle = u64;
+
+/// Why [`get`] could not release a plan for the requested handle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlanLookupError {
+    /// No plan is cached for the account at all — the process was likely restarted (the cache is
+    /// in-memory only) or the plan was already committed and cleared.
+    Missing,
+    /// A plan is cached for the account, but under a different handle: a later
+    /// `propose*`/`prepare*` call replaced the plan the caller was shown.
+    Superseded,
+}
+
+impl std::fmt::Display for PlanLookupError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PlanLookupError::Missing => f.write_str(
+                "No pending migration proposal for this account — call propose/prepare first",
+            ),
+            PlanLookupError::Superseded => f.write_str(
+                "The migration proposal identified by this handle has been superseded by a newer \
+                 proposal — re-propose and show the user the new schedule before signing",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PlanLookupError {}
+
+fn store() -> &'static Mutex<HashMap<AccountUuid, (PlanHandle, MigrationPlan)>> {
+    static STORE: OnceLock<Mutex<HashMap<AccountUuid, (PlanHandle, MigrationPlan)>>> =
+        OnceLock::new();
     STORE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 /// Records the most recently previewed plan for `account`, replacing any previous one (matches
-/// the old crate's "each propose call replaces any prior unconsumed proposal" semantics).
-pub fn set(account: AccountUuid, plan: MigrationPlan) {
+/// the old crate's "each propose call replaces any prior unconsumed proposal" semantics), and
+/// returns the fresh handle that now identifies it. Any handle previously issued for `account`
+/// is thereby invalidated: committing with it fails with [`PlanLookupError::Superseded`].
+pub fn set(account: AccountUuid, plan: MigrationPlan) -> PlanHandle {
+    let handle = OsRng.next_u64();
     store()
         .lock()
         .unwrap_or_else(|e| e.into_inner())
-        .insert(account, plan);
+        .insert(account, (handle, plan));
+    handle
 }
 
-/// Returns a clone of the cached plan for `account`, if any.
-pub fn get(account: AccountUuid) -> Option<MigrationPlan> {
-    store()
+/// Returns a clone of the cached plan for `account`, but only if `handle` identifies it —
+/// i.e. only if no later `propose*`/`prepare*` call has replaced the plan the caller was shown.
+pub fn get(account: AccountUuid, handle: PlanHandle) -> Result<MigrationPlan, PlanLookupError> {
+    match store()
         .lock()
         .unwrap_or_else(|e| e.into_inner())
         .get(&account)
-        .cloned()
+    {
+        None => Err(PlanLookupError::Missing),
+        Some((cached_handle, _)) if *cached_handle != handle => Err(PlanLookupError::Superseded),
+        Some((_, plan)) => Ok(plan.clone()),
+    }
 }
 
 /// Drops the cached plan for `account` — called once it's been committed, since the durable,

--- a/backend-lib/src/main/rust/tor.rs
+++ b/backend-lib/src/main/rust/tor.rs
@@ -91,7 +91,20 @@ impl TorRuntime {
     pub(crate) fn connect_to_lightwalletd(&self, endpoint: Uri) -> anyhow::Result<LwdConn> {
         let Self { runtime, client } = self.isolated_client();
 
-        let conn = runtime.block_on(async { client.connect_to_lightwalletd(endpoint).await })?;
+        // `allow_onion_services` used to be inferred internally by `zcash_client_backend` from
+        // the endpoint host; it's now an explicit caller decision (upstream commit 6721534b76),
+        // so re-derive the same `.onion` check here to keep supporting custom onion lightwalletd
+        // servers without changing this method's signature.
+        let allow_onion_services = endpoint
+            .host()
+            .map(|h| h.ends_with(".onion"))
+            .unwrap_or(false);
+
+        let conn = runtime.block_on(async {
+            client
+                .connect_to_lightwalletd(endpoint, allow_onion_services)
+                .await
+        })?;
 
         Ok(LwdConn {
             runtime,
@@ -168,13 +181,13 @@ impl LwdConn {
 
     /// Calls the given closure with UTXOS corresponding to the given t-address within the given
     /// block range.
-    pub(crate) fn with_taddress_utxos(
+    pub(crate) fn with_taddress_utxos<AccountId>(
         &mut self,
         params: &impl consensus::Parameters,
         address: TransparentAddress,
         start: Option<BlockHeight>,
         limit: Option<u32>,
-        mut f: impl FnMut(WalletTransparentOutput) -> anyhow::Result<()>,
+        mut f: impl FnMut(WalletTransparentOutput<AccountId>) -> anyhow::Result<()>,
     ) -> anyhow::Result<()> {
         let request = service::GetAddressUtxosArg {
             addresses: vec![address.encode(params)],
@@ -197,6 +210,11 @@ impl LwdConn {
                         Script(script::Code(result.script)),
                     ),
                     Some(BlockHeight::from(u32::try_from(result.height)?)),
+                    // Account attribution isn't known at this raw address-level lightwalletd
+                    // lookup — the caller resolves/attaches it when persisting the output.
+                    None,
+                    None,
+                    None,
                 )
                 .ok_or(anyhow!(
                     "Received UTXO that doesn't correspond to a valid P2PKH or P2SH address"

--- a/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/model/ProposalUnsafeTest.kt
+++ b/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/model/ProposalUnsafeTest.kt
@@ -1,0 +1,63 @@
+package cash.z.ecc.android.sdk.internal.model
+
+import cash.z.wallet.sdk.internal.ffi.ProposalOuterClass.FeeRule
+import cash.z.wallet.sdk.internal.ffi.ProposalOuterClass.ProposalStep
+import cash.z.wallet.sdk.internal.ffi.ProposalOuterClass.ProposedInput
+import cash.z.wallet.sdk.internal.ffi.ProposalOuterClass.ReceivedOutput
+import cash.z.wallet.sdk.internal.ffi.ProposalOuterClass.TransactionBalance
+import cash.z.wallet.sdk.internal.ffi.ProposalOuterClass.ValuePool
+import cash.z.wallet.sdk.internal.ffi.ProposalOuterClass.Proposal as ProposalProto
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ProposalUnsafeTest {
+    private fun receivedOutputInput(valuePool: ValuePool) =
+        ProposedInput.newBuilder()
+            .setReceivedOutput(
+                ReceivedOutput.newBuilder()
+                    .setValuePool(valuePool)
+                    .setIndex(0)
+                    .setValue(10_000L)
+            ).build()
+
+    private fun proposalWithInputs(vararg valuePools: ValuePool): ProposalUnsafe {
+        val step =
+            ProposalStep.newBuilder()
+                .addAllInputs(valuePools.map { receivedOutputInput(it) })
+                .setBalance(TransactionBalance.newBuilder().setFeeRequired(10_000L))
+                .build()
+        val proposal =
+            ProposalProto.newBuilder()
+                .setProtoVersion(1)
+                .setFeeRule(FeeRule.Zip317)
+                .setMinTargetHeight(1)
+                .addSteps(step)
+                .build()
+        return ProposalUnsafe(proposal)
+    }
+
+    @Test
+    fun sapling_only_inputs_do_not_use_orchard() {
+        val proposal = proposalWithInputs(ValuePool.Sapling, ValuePool.Transparent)
+        assertFalse(proposal.usesOrchardInputs())
+    }
+
+    @Test
+    fun any_orchard_input_uses_orchard() {
+        val proposal = proposalWithInputs(ValuePool.Sapling, ValuePool.Orchard)
+        assertTrue(proposal.usesOrchardInputs())
+    }
+
+    @Test
+    fun all_orchard_inputs_use_orchard() {
+        val proposal = proposalWithInputs(ValuePool.Orchard, ValuePool.Orchard)
+        assertTrue(proposal.usesOrchardInputs())
+    }
+
+    @Test
+    fun no_inputs_do_not_use_orchard() {
+        val proposal = proposalWithInputs()
+        assertFalse(proposal.usesOrchardInputs())
+    }
+}

--- a/demo-app/src/main/java/cash/z/ecc/android/sdk/demoapp/WalletCoordinatorFactory.kt
+++ b/demo-app/src/main/java/cash/z/ecc/android/sdk/demoapp/WalletCoordinatorFactory.kt
@@ -29,7 +29,8 @@ private val lazy =
             accountName = "Zcash Account 1",
             keySource = "ZCASH",
             isTorEnabled = flowOf(null),
-            isExchangeRateEnabled = flowOf(null)
+            isExchangeRateEnabled = flowOf(null),
+            isSyncBlocked = flowOf(false)
         )
     }
 

--- a/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/fixture/SingleCompactBlockFixture.kt
+++ b/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/fixture/SingleCompactBlockFixture.kt
@@ -11,6 +11,7 @@ internal object SingleCompactBlockFixture {
     internal const val DEFAULT_TIME = 0
     internal const val DEFAULT_SAPLING_OUTPUT_COUNT = 1u
     internal const val DEFAULT_ORCHARD_OUTPUT_COUNT = 2u
+    internal const val DEFAULT_IRONWOOD_OUTPUT_COUNT = 0u
     internal const val DEFAULT_HASH = DEFAULT_HEIGHT
     internal const val DEFAULT_BLOCK_BYTES = DEFAULT_HEIGHT
 
@@ -25,6 +26,7 @@ internal object SingleCompactBlockFixture {
         time: Int = DEFAULT_TIME,
         saplingOutputsCount: UInt = DEFAULT_SAPLING_OUTPUT_COUNT,
         orchardOutputsCount: UInt = DEFAULT_ORCHARD_OUTPUT_COUNT,
+        ironwoodOutputsCount: UInt = DEFAULT_IRONWOOD_OUTPUT_COUNT,
         blockBytes: ByteArray = heightToFixtureData(DEFAULT_BLOCK_BYTES)
     ): CompactBlockUnsafe =
         CompactBlockUnsafe(
@@ -33,6 +35,7 @@ internal object SingleCompactBlockFixture {
             time = time,
             saplingOutputsCount = saplingOutputsCount,
             orchardOutputsCount = orchardOutputsCount,
+            ironwoodOutputsCount = ironwoodOutputsCount,
             compactBlockBytes = blockBytes
         )
 }

--- a/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/model/CompactBlockUnsafe.kt
+++ b/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/model/CompactBlockUnsafe.kt
@@ -17,6 +17,10 @@ class CompactBlockUnsafe(
     val time: Int,
     val saplingOutputsCount: UInt,
     val orchardOutputsCount: UInt,
+    // Temporary diagnostic field (IRONWOOD_DIAG) — added to confirm whether the connected
+    // lightwalletd server actually populates CompactTx.ironwoodActions yet. Safe to remove once
+    // that's confirmed one way or the other.
+    val ironwoodOutputsCount: UInt,
     val compactBlockBytes: ByteArray
 ) {
     companion object {
@@ -28,6 +32,7 @@ class CompactBlockUnsafe(
                 time = compactBlock.time,
                 saplingOutputsCount = outputCounts.saplingOutputsCount,
                 orchardOutputsCount = outputCounts.orchardActionsCount,
+                ironwoodOutputsCount = outputCounts.ironwoodActionsCount,
                 compactBlockBytes = compactBlock.toByteArray()
             )
         }
@@ -35,18 +40,21 @@ class CompactBlockUnsafe(
         private fun getOutputsCounts(vtxList: List<CompactFormats.CompactTx>): CompactBlockOutputsCounts {
             var outputsCount: UInt = 0u
             var actionsCount: UInt = 0u
+            var ironwoodActionsCount: UInt = 0u
 
             vtxList.forEach { compactTx ->
                 outputsCount += compactTx.outputsCount.toUInt()
                 actionsCount += compactTx.actionsCount.toUInt()
+                ironwoodActionsCount += compactTx.ironwoodActionsCount.toUInt()
             }
 
-            return CompactBlockOutputsCounts(outputsCount, actionsCount)
+            return CompactBlockOutputsCounts(outputsCount, actionsCount, ironwoodActionsCount)
         }
     }
 
     data class CompactBlockOutputsCounts(
         val saplingOutputsCount: UInt,
-        val orchardActionsCount: UInt
+        val orchardActionsCount: UInt,
+        val ironwoodActionsCount: UInt
     )
 }

--- a/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/model/ShieldedProtocolEnum.kt
+++ b/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/model/ShieldedProtocolEnum.kt
@@ -4,11 +4,13 @@ import cash.z.wallet.sdk.internal.rpc.Service.ShieldedProtocol
 
 enum class ShieldedProtocolEnum {
     SAPLING,
-    ORCHARD;
+    ORCHARD,
+    IRONWOOD;
 
     fun toProtocol() =
         when (this) {
             SAPLING -> ShieldedProtocol.sapling
             ORCHARD -> ShieldedProtocol.orchard
+            IRONWOOD -> ShieldedProtocol.ironwood
         }
 }

--- a/lightwallet-client-lib/src/main/proto/compact_formats.proto
+++ b/lightwallet-client-lib/src/main/proto/compact_formats.proto
@@ -15,6 +15,7 @@ option swift_prefix = "";
 message ChainMetadata {
     uint32 saplingCommitmentTreeSize = 1; // the size of the Sapling note commitment tree as of the end of this block
     uint32 orchardCommitmentTreeSize = 2; // the size of the Orchard note commitment tree as of the end of this block
+    uint32 ironwoodCommitmentTreeSize = 3; // the size of the Ironwood note commitment tree as of the end of this block
 }
 
 // CompactBlock is a packaging of ONLY the data from a block that's needed to:
@@ -52,6 +53,10 @@ message CompactTx {
     repeated CompactSaplingSpend spends = 4;
     repeated CompactSaplingOutput outputs = 5;
     repeated CompactOrchardAction actions = 6;
+    // Ironwood (NU6.3) actions. Ironwood is Orchard note-version V3, so these reuse the
+    // CompactOrchardAction shape but ride a separate stream. Field number 9 matches lightwalletd;
+    // fields 7-8 (transparent vin/vout) are intentionally unused here.
+    repeated CompactOrchardAction ironwoodActions = 9;
 }
 
 // CompactSaplingSpend is a Sapling Spend Description as described in 7.3 of the Zcash

--- a/lightwallet-client-lib/src/main/proto/service.proto
+++ b/lightwallet-client-lib/src/main/proto/service.proto
@@ -117,11 +117,13 @@ message TreeState {
     uint32 time = 4;        // Unix epoch time when the block was mined
     string saplingTree = 5; // sapling commitment tree state
     string orchardTree = 6; // orchard commitment tree state
+    string ironwoodTree = 7; // ironwood commitment tree state
 }
 
 enum ShieldedProtocol {
     sapling = 0;
     orchard = 1;
+    ironwood = 2;
 }
 
 message GetSubtreeRootsArg {

--- a/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/WalletCoordinator.kt
+++ b/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/WalletCoordinator.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
@@ -34,6 +35,9 @@ import java.util.UUID
 /**
  * @param persistableWallet flow of the user's stored wallet.  Null indicates that no wallet has been stored.
  * @param isTorEnabled flow indicating whether tor has been enabled for Synchronizer features supporting tor connection
+ * @param isSyncBlocked flow indicating whether some external condition requires sync to stay stopped (e.g. a
+ * pending Orchard migration transfer needs sync and broadcast decoupled in time for privacy). Gated the same way
+ * as [isTorEnabled] — while true, the synchronizer is closed and will not reopen, regardless of [persistableWallet].
  * @param accountName A human-readable name for the account, that will be used while instantiating [Synchronizer.new]
  * @param keySource A string identifier or other metadata describing the source of the seed, that will be used while
  * instantiating [Synchronizer.new]
@@ -49,6 +53,7 @@ class WalletCoordinator(
     val persistableWallet: Flow<PersistableWallet?>,
     val isTorEnabled: Flow<Boolean?>,
     val isExchangeRateEnabled: Flow<Boolean?>,
+    val isSyncBlocked: Flow<Boolean>,
     val accountName: String,
     val keySource: String?,
 ) {
@@ -76,6 +81,8 @@ class WalletCoordinator(
         class Lockout(
             val id: UUID
         ) : InternalSynchronizerStatus()
+
+        object Blocked : InternalSynchronizerStatus()
     }
 
     @Suppress("DestructuringDeclarationWithTooManyEntries")
@@ -85,17 +92,26 @@ class WalletCoordinator(
             persistableWallet,
             synchronizerLockoutId,
             isTorEnabled,
-            isExchangeRateEnabled
-        ) { persistableWallet, lockoutId, isTorEnabled, isExchangeRateEnabled ->
+            isExchangeRateEnabled,
+            isSyncBlocked
+        ) { persistableWallet, lockoutId, isTorEnabled, isExchangeRateEnabled, isSyncBlocked ->
             SynchronizerLockoutInternalState(
                 persistableWallet = persistableWallet,
                 lockoutId = lockoutId,
                 isTorEnabled = isTorEnabled,
-                isExchangeRateEnabled = isExchangeRateEnabled
+                isExchangeRateEnabled = isExchangeRateEnabled,
+                isSyncBlocked = isSyncBlocked
             )
-        }.flatMapLatest { (persistableWallet, lockoutId, isTorEnabled, isExchangeRateEnabled) ->
+            // isSyncBlocked's first real value always arrives asynchronously, after this combine()
+            // has already fired once using its stale placeholder — without dropping that redundant
+            // re-emission, flatMapLatest below would cancel an in-flight Synchronizer.new() (and
+            // therefore its checkpoint loading) on every cold start, even though nothing changed.
+        }.distinctUntilChanged()
+            .flatMapLatest { (persistableWallet, lockoutId, isTorEnabled, isExchangeRateEnabled, isSyncBlocked) ->
             if (null != lockoutId) { // this one needs to come first
                 flowOf(InternalSynchronizerStatus.Lockout(lockoutId))
+            } else if (isSyncBlocked) {
+                flowOf(InternalSynchronizerStatus.Blocked)
             } else if (null == persistableWallet) {
                 flowOf(InternalSynchronizerStatus.NoWallet)
             } else {
@@ -140,6 +156,7 @@ class WalletCoordinator(
                     is InternalSynchronizerStatus.Available -> it.synchronizer
                     is InternalSynchronizerStatus.Lockout -> null
                     InternalSynchronizerStatus.NoWallet -> null
+                    InternalSynchronizerStatus.Blocked -> null
                 }
             }.stateIn(
                 scope = walletScope,
@@ -247,5 +264,6 @@ private data class SynchronizerLockoutInternalState(
     val persistableWallet: PersistableWallet?,
     val lockoutId: UUID?,
     val isTorEnabled: Boolean?,
-    val isExchangeRateEnabled: Boolean?
+    val isExchangeRateEnabled: Boolean?,
+    val isSyncBlocked: Boolean
 )

--- a/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/fixture/AccountBalanceFixture.kt
+++ b/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/fixture/AccountBalanceFixture.kt
@@ -9,14 +9,17 @@ object AccountBalanceFixture {
     val TRANSPARENT_BALANCE: Zatoshi = Zatoshi(8)
     val SAPLING_BALANCE: WalletBalance = WalletBalanceFixture.new(Zatoshi(4), Zatoshi(4), Zatoshi(2))
     val ORCHARD_BALANCE: WalletBalance = WalletBalanceFixture.new(Zatoshi(5), Zatoshi(2), Zatoshi(1))
+    val IRONWOOD_BALANCE: WalletBalance = WalletBalanceFixture.new(Zatoshi(0), Zatoshi(0), Zatoshi(0))
 
     fun new(
         orchardBalance: WalletBalance = ORCHARD_BALANCE,
         saplingBalance: WalletBalance = SAPLING_BALANCE,
-        transparentBalance: Zatoshi = TRANSPARENT_BALANCE
+        transparentBalance: Zatoshi = TRANSPARENT_BALANCE,
+        ironwoodBalance: WalletBalance = IRONWOOD_BALANCE
     ) = AccountBalance(
         saplingBalance,
         orchardBalance,
+        ironwoodBalance,
         transparentBalance
     )
 }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
@@ -83,9 +83,18 @@ data class NetworkPrivacyOptions(
  *
  * Splitting into ~10 notes is the current target heuristic (20k ZEC cap per note).
  */
+/**
+ * [proposalHandle] is the opaque identifier of the SDK-native cached migration plan this proposal
+ * was rendered from. The plan's details never leave the native side: commit calls
+ * ([OrchardMigrationSdk.submitNoteSplit], [OrchardMigrationSdk.createUnsignedNoteSplitPczt])
+ * pass the handle back, and the native side refuses to sign any plan other than the one it
+ * identifies — throwing if a later propose/prepare call superseded it, so what gets signed is
+ * always exactly what the user reviewed.
+ */
 data class NoteSplitProposal(
     val outputNotes: List<Long>,  // amounts in zatoshi
-    val fee: Long
+    val fee: Long,
+    val proposalHandle: Long
 )
 
 /**
@@ -114,10 +123,15 @@ data class TransferProposal(
  * Full migration schedule returned by [OrchardMigrationSdk.proposeMigrationTransfers].
  * Shown to the user for review before [OrchardMigrationSdk.signAndStoreMigrationSchedule]
  * is called. After sign+store, individual transfers do not require per-send confirmation.
+ *
+ * [proposalHandle] identifies the SDK-native cached plan this schedule was rendered from — see
+ * [NoteSplitProposal.proposalHandle] for the contract. The transfer fields here are for display;
+ * signing passes only the handle back, so the native side signs exactly the identified plan.
  */
 data class MigrationSchedule(
     val transfers: List<TransferProposal>,
-    val estimatedDurationHours: Int
+    val estimatedDurationHours: Int,
+    val proposalHandle: Long
 )
 
 /**
@@ -346,11 +360,13 @@ interface OrchardMigrationSdk {
     // ── External signer (Keystone hardware wallet) ───────────────────────────
 
     /**
-     * Builds the note-split transaction as an unsigned PCZT for an external signer — the
-     * [submitNoteSplit] equivalent for callers with no software spending key. Nothing is
-     * broadcast; pass the device's returned signature to [storeSignedNoteSplitPczt].
+     * Builds the note-split transaction of the plan [proposal] identifies as an unsigned PCZT
+     * for an external signer — the [submitNoteSplit] equivalent for callers with no software
+     * spending key. Nothing is broadcast; pass the device's returned signature to
+     * [storeSignedNoteSplitPczt]. Throws if [proposal]'s plan has been superseded by a later
+     * propose/prepare call (see [NoteSplitProposal.proposalHandle]).
      */
-    suspend fun createUnsignedNoteSplitPczt(): ByteArray
+    suspend fun createUnsignedNoteSplitPczt(proposal: NoteSplitProposal): ByteArray
 
     /**
      * Accepts the externally-signed note-split PCZT, finalizes it, and broadcasts it — the
@@ -454,11 +470,14 @@ interface OrchardMigrationSdk {
      * never actually mints, which then silently (and incorrectly) falls back to an unrelated
      * already-existing note — one the split's own "sweep every spendable note" construction may
      * already be consuming as one of its own inputs, a double-spend once the split mines. Deriving
-     * the schedule from the split's own realized output plan instead makes this class of mismatch
-     * structurally impossible.
+     * the schedule from the split's own plan instead makes this class of mismatch structurally
+     * impossible.
      *
-     * Implementation note (Rust bridge, 2026-07-20): backed by
-     * `MigrationContext::propose_migration_transfers_from_split`.
+     * This never re-plans: it renders the schedule of the exact SDK-native cached plan
+     * [splitProposal] identifies (via [NoteSplitProposal.proposalHandle]) — the same plan whose
+     * split the user was just shown — and throws if that plan is missing or superseded. The
+     * returned [MigrationSchedule] carries the SAME handle, so split view, schedule view, and the
+     * eventual [submitNoteSplit]/[signAndStoreMigrationSchedule] all refer to one plan.
      */
     suspend fun proposeMigrationTransfersFromSplit(splitProposal: NoteSplitProposal): MigrationSchedule
 
@@ -498,6 +517,11 @@ interface OrchardMigrationSdk {
      * witnessed yet — it defers the proof for such transfers rather than requiring them to wait.
      * Callers do not need to wait for note-split to confirm on-chain before calling this. See
      * [finalizeReadyTransfers] for how those deferred-proof transfers are later completed.
+     *
+     * Only [schedule]'s [MigrationSchedule.proposalHandle] crosses to the native side — the
+     * schedule's display fields are never echoed back. The native side signs exactly the cached
+     * plan the handle identifies, and throws if a later propose/prepare call superseded it (in
+     * which case re-propose and show the user the new schedule before retrying).
      */
     suspend fun signAndStoreMigrationSchedule(schedule: MigrationSchedule, usk: UnifiedSpendingKey)
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
@@ -627,6 +627,32 @@ interface OrchardMigrationSdk {
      */
     suspend fun lockRemainingOrchardBalance()
 
+    // ── Debug ─────────────────────────────────────────────────────────────────
+
+    /**
+     * DEBUG ONLY: wipes this account's in-progress migration entirely (every preparation and
+     * transfer transaction, regardless of state), so the next propose/commit call starts
+     * completely fresh. Not for production use — exists purely as a debug-settings testing aid
+     * (e.g. re-running a migration proposal with a shorter test schedule without waiting out or
+     * resuming the previous one).
+     */
+    suspend fun clearMigration()
+
+    /**
+     * DEBUG ONLY: reschedules every not-yet-broadcast transfer in this account's migration to
+     * become due in quick succession (first ~2.5 min out, then ~5 min apart), instead of ZIP
+     * 318's normal privacy-motivated schedule (mean ~3h between transfers). Only the persisted
+     * `scheduled_height` (which gates broadcast eligibility) is touched — proving, anchors, and
+     * any real mining dependency a transfer has are unaffected, since transfers never depend on
+     * each other (only, at most, on the single preparation transaction that minted their own
+     * funding note). Not for production use.
+     *
+     * @return the number of transfer rows actually rescheduled (0 if there's no in-progress
+     * migration, or every transfer is already broadcast/mined) — surface this to whoever is
+     * testing with it, since a silent 0 looks identical to a successful reschedule otherwise.
+     */
+    suspend fun debugRescheduleTransfers(): Int
+
     companion object {
         /**
          * Constructs the real, Rust-backed [OrchardMigrationSdk].

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
@@ -49,10 +49,15 @@ import kotlin.time.Duration
  * - [submitNoteSplit] / [signAndStoreMigrationSchedule] gained a `usk: UnifiedSpendingKey`
  *   parameter — sdk-lib never stores/derives a spending key itself (see
  *   [Synchronizer.createProposedTransactions]), and the Rust calls they wrap require one.
- * - [getMigrationState] / [getMigrationProgress] / [isNoteSplitNeeded] /
- *   [isSyncRequiredBeforeNextTransfer] / [hasOverdueTransfers] / [hasInvalidTransfers] became
- *   `suspend` — each opens a `MigrationContext` against the wallet's SQLite database, unlike the
- *   mock's free in-memory answers.
+ * - [getMigrationState] / [getMigrationProgress] / [isNoteSplitNeeded] / [hasOverdueTransfers] /
+ *   [hasInvalidTransfers] became `suspend` — each opens a `MigrationContext` against the wallet's
+ *   SQLite database, unlike the mock's free in-memory answers.
+ *
+ * Reconciled 2026-07-23 removing a dead gate: `isSyncRequiredBeforeNextTransfer()` — a real Rust
+ * JNI call that always returned `false` — was deleted entirely. It was never a working check to
+ * begin with; [isSyncBlocked]'s `next_broadcastable`-driven overdue detection already provides the
+ * genuine ZIP 318 sync/broadcast decoupling in both directions (see that method's doc), so nothing
+ * replaces the deleted method — there was no real gap to fill.
  */
 
 // ─── Supporting types ─────────────────────────────────────────────────────────
@@ -247,11 +252,17 @@ interface OrchardMigrationSdk {
      * that removes the need for manual polling.
      *
      * Implementation note (Rust bridge, 2026-07-15): this and the other state-query methods below
-     * (`getMigrationProgress`, `isNoteSplitNeeded`, `isSyncRequiredBeforeNextTransfer`,
-     * `hasOverdueTransfers`, `hasInvalidTransfers`) are `suspend` — not the synchronous calls their
-     * original signatures implied — because the real implementation opens a `MigrationContext`
-     * against the wallet's SQLite database on every call. The mock's answers were free (in-memory
-     * state), so the original interface didn't need `suspend` here; the real bridge does.
+     * (`getMigrationProgress`, `isNoteSplitNeeded`, `hasOverdueTransfers`, `hasInvalidTransfers`)
+     * are `suspend` — not the synchronous calls their original signatures implied — because the
+     * real implementation opens a `MigrationContext` against the wallet's SQLite database on every
+     * call. The mock's answers were free (in-memory state), so the original interface didn't need
+     * `suspend` here; the real bridge does.
+     *
+     * Implementation note (2026-07-23): `isSyncRequiredBeforeNextTransfer()` used to be listed
+     * alongside these — it was removed as dead code (a Rust JNI call that always returned `false`,
+     * with no other logic behind it). [isSyncBlocked]'s `next_broadcastable`-driven overdue check
+     * already provides the real ZIP 318 sync/broadcast decoupling; there was nothing this method
+     * contributed that isn't already covered there.
      */
     suspend fun getMigrationState(): MigrationState
 
@@ -463,17 +474,6 @@ interface OrchardMigrationSdk {
     // ── Background execution ─────────────────────────────────────────────────
 
     /**
-     * Returns true if a sync is needed before the next transfer can be executed.
-     * Happens when the previous transfer produced change back to Orchard — that
-     * change must be confirmed and synced before it can be spent.
-     *
-     * WorkManager task should check this before calling executeNextPendingTransfer().
-     * If true, task should exit and trigger a separate sync (not in the same session —
-     * sync and broadcast must be decoupled in time).
-     */
-    suspend fun isSyncRequiredBeforeNextTransfer(): Boolean
-
-    /**
      * Completes every pre-signed transfer that is awaiting a proof (its funding note — a
      * not-yet-mined note-split output — was not yet witnessed at signing time) and whose funding
      * note has since become witnessed: attaches the note's real witness and anchor, runs the
@@ -485,10 +485,12 @@ interface OrchardMigrationSdk {
      * not a failure. Callers do not need to guard calls to this with [isNoteSplitNeeded] or any
      * other state check first.
      *
-     * WorkManager task should call this before [isSyncRequiredBeforeNextTransfer] /
-     * [executeNextPendingTransfer] on every run, so a funding note that became witnessed since the
-     * last run gets finalized to broadcastable in the same session that might then immediately
-     * find and broadcast it.
+     * WorkManager task should call this before [executeNextPendingTransfer] on every run, so a
+     * funding note that became witnessed since the last run gets finalized to broadcastable in the
+     * same session that might then immediately find and broadcast it. There is no separate
+     * pre-transfer sync gate to check first — [isSyncBlocked]'s `next_broadcastable`-driven overdue
+     * check (see that method's doc) already keeps sync and broadcast decoupled in both directions,
+     * so this task's three-step sequence runs unconditionally.
      *
      * Implementation note (Rust bridge, 2026-07-18): backed by
      * `MigrationContext::finalize_ready_transfers`, added alongside the sign-now/prove-later

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
@@ -679,6 +679,16 @@ interface OrchardMigrationSdk {
     // ── Dust locking ─────────────────────────────────────────────────────────
 
     /**
+     * The zatoshi value below which a remaining post-migration Orchard balance counts as dust
+     * (as opposed to a residual too large to ignore) — e.g. for the Migration Complete screen's
+     * "is the leftover balance negligible" gate. 100,000 zatoshi (0.001 ZEC) as of this writing.
+     * A fixed protocol-level constant (`MIGRATION_DUST_THRESHOLD_ZATOSHI` in `migration.rs`), not
+     * derived from any wallet/account state — callers should still call this rather than hardcode
+     * the value, so the app and the Rust engine can't drift apart on what counts as dust.
+     */
+    suspend fun migrationDustThresholdZatoshi(): Long
+
+    /**
      * Marks whatever Orchard balance remains after migration (dust below the migratable
      * threshold, or an opted-out residual) as unspendable, so it can't later be swept into a
      * transaction that reveals its specific — and therefore identifying — amount.

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
@@ -1,5 +1,6 @@
 package cash.z.ecc.android.sdk
 
+import cash.z.ecc.android.sdk.model.Proposal
 import cash.z.ecc.android.sdk.model.UnifiedSpendingKey
 import kotlinx.coroutines.flow.Flow
 import kotlin.time.Duration
@@ -154,6 +155,30 @@ data class KeystoneBatchDecodeResult(
 data class KeystoneBatchSignedPczts(
     val splitSignedPczt: ByteArray?,
     val transferSignedPczts: List<ByteArray>
+)
+
+/**
+ * The live, persisted status of one committed transfer transaction — [id] matches
+ * [TransferProposal.id] (the real, stable `MigrationTxId`), NOT its position in
+ * [MigrationSchedule.transfers]: the engine assigns real transfer ids in its own funding-note/
+ * crossing order, while array position there is sorted by broadcast height — ZIP 318 deliberately
+ * shuffles those two orderings apart, so a caller must correlate by [id], never by array index.
+ */
+data class MigrationTransferState(
+    val id: String,
+    val isSent: Boolean,
+    val scheduledHeight: Long
+)
+
+/**
+ * The live schedule/status of every committed transfer transaction, read straight from the
+ * persisted migration store — see [OrchardMigrationSdk.getMigrationTransferStates].
+ * [tipHeight] is the wallet's current tip at the time of the read, for converting
+ * [MigrationTransferState.scheduledHeight] into a wall-clock estimate.
+ */
+data class MigrationTransferStates(
+    val transfers: List<MigrationTransferState>,
+    val tipHeight: Long
 )
 
 /**
@@ -438,17 +463,22 @@ interface OrchardMigrationSdk {
     suspend fun proposeMigrationTransfersFromSplit(splitProposal: NoteSplitProposal): MigrationSchedule
 
     /**
-     * Proposes a single, unsplit, full-balance migration transfer for immediate broadcast —
-     * no privacy-preserving multi-transfer split. The returned [MigrationSchedule] always
-     * contains exactly one [TransferProposal] whose [TransferProposal.nextExecutableAfterHeight]
-     * is immediately executable, so the caller broadcasts it right away via
-     * [executeNextPendingTransfer] after [signAndStoreMigrationSchedule] — no WorkManager /
-     * BGTaskScheduler background scheduling is needed for this path.
+     * Proposes an ordinary send-max transaction sweeping all spendable Orchard funds into this
+     * account's own Ironwood receiver — bypassing the migration engine entirely. Call only when
+     * state is ReadyToPropose, as an alternative to [proposeMigrationTransfers] for users who
+     * explicitly opt out of the privacy-preserving schedule.
      *
-     * Call only when state is ReadyToPropose, as an alternative to [proposeMigrationTransfers]
-     * for users who explicitly opt out of the privacy-preserving schedule.
+     * Unlike [proposeMigrationTransfers]/[proposeMigrationTransfersFromSplit], the result is never
+     * persisted as migration state (no `MigrationState` row is read or written): sign and submit
+     * it exactly like an ordinary send (see the app's `SubmitProposalUseCase`/proposal repository
+     * machinery), not through [signAndStoreMigrationSchedule].
+     *
+     * Implementation note (Rust bridge, 2026-07-23): backed by
+     * `migration_engine::propose_immediate_send_max`, proto-encoded exactly like an ordinary
+     * send's proposal (`RustBackend.proposeTransfer`'s encoding) rather than a migration-specific
+     * type — this replaces the old, engine-routed `MigrationSchedule`-returning version.
      */
-    suspend fun proposeImmediateMigration(): MigrationSchedule
+    suspend fun proposeImmediateMigration(): Proposal
 
     /**
      * User has confirmed the schedule. SDK signs all transactions and stores them
@@ -614,6 +644,14 @@ interface OrchardMigrationSdk {
      */
     suspend fun restartCurrentMigrationStep(includeResidual: Boolean = false): MigrationSchedule
 
+    /**
+     * The live, persisted status of every committed transfer transaction — reflects any
+     * reschedule (production [rescheduleOverdueTransfer], or the debug-only
+     * [debugRescheduleTransfers]) immediately, unlike an app-side cache populated once at
+     * propose/commit time. Returns `null` if there's no in-progress migration.
+     */
+    suspend fun getMigrationTransferStates(): MigrationTransferStates?
+
     // ── Dust locking ─────────────────────────────────────────────────────────
 
     /**
@@ -643,11 +681,14 @@ interface OrchardMigrationSdk {
     /**
      * DEBUG ONLY: reschedules every not-yet-broadcast transfer in this account's migration to
      * become due in quick succession (first ~2.5 min out, then ~5 min apart), instead of ZIP
-     * 318's normal privacy-motivated schedule (mean ~3h between transfers). Only the persisted
-     * `scheduled_height` (which gates broadcast eligibility) is touched — proving, anchors, and
-     * any real mining dependency a transfer has are unaffected, since transfers never depend on
-     * each other (only, at most, on the single preparation transaction that minted their own
-     * funding note). Not for production use.
+     * 318's normal privacy-motivated schedule (mean ~3h between transfers). Both the persisted
+     * `scheduled_height` (broadcast eligibility) and `anchor_boundary` (proving eligibility) are
+     * rewritten — the original `anchor_boundary` is drawn relative to the chain tip at commit
+     * time and can still be far in the *future* of the current synced tip, which would otherwise
+     * leave every rescheduled transfer stuck un-provable regardless of how soon it's due. Any real
+     * mining dependency a transfer has is unaffected, since transfers never depend on each other
+     * (only, at most, on the single preparation transaction that minted their own funding note).
+     * Not for production use.
      *
      * @return the number of transfer rows actually rescheduled (0 if there's no in-progress
      * migration, or every transfer is already broadcast/mined) — surface this to whoever is

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
@@ -203,7 +203,6 @@ data class MigrationTransferStates(
 data class MigrationProgress(
     val completedTransfers: Int,
     val totalTransfers: Int,
-    val remainingOrchardZatoshi: Long,
     val nextTransferReadyAtHeight: Long?
 )
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
@@ -1,0 +1,676 @@
+package cash.z.ecc.android.sdk
+
+import cash.z.ecc.android.sdk.model.UnifiedSpendingKey
+import kotlinx.coroutines.flow.Flow
+import kotlin.time.Duration
+
+/**
+ * Kotlin interface for the Orchard → Ironwood migration SDK bridge.
+ *
+ * Boundary: SDK owns all business logic (split algorithm, anchor height selection,
+ * transaction signing, storage, invalidity detection). App owns UI, WorkManager
+ * scheduling, permissions, and notifications.
+ *
+ * Based on: Orchard Migration Flow — Implementation Proposal (Path A)
+ * Sync: 2026-06-17
+ *
+ * Reconciled 2026-07-10 against the real Rust bridge (`zcash_pool_migration` crate,
+ * `zcash/librustzcash` branch `michal/ironwood-migration`, PR #2572) — see the "Implementation
+ * note (Rust bridge, ...)" comments below for what changed and why:
+ * - [proposeMigrationTransfers] / [restartCurrentMigrationStep] gained an `includeResidual`
+ *   parameter (pass `false` until the opt-in UI exists).
+ * - [rescheduleOverdueTransfer] needs no Rust call at all — a pre-signed transfer stays due until
+ *   broadcast or expiry, so "rescheduling" is a purely local decision; its old doc incorrectly
+ *   implied SDK-side persistence.
+ * - `initializePostUpgrade()` was removed — unused anywhere in the app, and `MigrationContext`
+ *   has no corresponding "post-upgrade init" step (everything is computed live from wallet state).
+ * - [submitNoteSplit] / [executeNextPendingTransfer] are each a composition of several Rust calls
+ *   (sign/fetch → extract → broadcast via the existing submission path → record result) — the
+ *   Kotlin signatures are unchanged, but see their doc comments for the real implementation shape.
+ * - [isSyncBlocked] / [privacySyncBufferDuration] are confirmed Kotlin-only (no Rust backing) —
+ *   the sync/broadcast de-correlation technique they implement lives entirely in this SDK layer.
+ *
+ * Reconciled 2026-07-18 while wiring the external-signer (Keystone hardware wallet) path:
+ * - New: [createUnsignedNoteSplitPczt] / [storeSignedNoteSplitPczt] and
+ *   [createUnsignedTransferPczts] / [storeSignedSchedulePczts] split [submitNoteSplit]'s and
+ *   [signAndStoreMigrationSchedule]'s "sign" step into "build the unsigned PCZT" / "accept an
+ *   externally-produced signature" halves, for callers with no software spending key at all.
+ *   [createUnsignedTransferPczts]'s self-funding transfers use the same sign-now/prove-later
+ *   placeholder-witness scheme [signAndStoreMigrationSchedule] does — [finalizeReadyTransfers]
+ *   completes them the same way regardless of which path signed them.
+ * - New: [buildKeystoneSignBatchQrParts] / [resetKeystoneSignBatchDecoder] /
+ *   [decodeKeystoneSignBatchPart] / [applyKeystoneBatchSignatures] — the Keystone-specific
+ *   animated-QR batch-signing bridge (encode every unsigned PCZT the caller wants signed as one
+ *   multi-part UR QR sequence; decode the device's scanned response back into per-PCZT
+ *   signatures). Pure PCZT/UR operations with no wallet-database access, unlike almost everything
+ *   else in this interface.
+ *
+ * Reconciled 2026-07-15 while wiring the real JNI implementation:
+ * - [submitNoteSplit] / [signAndStoreMigrationSchedule] gained a `usk: UnifiedSpendingKey`
+ *   parameter — sdk-lib never stores/derives a spending key itself (see
+ *   [Synchronizer.createProposedTransactions]), and the Rust calls they wrap require one.
+ * - [getMigrationState] / [getMigrationProgress] / [isNoteSplitNeeded] /
+ *   [isSyncRequiredBeforeNextTransfer] / [hasOverdueTransfers] / [hasInvalidTransfers] became
+ *   `suspend` — each opens a `MigrationContext` against the wallet's SQLite database, unlike the
+ *   mock's free in-memory answers.
+ */
+
+// ─── Supporting types ─────────────────────────────────────────────────────────
+
+/**
+ * Controls how migration transactions are broadcast.
+ *
+ * [useTor] — routes the broadcast through Tor when true.
+ * [submissionEndpoint] — null means use the same LWD server as sync.
+ *   Pass a secondary endpoint to de-correlate sync and submission servers
+ *   (privacy improvement: an observer cannot link sync traffic and broadcast traffic
+ *   to the same wallet).
+ */
+data class NetworkPrivacyOptions(
+    val useTor: Boolean,
+    val submissionEndpoint: String? = null
+)
+
+/**
+ * SDK-generated note split proposal. The SDK decides the number of output notes,
+ * their sizes, and randomisation — the app only shows this to the user for confirmation.
+ *
+ * Splitting into ~10 notes is the current target heuristic (20k ZEC cap per note).
+ */
+data class NoteSplitProposal(
+    val outputNotes: List<Long>,  // amounts in zatoshi
+    val fee: Long
+)
+
+/**
+ * A single scheduled migration transfer.
+ *
+ * [anchorHeight] is chosen from a shared network-wide 288-block bucket
+ * (block height divisible by 288, ≈ 6-hour intervals). This hides the wallet's
+ * last sync time from an observer. The anchor and the broadcast time are independent —
+ * the transaction can be broadcast at any point after [nextExecutableAfterHeight].
+ *
+ * [nextExecutableAfterHeight] is what the app uses to schedule the WorkManager task.
+ * The SDK sets this; the app does not compute it.
+ *
+ * [expiryHeight] — if the transaction is not broadcast before this height it becomes
+ * invalid and [OrchardMigrationSdk.restartCurrentMigrationStep] must be called.
+ */
+data class TransferProposal(
+    val id: String,
+    val amountZatoshi: Long,
+    val anchorHeight: Long,
+    val nextExecutableAfterHeight: Long,
+    val expiryHeight: Long
+)
+
+/**
+ * Full migration schedule returned by [OrchardMigrationSdk.proposeMigrationTransfers].
+ * Shown to the user for review before [OrchardMigrationSdk.signAndStoreMigrationSchedule]
+ * is called. After sign+store, individual transfers do not require per-send confirmation.
+ */
+data class MigrationSchedule(
+    val transfers: List<TransferProposal>,
+    val estimatedDurationHours: Int
+)
+
+/**
+ * The result of feeding one scanned QR frame to the Keystone batch-signing UR decoder —
+ * see [OrchardMigrationSdk.decodeKeystoneSignBatchPart].
+ *
+ * [complete] is `false` while more frames are still expected — [progress] (0–100) tracks how far
+ * the multi-part scan has gotten. Once `complete` is `true`, [data] carries the decoded batch
+ * signing response bytes to pass to [OrchardMigrationSdk.applyKeystoneBatchSignatures]; `null`
+ * otherwise.
+ *
+ * [firmwareVersion] is the signing device's raw `[major, minor, build]` firmware version — also
+ * non-null exactly when [complete]. This comes straight from the `zcash-batch-sig-result` UR
+ * envelope, not from any signed PCZT: the batch protocol returns signatures only and never echoes
+ * PCZT bytes back, so this field is the only way to learn the device's firmware version for a
+ * batch-signed migration. Callers should check this **before** relying on any PCZT-embedded
+ * firmware stamp (that mechanism belongs to the single-transaction Keystone sign flow and will
+ * never be present on a batch-reconstructed PCZT).
+ */
+data class KeystoneBatchDecodeResult(
+    val complete: Boolean,
+    val progress: Int,
+    val data: ByteArray?,
+    val firmwareVersion: ByteArray?
+)
+
+/**
+ * The signed-but-unproven PCZT bytes produced by [OrchardMigrationSdk.applyKeystoneBatchSignatures]
+ * — [splitSignedPczt] is `null` iff no split PCZT was included in the batch;
+ * [transferSignedPczts] is in the same order the unsigned PCZTs were passed to
+ * [OrchardMigrationSdk.buildKeystoneSignBatchQrParts]. Pass [splitSignedPczt] to
+ * [OrchardMigrationSdk.storeSignedNoteSplitPczt] and [transferSignedPczts] (paired back up with
+ * their transfer ids) to [OrchardMigrationSdk.storeSignedSchedulePczts].
+ */
+data class KeystoneBatchSignedPczts(
+    val splitSignedPczt: ByteArray?,
+    val transferSignedPczts: List<ByteArray>
+)
+
+/**
+ * Live migration progress used by the progress UI.
+ * [nextTransferReadyAtHeight] is null when all transfers are complete or migration
+ * has not started yet.
+ */
+data class MigrationProgress(
+    val completedTransfers: Int,
+    val totalTransfers: Int,
+    val remainingOrchardZatoshi: Long,
+    val nextTransferReadyAtHeight: Long?
+)
+
+/**
+ * Top-level migration state machine.
+ *
+ * NotStarted
+ *   → SplitPendingConfirmation  (if split needed, split tx submitted)
+ *   → ReadyToPropose            (split confirmed, or split not needed)
+ *   → InProgress                (schedule signed and stored)
+ *   → RequiresAttention         (transfer invalid/expired, user must act)
+ *   → Complete
+ */
+sealed class MigrationState {
+    /** No migration has been initiated. Show migration entry point. */
+    object NotStarted : MigrationState()
+
+    /** Note split transaction submitted, waiting for on-chain confirmation (~1 block). */
+    object SplitPendingConfirmation : MigrationState()
+
+    /** Split confirmed (or was not needed). Ready to call proposeMigrationTransfers(). */
+    object ReadyToPropose : MigrationState()
+
+    /** Migration schedule is committed and transfers are executing. */
+    data class InProgress(val progress: MigrationProgress) : MigrationState()
+
+    /**
+     * A transfer cannot proceed automatically. App must surface a non-error prompt
+     * and call restartCurrentMigrationStep() after user acknowledges.
+     */
+    data class RequiresAttention(val reason: AttentionReason) : MigrationState()
+
+    /** All transfers confirmed on-chain. Orchard balance is zero. */
+    object Complete : MigrationState()
+}
+
+sealed class AttentionReason {
+    /** Input note was spent externally before the migration transfer was broadcast. */
+    data class InvalidTransfer(val transferId: String) : AttentionReason()
+
+    /** Transaction anchor expired before broadcast (e.g. extended offline period). */
+    object TransferExpired : AttentionReason()
+
+    /**
+     * A transfer produced change back to Orchard. That change must be synced before
+     * the next transfer can spend it. App should trigger sync, then resume execution.
+     */
+    object SyncRequiredBeforeNext : AttentionReason()
+}
+
+/**
+ * Result of a broadcast attempt. The app maps each case to a specific UI/retry action —
+ * do not collapse these into a generic error.
+ */
+sealed class TransferResult {
+    data class Success(val txId: String) : TransferResult()
+
+    /** Transient network failure. Retry in the next WorkManager window. */
+    data class NetworkError(val retryable: Boolean) : TransferResult()
+
+    /**
+     * Input note is already spent. Sets MigrationState to RequiresAttention.
+     * App must call restartCurrentMigrationStep() for the remaining balance.
+     */
+    object InvalidNote : TransferResult()
+
+    /**
+     * Transaction anchor height has expired. Same handling as InvalidNote.
+     * Call restartCurrentMigrationStep().
+     */
+    object Expired : TransferResult()
+}
+
+// ─── Main interface ───────────────────────────────────────────────────────────
+
+interface OrchardMigrationSdk {
+
+    // ── State ────────────────────────────────────────────────────────────────
+
+    /**
+     * Current state of the migration. App calls this on every launch and after
+     * every SDK operation to decide which screen to show.
+     *
+     * Consider exposing as Flow<MigrationState> if the Rust bridge supports it —
+     * that removes the need for manual polling.
+     *
+     * Implementation note (Rust bridge, 2026-07-15): this and the other state-query methods below
+     * (`getMigrationProgress`, `isNoteSplitNeeded`, `isSyncRequiredBeforeNextTransfer`,
+     * `hasOverdueTransfers`, `hasInvalidTransfers`) are `suspend` — not the synchronous calls their
+     * original signatures implied — because the real implementation opens a `MigrationContext`
+     * against the wallet's SQLite database on every call. The mock's answers were free (in-memory
+     * state), so the original interface didn't need `suspend` here; the real bridge does.
+     */
+    suspend fun getMigrationState(): MigrationState
+
+    /** Convenience accessor for progress details when state is InProgress. */
+    suspend fun getMigrationProgress(): MigrationProgress?
+
+    /**
+     * How many successive migration runs the account's current Orchard balance would need, given
+     * the engine's per-run note cap — a read-only, stateless preview with no memory of prior
+     * calls or rounds already committed. Callers must call this fresh every time they need it
+     * (e.g. on every entry to the migration Review screen); the answer reflects whatever balance
+     * remains right now, not a running count from when a multi-round campaign started. `null` when
+     * no account is bound yet.
+     */
+    suspend fun estimateMigrationRunCount(): Int?
+
+    // ── Note splitting ───────────────────────────────────────────────────────
+
+    /**
+     * Returns true if the current Orchard notes must be split before migration.
+     * Note splitting is mandatory — do not proceed to proposeMigrationTransfers()
+     * without splitting first if this returns true.
+     */
+    suspend fun isNoteSplitNeeded(): Boolean
+
+    /**
+     * SDK computes the optimal split (number of notes, sizes, randomisation).
+     * Returns a proposal for user review. Nothing is broadcast until submitNoteSplit().
+     */
+    suspend fun prepareNoteSplit(): NoteSplitProposal
+
+    /**
+     * Broadcasts the note-split transaction. State transitions to SplitPendingConfirmation.
+     * The split is a wallet-internal send (no external receiver).
+     *
+     * Implementation note (Rust bridge, 2026-07-10): the Rust `MigrationContext` splits this
+     * into three separate steps — `sign_note_split(proposal, usk)` (returns a `PreparedTransfer`:
+     * txid + PCZT bytes, nothing broadcast yet), `extract_broadcast_tx(pczt_bytes)` (PCZT →
+     * consensus tx bytes), then the SDK's *existing* transaction-submission path (the same one
+     * ordinary sends use) to actually broadcast, and finally `record_transfer_result(id, result)`
+     * to tell the engine the outcome. This Kotlin method's real implementation composes all four
+     * calls and maps the outcome to [TransferResult] — the app only ever sees the single
+     * broadcast-and-record round trip.
+     *
+     * Open question: should this accept NetworkPrivacyOptions?
+     * The split is on-chain visible, so routing through Tor may be desirable for
+     * large balances. Defaulting to no Tor for simplicity for now.
+     *
+     * Implementation note (Rust bridge, 2026-07-15): [usk] is required because `sign_note_split`
+     * signs the split transaction — sdk-lib never stores or derives a spending key itself, it only
+     * ever receives one per-call from the caller, the same boundary
+     * [Synchronizer.createProposedTransactions] already establishes for ordinary sends.
+     */
+    suspend fun submitNoteSplit(proposal: NoteSplitProposal, usk: UnifiedSpendingKey): TransferResult
+
+    // ── External signer (Keystone hardware wallet) ───────────────────────────
+
+    /**
+     * Builds the note-split transaction as an unsigned PCZT for an external signer — the
+     * [submitNoteSplit] equivalent for callers with no software spending key. Nothing is
+     * broadcast; pass the device's returned signature to [storeSignedNoteSplitPczt].
+     */
+    suspend fun createUnsignedNoteSplitPczt(): ByteArray
+
+    /**
+     * Accepts the externally-signed note-split PCZT, finalizes it, and broadcasts it — the
+     * back half of [createUnsignedNoteSplitPczt], mirroring [submitNoteSplit]'s composition
+     * (extract → broadcast via the existing submission path → record result) exactly.
+     */
+    suspend fun storeSignedNoteSplitPczt(signedPczt: ByteArray, options: NetworkPrivacyOptions): TransferResult
+
+    /**
+     * Builds one unsigned PCZT per transfer of `schedule` for an external signer — the
+     * [signAndStoreMigrationSchedule] equivalent for callers with no software spending key.
+     * Returns `(transfer id, unsigned PCZT bytes)` pairs; the pairing must survive to
+     * [storeSignedSchedulePczts], which matches signed PCZTs back to these by id.
+     *
+     * Self-funding transfers (the common case) use the same sign-now/prove-later
+     * placeholder-witness scheme [signAndStoreMigrationSchedule] does — callers do not need to
+     * wait for the note-split to confirm on-chain before calling this either.
+     */
+    suspend fun createUnsignedTransferPczts(schedule: MigrationSchedule): List<Pair<String, ByteArray>>
+
+    /**
+     * Accepts the full set of externally-signed transfer PCZTs — **all-or-nothing**, matched back
+     * to their staged unsigned originals by id (from [createUnsignedTransferPczts]) — and persists
+     * the committed schedule. No broadcast happens here (mirrors [signAndStoreMigrationSchedule]'s
+     * role): [finalizeReadyTransfers] later completes any transfer that was staged awaiting proof,
+     * exactly as it already does for the software-signing path.
+     */
+    suspend fun storeSignedSchedulePczts(signed: List<Pair<String, ByteArray>>)
+
+    /**
+     * Builds the animated multi-part QR frames for one combined Keystone batch-signing request
+     * covering the optional note-split PCZT (pass `null` when [isNoteSplitNeeded] is `false`) and
+     * every schedule transfer's unsigned PCZT, in that order — so split and schedule sign in a
+     * single device round trip rather than two. [requestId] is an opaque correlation token (e.g. a
+     * UUID's bytes) the device round-trips, checked by [decodeKeystoneSignBatchPart].
+     *
+     * Pure PCZT/UR encoding — no wallet-database access, unlike almost every other method here.
+     */
+    suspend fun buildKeystoneSignBatchQrParts(
+        requestId: ByteArray,
+        splitUnsignedPczt: ByteArray?,
+        transferUnsignedPczts: List<ByteArray>,
+        maxFragmentLen: Int
+    ): List<String>
+
+    /**
+     * Discards any in-flight multi-part Keystone batch-signing scan session. Call on scan-screen
+     * entry so a new attempt always starts from a clean slate.
+     */
+    suspend fun resetKeystoneSignBatchDecoder()
+
+    /**
+     * Feeds one scanned QR frame into the active (or a freshly started) Keystone batch-signing
+     * decode session. [expectedRequestId] must match [buildKeystoneSignBatchQrParts]'s
+     * `requestId` — a mismatch (or any other decode error) resets the session; call
+     * [resetKeystoneSignBatchDecoder] before retrying.
+     */
+    suspend fun decodeKeystoneSignBatchPart(part: String, expectedRequestId: ByteArray): KeystoneBatchDecodeResult
+
+    /**
+     * Applies a completed Keystone batch-signing response ([KeystoneBatchDecodeResult.data] once
+     * `complete`) back to the retained unsigned PCZTs — in the exact split-then-transfers order
+     * they were passed to [buildKeystoneSignBatchQrParts] — producing signed-but-unproven PCZT
+     * bytes for each, ready for [storeSignedNoteSplitPczt]/[storeSignedSchedulePczts].
+     */
+    suspend fun applyKeystoneBatchSignatures(
+        splitUnsignedPczt: ByteArray?,
+        transferUnsignedPczts: List<ByteArray>,
+        batchSignResponse: ByteArray
+    ): KeystoneBatchSignedPczts
+
+    // ── Migration proposal ───────────────────────────────────────────────────
+
+    /**
+     * Generates the full migration schedule. Call only when state is ReadyToPropose.
+     *
+     * SDK decides: number of transfers, randomised amounts, anchor heights
+     * (from 288-block buckets), and nextExecutableAfterHeight per transfer.
+     * App shows this to the user for one-time confirmation before signing.
+     *
+     * [includeResidual] — when the spendable balance leaves a leftover too small to form a whole
+     * migratable note but too large to be dust (see the Rust bridge's `residual_after_migration()`
+     * threshold, ~0.001 ZEC), that leftover is excluded from the schedule by default: migrating it
+     * requires one extra, non-round-number transfer, which is more identifiable on-chain than the
+     * power-of-ten crossings (a privacy/completeness trade-off — see ProposalA.md's "sub-1-ZEC"
+     * open point). Pass `true` only once the app exposes this as an explicit user choice; **for
+     * now, always pass `false`** — the opt-in UI for this does not exist yet.
+     */
+    suspend fun proposeMigrationTransfers(includeResidual: Boolean = false): MigrationSchedule
+
+    /**
+     * Proposes the migration schedule directly from a note-split's own output plan
+     * ([NoteSplitProposal] returned by [prepareNoteSplit]) — use this instead of
+     * [proposeMigrationTransfers] whenever a split is about to run or just ran (i.e. whenever
+     * [isNoteSplitNeeded] returned `true`), so every crossing value is guaranteed to match a note
+     * the split actually produces.
+     *
+     * [proposeMigrationTransfers] and [prepareNoteSplit] each compute their own denomination plan
+     * independently over the same balance, and are not guaranteed to agree — a schedule built from
+     * [proposeMigrationTransfers] before the split has run can end up needing a note the split
+     * never actually mints, which then silently (and incorrectly) falls back to an unrelated
+     * already-existing note — one the split's own "sweep every spendable note" construction may
+     * already be consuming as one of its own inputs, a double-spend once the split mines. Deriving
+     * the schedule from the split's own realized output plan instead makes this class of mismatch
+     * structurally impossible.
+     *
+     * Implementation note (Rust bridge, 2026-07-20): backed by
+     * `MigrationContext::propose_migration_transfers_from_split`.
+     */
+    suspend fun proposeMigrationTransfersFromSplit(splitProposal: NoteSplitProposal): MigrationSchedule
+
+    /**
+     * Proposes a single, unsplit, full-balance migration transfer for immediate broadcast —
+     * no privacy-preserving multi-transfer split. The returned [MigrationSchedule] always
+     * contains exactly one [TransferProposal] whose [TransferProposal.nextExecutableAfterHeight]
+     * is immediately executable, so the caller broadcasts it right away via
+     * [executeNextPendingTransfer] after [signAndStoreMigrationSchedule] — no WorkManager /
+     * BGTaskScheduler background scheduling is needed for this path.
+     *
+     * Call only when state is ReadyToPropose, as an alternative to [proposeMigrationTransfers]
+     * for users who explicitly opt out of the privacy-preserving schedule.
+     */
+    suspend fun proposeImmediateMigration(): MigrationSchedule
+
+    /**
+     * User has confirmed the schedule. SDK signs all transactions and stores them
+     * in the database via the existing transaction-resubmission infrastructure.
+     * State transitions to InProgress. Individual transfers no longer need per-send
+     * confirmation.
+     *
+     * After this call, app reads nextExecutableAfterHeight from each TransferProposal
+     * to schedule WorkManager tasks.
+     *
+     * Implementation note (Rust bridge, 2026-07-15): [usk] is required for the same reason as
+     * [submitNoteSplit]'s — `sign_and_store_migration_schedule` signs every transfer in the
+     * schedule.
+     *
+     * Implementation note (Rust bridge, 2026-07-18, sign-now/prove-later): this signs every
+     * transfer immediately, even one whose funding note (a not-yet-mined note-split output) isn't
+     * witnessed yet — it defers the proof for such transfers rather than requiring them to wait.
+     * Callers do not need to wait for note-split to confirm on-chain before calling this. See
+     * [finalizeReadyTransfers] for how those deferred-proof transfers are later completed.
+     */
+    suspend fun signAndStoreMigrationSchedule(schedule: MigrationSchedule, usk: UnifiedSpendingKey)
+
+    // ── Background execution ─────────────────────────────────────────────────
+
+    /**
+     * Returns true if a sync is needed before the next transfer can be executed.
+     * Happens when the previous transfer produced change back to Orchard — that
+     * change must be confirmed and synced before it can be spent.
+     *
+     * WorkManager task should check this before calling executeNextPendingTransfer().
+     * If true, task should exit and trigger a separate sync (not in the same session —
+     * sync and broadcast must be decoupled in time).
+     */
+    suspend fun isSyncRequiredBeforeNextTransfer(): Boolean
+
+    /**
+     * Completes every pre-signed transfer that is awaiting a proof (its funding note — a
+     * not-yet-mined note-split output — was not yet witnessed at signing time) and whose funding
+     * note has since become witnessed: attaches the note's real witness and anchor, runs the
+     * prover, and makes the transfer eligible for [executeNextPendingTransfer] from then on.
+     *
+     * Idempotent and cheap to call redundantly — returns `0`, **not** an error, whenever there is
+     * nothing awaiting a proof yet or every awaiting transfer's funding note is still unwitnessed;
+     * that is the ordinary, expected steady state while a note-preparation output is still mining,
+     * not a failure. Callers do not need to guard calls to this with [isNoteSplitNeeded] or any
+     * other state check first.
+     *
+     * WorkManager task should call this before [isSyncRequiredBeforeNextTransfer] /
+     * [executeNextPendingTransfer] on every run, so a funding note that became witnessed since the
+     * last run gets finalized to broadcastable in the same session that might then immediately
+     * find and broadcast it.
+     *
+     * Implementation note (Rust bridge, 2026-07-18): backed by
+     * `MigrationContext::finalize_ready_transfers`, added alongside the sign-now/prove-later
+     * pipeline change to `signAndStoreMigrationSchedule` (see that method's implementation note) —
+     * that change lets signing succeed immediately even when a transfer's funding note isn't
+     * witnessed yet; this method is what later completes such a transfer once its note is.
+     */
+    suspend fun finalizeReadyTransfers(): Int
+
+    /**
+     * Broadcasts the next pending transfer. App does not need to track which transfer
+     * is next — the SDK manages internal ordering.
+     *
+     * Returns null if there is nothing to execute (all done or none stored yet).
+     *
+     * Called from: WorkManager Worker (Android) / BGTaskScheduler task (iOS).
+     * Sync must NOT be triggered inside the same background session as this call.
+     *
+     * [options] — Tor and submission endpoint settings chosen by the user during
+     * the confirmation flow. Store and pass through from the committed schedule.
+     *
+     * Implementation note (Rust bridge, 2026-07-10): same three-call composition as
+     * [submitNoteSplit] — `next_due_transfer()` (returns `None` when nothing is due, mapped to
+     * this method's `null`), `extract_broadcast_tx(pczt_bytes)`, submit via the existing
+     * transaction-submission path honoring [options], then `record_transfer_result(id, result)`.
+     * A transfer that is due but not yet broadcast is returned by `next_due_transfer()` again on
+     * every call — there is no separate "claim" step, so a retried/interrupted call is safe to
+     * simply call again.
+     */
+    suspend fun executeNextPendingTransfer(options: NetworkPrivacyOptions): TransferResult?
+
+    // ── Sync coordination ────────────────────────────────────────────────────
+
+    /**
+     * True whenever wallet sync must not run: a transfer is overdue (its
+     * nextExecutableAfterHeight has passed but it hasn't broadcast), or a transfer was just
+     * broadcast via the immediate ("send now") path and is still inside its post-broadcast
+     * privacy buffer (see [privacySyncBufferDuration]).
+     *
+     * The SDK owns this decision entirely and re-derives it from its own persisted migration
+     * state — the app does not toggle this, it only observes it (typically by feeding it
+     * straight into the synchronizer's own construction/gating, the same way isTorEnabled
+     * already works). This guarantees blocking can never get "stuck" from a forgotten resume
+     * call, since there is no imperative resume call to forget.
+     *
+     * Implementation note (Rust bridge, 2026-07-10): "SDK owns this" means the **Kotlin**
+     * implementation of [OrchardMigrationSdk], not the Rust `MigrationContext` — the Rust engine
+     * has no concept of sync-blocking or a resume buffer at all (that's a network/timing-privacy
+     * technique for de-correlating sync traffic from broadcast traffic, layered on top of the
+     * migration engine, not part of it). The Kotlin implementation derives the "overdue" half from
+     * `has_overdue_transfers()` (a real Rust call) and owns the "post-broadcast buffer" half
+     * itself (e.g. a persisted resume-at timestamp, as the current mock already does via
+     * `MigrationSyncResumeAtStorageProvider`) — no Rust call backs that half.
+     */
+    fun isSyncBlocked(): Flow<Boolean>
+
+    /**
+     * How long sync must stay blocked after a transfer is broadcast via the immediate
+     * ("send now") path, to decouple broadcast timing from sync-resume timing for privacy.
+     * SDK-owned so this stays consistent with whatever cadence the SDK actually schedules
+     * transfers at — the app only displays this value, it does not compute it.
+     *
+     * Implementation note (Rust bridge, 2026-07-10): a Kotlin-side constant/config, same as
+     * [isSyncBlocked]'s buffer half — not backed by any Rust call.
+     */
+    fun privacySyncBufferDuration(): Duration
+
+    // ── On-launch reconciliation ─────────────────────────────────────────────
+
+    /**
+     * True if one or more scheduled transfers are past their nextExecutableAfterHeight
+     * but have not been broadcast yet. App shows the fallback prompt on launch.
+     *
+     * This is the primary catch-up mechanism — do not rely on notification delivery.
+     */
+    suspend fun hasOverdueTransfers(): Boolean
+
+    /**
+     * Defers the current overdue transfer to a later execution window, instead of broadcasting it
+     * right now via [executeNextPendingTransfer]. Unlike [restartCurrentMigrationStep], the
+     * transfer itself is still validly signed (its note hasn't been spent, its anchor hasn't
+     * expired) — only its window was missed — so this does not invalidate or re-sign anything.
+     *
+     * Implementation note (Rust bridge, 2026-07-10): there is **no Rust-side call** for this —
+     * `MigrationContext` has no "reschedule" operation, because it doesn't need one. A pre-signed
+     * transfer is due-and-broadcastable for as long as `TransferProposal.expiryHeight` allows;
+     * `next_due_transfer()`/`executeNextPendingTransfer` will simply keep returning the *same*
+     * transfer on every call until it's either broadcast or its expiry passes. "Rescheduling" is
+     * therefore purely a local decision not to call [executeNextPendingTransfer] yet — the SDK
+     * persists nothing new, it only computes and returns a later target time (e.g. the next
+     * natural anchor-bucket boundary) for the app's WorkManager job. **The chosen time must still
+     * be before the transfer's `expiryHeight`** — pushing past it isn't a valid reschedule; that
+     * case is [hasInvalidTransfers]/[restartCurrentMigrationStep]'s job instead. (The previous
+     * revision of this doc said the SDK "persists the new schedule" — that described the mock's
+     * behavior, not the real bridge; callers relying on that persistence will need updating.)
+     */
+    suspend fun rescheduleOverdueTransfer(): TransferProposal
+
+    /**
+     * True if any stored transfer is in an invalid state (spent note or expired anchor).
+     * App shows the RequiresAttention screen. Call restartCurrentMigrationStep() after
+     * user acknowledges.
+     *
+     * Detection condition: orchardBalance > 0 AND no valid queued migration transaction.
+     */
+    suspend fun hasInvalidTransfers(): Boolean
+
+    // ── Invalidity recovery ──────────────────────────────────────────────────
+
+    /**
+     * Called when state is RequiresAttention. SDK invalidates the broken transfer,
+     * re-evaluates the remaining unspent Orchard notes, and returns a new schedule
+     * for the remainder of the balance.
+     *
+     * The returned MigrationSchedule must go through the normal user confirmation
+     * flow → signAndStoreMigrationSchedule() — same as the first time.
+     *
+     * [includeResidual] — should match whatever choice the user made for
+     * [proposeMigrationTransfers] on the schedule being recovered (**pass `false`** until the
+     * opt-in UI for that exists — see [proposeMigrationTransfers]'s doc).
+     */
+    suspend fun restartCurrentMigrationStep(includeResidual: Boolean = false): MigrationSchedule
+
+    // ── Dust locking ─────────────────────────────────────────────────────────
+
+    /**
+     * Marks whatever Orchard balance remains after migration (dust below the migratable
+     * threshold, or an opted-out residual) as unspendable, so it can't later be swept into a
+     * transaction that reveals its specific — and therefore identifying — amount.
+     *
+     * Backed by `zcash_client_backend`'s note-locking (`WalletWrite::lock_outputs`, librustzcash
+     * PR #2716): the remaining spendable Orchard notes for this account are locked under a fixed,
+     * well-known owner token with no practical expiry, so ordinary note selection (sends,
+     * shielding, any future migration round) excludes them by default. Calling this again is
+     * idempotent (same-owner re-locking just extends the existing lock).
+     */
+    suspend fun lockRemainingOrchardBalance()
+
+    companion object {
+        /**
+         * Constructs the real, Rust-backed [OrchardMigrationSdk].
+         *
+         * Deliberately independent of [Synchronizer] — [WalletCoordinator]'s `isSyncBlocked` input
+         * needs this *before* any `Synchronizer` exists (a `Synchronizer`-scoped factory would be
+         * circular), so this only needs the same inputs [Synchronizer.new] itself takes.
+         *
+         * [lightWalletEndpoint] should be the same endpoint the app passes to [Synchronizer.new] —
+         * there is no independent way for this factory to discover it (wallet/endpoint persistence
+         * is an app-layer concern, not an SDK one).
+         *
+         * [NetworkPrivacyOptions.useTor] uses its own dedicated [cash.z.ecc.android.sdk.internal.model.TorClient]
+         * (own on-disk directory, separate from the main `Synchronizer`'s), built lazily on first
+         * use — this is a genuinely per-migration setting, independent of the app's global Tor
+         * toggle.
+         *
+         * [account] is the wallet account this instance operates on — whichever account the
+         * migration flow is actually running for (the app resolves this, e.g. from the currently
+         * selected account; it is never auto-picked here). Pass `null` only for the one legitimate
+         * case that has no account selection to make yet: gating [Synchronizer]-independent sync
+         * (e.g. [WalletCoordinator]'s `isSyncBlocked` input) before any account is chosen — with a
+         * `null` account, [OrchardMigrationSdk.isSyncBlocked] checks every account in the wallet
+         * instead of assuming one, and every other method degrades to its "nothing to do" answer
+         * or throws (see [cash.z.ecc.android.sdk.internal.OrchardMigrationSdkImpl]'s doc).
+         */
+        fun new(
+            appContext: android.content.Context,
+            zcashNetwork: cash.z.ecc.android.sdk.model.ZcashNetwork,
+            lightWalletEndpoint: co.electriccoin.lightwallet.client.model.LightWalletEndpoint,
+            account: cash.z.ecc.android.sdk.model.AccountUuid?,
+            alias: String = cash.z.ecc.android.sdk.ext.ZcashSdk.DEFAULT_ALIAS
+        ): OrchardMigrationSdk =
+            cash.z.ecc.android.sdk.internal.OrchardMigrationSdkImpl(
+                context = appContext.applicationContext,
+                network = zcashNetwork,
+                alias = alias,
+                account = account,
+                migrationBackend = cash.z.ecc.android.sdk.internal.TypesafeMigrationBackendImpl(),
+                defaultSubmitEndpoint = lightWalletEndpoint,
+                preferenceProviderHolder =
+                    cash.z.ecc.android.sdk.internal.storage.preference.EncryptedPreferenceProvider(
+                        appContext.applicationContext
+                    )
+            )
+    }
+}

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
@@ -545,6 +545,7 @@ class SdkSynchronizer private constructor(
                     ZcashProtocol.TRANSPARENT -> TransactionPool.TRANSPARENT
                     ZcashProtocol.SAPLING -> TransactionPool.SAPLING
                     ZcashProtocol.ORCHARD -> TransactionPool.ORCHARD
+                    ZcashProtocol.IRONWOOD -> TransactionPool.IRONWOOD
                 }
             )
         }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessor.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessor.kt
@@ -265,7 +265,7 @@ class CompactBlockProcessor internal constructor(
     suspend fun start() {
         val traceScope = TraceScope("CompactBlockProcessor.start")
 
-        val (saplingStartIndex, orchardStartIndex) = refreshWalletSummary()
+        val (saplingStartIndex, orchardStartIndex, ironwoodStartIndex) = refreshWalletSummary()
 
         updateBirthdayHeight()
 
@@ -282,7 +282,7 @@ class CompactBlockProcessor internal constructor(
 
         // Download note commitment tree data from lightwalletd to decide if we communicate with linear
         // or spend-before-sync node.
-        var subTreeRootResult = getSubtreeRoots(downloader, saplingStartIndex, orchardStartIndex)
+        var subTreeRootResult = getSubtreeRoots(downloader, saplingStartIndex, orchardStartIndex, ironwoodStartIndex)
         Twig.info { "Fetched SubTreeRoot result: $subTreeRootResult" }
 
         Twig.debug { "Setup verified. Processor starting..." }
@@ -316,6 +316,10 @@ class CompactBlockProcessor internal constructor(
                                             orchardSubtreeRootList =
                                                 (subTreeRootResult as GetSubtreeRootsResult.SpendBeforeSync)
                                                     .orchardSubtreeRootList,
+                                            ironwoodStartIndex = ironwoodStartIndex,
+                                            ironwoodSubtreeRootList =
+                                                (subTreeRootResult as GetSubtreeRootsResult.SpendBeforeSync)
+                                                    .ironwoodSubtreeRootList,
                                             lastValidHeight = lowerBoundHeight
                                         )
                                 ) {
@@ -353,7 +357,7 @@ class CompactBlockProcessor internal constructor(
                             GetSubtreeRootsResult.FailureConnection -> {
                                 // SubtreeRoot fetching retry
                                 subTreeRootResult =
-                                    getSubtreeRoots(downloader, saplingStartIndex, orchardStartIndex)
+                                    getSubtreeRoots(downloader, saplingStartIndex, orchardStartIndex, ironwoodStartIndex)
                                 BlockProcessingResult.Reconnecting
                             }
                         }
@@ -880,7 +884,7 @@ class CompactBlockProcessor internal constructor(
      *
      * @return the next subtree index to fetch.
      */
-    internal suspend fun refreshWalletSummary(): Pair<UInt, UInt> {
+    internal suspend fun refreshWalletSummary(): Triple<UInt, UInt, UInt> {
         when (val result = getWalletSummary(backend)) {
             is GetWalletSummaryResult.Success -> {
                 val scanProgress = result.walletSummary.scanProgress
@@ -889,9 +893,10 @@ class CompactBlockProcessor internal constructor(
                 setProgress(scanProgress, recoveryProgress)
                 setFullyScannedHeight(result.walletSummary.fullyScannedHeight)
                 updateAllBalances(result.walletSummary)
-                return Pair(
+                return Triple(
                     result.walletSummary.nextSaplingSubtreeIndex,
-                    result.walletSummary.nextOrchardSubtreeIndex
+                    result.walletSummary.nextOrchardSubtreeIndex,
+                    result.walletSummary.nextIronwoodSubtreeIndex
                 )
             }
 
@@ -899,7 +904,7 @@ class CompactBlockProcessor internal constructor(
                 // Do not report the progress and balances in case of any error, and
                 // tell the caller to fetch all subtree roots.
                 Twig.info { "Progress from rust: no progress information available, progress type: $result" }
-                return Pair(UInt.MIN_VALUE, UInt.MIN_VALUE)
+                return Triple(UInt.MIN_VALUE, UInt.MIN_VALUE, UInt.MIN_VALUE)
             }
         }
     }
@@ -1327,7 +1332,8 @@ class CompactBlockProcessor internal constructor(
     internal suspend fun getSubtreeRoots(
         downloader: CompactBlockDownloader,
         saplingStartIndex: UInt,
-        orchardStartIndex: UInt
+        orchardStartIndex: UInt,
+        ironwoodStartIndex: UInt
     ): GetSubtreeRootsResult {
         Twig.debug { "Fetching SubtreeRoots..." }
         val traceScope = TraceScope("CompactBlockProcessor.getSubtreeRoots")
@@ -1336,6 +1342,7 @@ class CompactBlockProcessor internal constructor(
 
         var saplingSubtreeRootList: List<SubtreeRoot> = emptyList()
         var orchardSubtreeRootList: List<SubtreeRoot> = emptyList()
+        var ironwoodSubtreeRootList: List<SubtreeRoot> = emptyList()
 
         retryUpToAndContinue(GET_SUBTREE_ROOTS_RETRIES) {
             downloader
@@ -1441,18 +1448,72 @@ class CompactBlockProcessor internal constructor(
                 }
         }
 
-        // Intentionally omitting [orchardSubtreeRootList], e.g., for Mainnet usage, we could check it, but on
-        // custom networks without NU5 activation, it wouldn't work. If the Orchard subtree roots are empty, it's
-        // technically still ok (as Orchard activates after Sapling, so on a network that doesn't have NU5
-        // activated, this would behave correctly). In contrast, if the Sapling subtree roots are empty, we
-        // cannot do SbS at all.
+        retryUpToAndContinue(GET_SUBTREE_ROOTS_RETRIES) {
+            downloader
+                .getSubtreeRoots(
+                    startIndex = ironwoodStartIndex,
+                    shieldedProtocol = ShieldedProtocolEnum.IRONWOOD,
+                    maxEntries = UInt.MIN_VALUE,
+                    serviceMode = ServiceMode.Direct
+                ).onEach { response ->
+                    when (response) {
+                        is Response.Success -> {
+                            Twig.verbose {
+                                "Ironwood SubtreeRoot fetched successfully: its completingHeight is: ${
+                                    response.result
+                                        .completingBlockHeight
+                                }"
+                            }
+                        }
+
+                        is Response.Failure -> {
+                            val error =
+                                LightWalletException.GetSubtreeRootsException(
+                                    response.code,
+                                    response.description,
+                                    response.toThrowable()
+                                )
+                            if (response is Response.Failure.Server.Unavailable) {
+                                Twig.error {
+                                    "Fetching Ironwood SubtreeRoot failed due to server communication problem with" +
+                                        " failure: ${response.toThrowable()}"
+                                }
+                                result = GetSubtreeRootsResult.FailureConnection
+                            } else {
+                                Twig.error {
+                                    "Fetching Ironwood SubtreeRoot failed with failure: ${response.toThrowable()}"
+                                }
+                                result = GetSubtreeRootsResult.OtherFailure(error)
+                            }
+                            traceScope.end()
+                            throw error
+                        }
+                    }
+                }.filterIsInstance<Response.Success<SubtreeRootUnsafe>>()
+                .map { response ->
+                    response.result
+                }.toList()
+                .map {
+                    SubtreeRoot.new(it)
+                }.let {
+                    ironwoodSubtreeRootList = it
+                }
+        }
+
+        // Intentionally omitting [orchardSubtreeRootList]/[ironwoodSubtreeRootList], e.g., for Mainnet usage, we
+        // could check it, but on custom networks without NU5/NU6.3 activation, it wouldn't work. If the Orchard or
+        // Ironwood subtree roots are empty, it's technically still ok (both activate after Sapling, so on a network
+        // that doesn't have them activated yet, this would behave correctly). In contrast, if the Sapling subtree
+        // roots are empty, we cannot do SbS at all.
         if (saplingSubtreeRootList.isNotEmpty()) {
             result =
                 GetSubtreeRootsResult.SpendBeforeSync(
                     saplingStartIndex,
                     saplingSubtreeRootList,
                     orchardStartIndex,
-                    orchardSubtreeRootList
+                    orchardSubtreeRootList,
+                    ironwoodStartIndex,
+                    ironwoodSubtreeRootList
                 )
         }
 
@@ -1476,6 +1537,8 @@ class CompactBlockProcessor internal constructor(
         saplingSubtreeRootList: List<SubtreeRoot>,
         orchardStartIndex: UInt,
         orchardSubtreeRootList: List<SubtreeRoot>,
+        ironwoodStartIndex: UInt,
+        ironwoodSubtreeRootList: List<SubtreeRoot>,
         lastValidHeight: BlockHeight
     ): PutSaplingSubtreeRootsResult =
         runCatching {
@@ -1484,11 +1547,13 @@ class CompactBlockProcessor internal constructor(
                 saplingRoots = saplingSubtreeRootList,
                 orchardStartIndex = orchardStartIndex,
                 orchardRoots = orchardSubtreeRootList,
+                ironwoodStartIndex = ironwoodStartIndex,
+                ironwoodRoots = ironwoodSubtreeRootList,
             )
         }.onSuccess {
             Twig.info {
-                "Subtree roots put successfully with saplingStartIndex: $saplingStartIndex and " +
-                    "orchardStartIndex: $orchardStartIndex"
+                "Subtree roots put successfully with saplingStartIndex: $saplingStartIndex, " +
+                    "orchardStartIndex: $orchardStartIndex and ironwoodStartIndex: $ironwoodStartIndex"
             }
         }.onFailure {
             Twig.error { "Sapling subtree roots put failed with: $it" }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/model/GetSubtreeRootsResult.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/model/GetSubtreeRootsResult.kt
@@ -10,7 +10,9 @@ internal sealed class GetSubtreeRootsResult {
         val saplingStartIndex: UInt,
         val saplingSubtreeRootList: List<SubtreeRoot>,
         val orchardStartIndex: UInt,
-        val orchardSubtreeRootList: List<SubtreeRoot>
+        val orchardSubtreeRootList: List<SubtreeRoot>,
+        val ironwoodStartIndex: UInt,
+        val ironwoodSubtreeRootList: List<SubtreeRoot>
     ) : GetSubtreeRootsResult()
 
     data object Linear : GetSubtreeRootsResult()

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
@@ -654,7 +654,6 @@ private fun JniMigrationProgress.toPublic(): MigrationProgress =
     MigrationProgress(
         completedTransfers = completedTransfers,
         totalTransfers = totalTransfers,
-        remainingOrchardZatoshi = remainingOrchardValueZatoshi,
         nextTransferReadyAtHeight = nextTransferReadyAtHeight.takeIf { it != -1L },
     )
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
@@ -481,6 +481,21 @@ internal class OrchardMigrationSdkImpl(
         Unit
     }
 
+    // ── Debug ─────────────────────────────────────────────────────────────────
+
+    override suspend fun clearMigration() = logged("clearMigration") {
+        val dbDataPath = dbDataPath()
+        val account = account ?: noAccountAvailable()
+        migrationBackend.clearMigration(dbDataPath, network, account)
+        Unit
+    }
+
+    override suspend fun debugRescheduleTransfers(): Int = logged("debugRescheduleTransfers") {
+        val dbDataPath = dbDataPath()
+        val account = account ?: noAccountAvailable()
+        migrationBackend.debugRescheduleTransfers(dbDataPath, network, account)
+    }
+
     private suspend fun isSyncBlockedNow(preferenceProvider: PreferenceProvider): Boolean {
         val dbDataPath = dbDataPath()
         // Same mutex as logged() — this poll must never read the wallet DB at the same moment a

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
@@ -368,12 +368,6 @@ internal class OrchardMigrationSdkImpl(
 
     // ── Background execution ─────────────────────────────────────────────────
 
-    override suspend fun isSyncRequiredBeforeNextTransfer(): Boolean = logged("isSyncRequiredBeforeNextTransfer") {
-        val dbDataPath = dbDataPath()
-        val account = account ?: return@logged false
-        migrationBackend.isSyncRequiredBeforeNextTransfer(dbDataPath, network, account)
-    }
-
     override suspend fun finalizeReadyTransfers(): Int = logged("finalizeReadyTransfers") {
         val dbDataPath = dbDataPath()
         val account = account ?: return@logged 0

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
@@ -7,6 +7,8 @@ import cash.z.ecc.android.sdk.KeystoneBatchSignedPczts
 import cash.z.ecc.android.sdk.MigrationProgress
 import cash.z.ecc.android.sdk.MigrationSchedule
 import cash.z.ecc.android.sdk.MigrationState
+import cash.z.ecc.android.sdk.MigrationTransferState
+import cash.z.ecc.android.sdk.MigrationTransferStates
 import cash.z.ecc.android.sdk.NetworkPrivacyOptions
 import cash.z.ecc.android.sdk.NoteSplitProposal
 import cash.z.ecc.android.sdk.OrchardMigrationSdk
@@ -21,6 +23,8 @@ import cash.z.ecc.android.sdk.internal.model.migration.JniKeystoneBatchSignedPcz
 import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationProgress
 import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationSchedule
 import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationState
+import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationTransferState
+import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationTransferStates
 import cash.z.ecc.android.sdk.internal.model.migration.JniTransferProposal
 import cash.z.ecc.android.sdk.internal.storage.preference.EncryptedPreferenceProvider
 import cash.z.ecc.android.sdk.internal.storage.preference.api.PreferenceProvider
@@ -28,6 +32,7 @@ import cash.z.ecc.android.sdk.internal.storage.preference.keys.EncryptedPreferen
 import cash.z.ecc.android.sdk.internal.transaction.submitTransaction
 import cash.z.ecc.android.sdk.model.AccountUuid
 import cash.z.ecc.android.sdk.model.FirstClassByteArray
+import cash.z.ecc.android.sdk.model.Proposal
 import cash.z.ecc.android.sdk.model.SdkFlags
 import cash.z.ecc.android.sdk.model.TransactionSubmitResult
 import cash.z.ecc.android.sdk.model.UnifiedSpendingKey
@@ -347,10 +352,10 @@ internal class OrchardMigrationSdkImpl(
             ).toPublic()
         }
 
-    override suspend fun proposeImmediateMigration(): MigrationSchedule = logged("proposeImmediateMigration") {
+    override suspend fun proposeImmediateMigration(): Proposal = logged("proposeImmediateMigration") {
         val dbDataPath = dbDataPath()
         val account = account ?: noAccountAvailable()
-        migrationBackend.proposeImmediateMigrationTransfers(dbDataPath, network, account).toPublic()
+        Proposal.fromByteArray(migrationBackend.proposeImmediateSendMax(dbDataPath, network, account))
     }
 
     override suspend fun signAndStoreMigrationSchedule(schedule: MigrationSchedule, usk: UnifiedSpendingKey) =
@@ -464,6 +469,13 @@ internal class OrchardMigrationSdkImpl(
             val dbDataPath = dbDataPath()
             val account = account ?: noAccountAvailable()
             migrationBackend.restartCurrentMigrationStep(dbDataPath, network, account, includeResidual).toPublic()
+        }
+
+    override suspend fun getMigrationTransferStates(): MigrationTransferStates? =
+        logged("getMigrationTransferStates") {
+            val dbDataPath = dbDataPath()
+            val account = account ?: noAccountAvailable()
+            migrationBackend.migrationTransferStates(dbDataPath, network, account)?.toPublic()
         }
 
     // ── Dust locking ─────────────────────────────────────────────────────────
@@ -661,6 +673,19 @@ private fun JniMigrationSchedule.toPublic(): MigrationSchedule =
     MigrationSchedule(
         transfers = transfers.map { it.toPublic() },
         estimatedDurationHours = estimatedDurationHours,
+    )
+
+private fun JniMigrationTransferState.toPublic(): MigrationTransferState =
+    MigrationTransferState(
+        id = id,
+        isSent = isSent,
+        scheduledHeight = scheduledHeight,
+    )
+
+private fun JniMigrationTransferStates.toPublic(): MigrationTransferStates =
+    MigrationTransferStates(
+        transfers = transfers.map { it.toPublic() },
+        tipHeight = tipHeight,
     )
 
 private fun TransferProposal.toJni(): JniTransferProposal =

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
@@ -1,0 +1,694 @@
+package cash.z.ecc.android.sdk.internal
+
+import android.content.Context
+import cash.z.ecc.android.sdk.AttentionReason
+import cash.z.ecc.android.sdk.KeystoneBatchDecodeResult
+import cash.z.ecc.android.sdk.KeystoneBatchSignedPczts
+import cash.z.ecc.android.sdk.MigrationProgress
+import cash.z.ecc.android.sdk.MigrationSchedule
+import cash.z.ecc.android.sdk.MigrationState
+import cash.z.ecc.android.sdk.NetworkPrivacyOptions
+import cash.z.ecc.android.sdk.NoteSplitProposal
+import cash.z.ecc.android.sdk.OrchardMigrationSdk
+import cash.z.ecc.android.sdk.TransferProposal
+import cash.z.ecc.android.sdk.TransferResult
+import cash.z.ecc.android.sdk.internal.db.DatabaseCoordinator
+import cash.z.ecc.android.sdk.internal.jni.RustBackend
+import cash.z.ecc.android.sdk.internal.model.TorClient
+import cash.z.ecc.android.sdk.internal.model.migration.JniAttentionReason
+import cash.z.ecc.android.sdk.internal.model.migration.JniKeystoneBatchDecodeResult
+import cash.z.ecc.android.sdk.internal.model.migration.JniKeystoneBatchSignedPczts
+import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationProgress
+import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationSchedule
+import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationState
+import cash.z.ecc.android.sdk.internal.model.migration.JniTransferProposal
+import cash.z.ecc.android.sdk.internal.storage.preference.EncryptedPreferenceProvider
+import cash.z.ecc.android.sdk.internal.storage.preference.api.PreferenceProvider
+import cash.z.ecc.android.sdk.internal.storage.preference.keys.EncryptedPreferenceKeys
+import cash.z.ecc.android.sdk.internal.transaction.submitTransaction
+import cash.z.ecc.android.sdk.model.AccountUuid
+import cash.z.ecc.android.sdk.model.FirstClassByteArray
+import cash.z.ecc.android.sdk.model.SdkFlags
+import cash.z.ecc.android.sdk.model.TransactionSubmitResult
+import cash.z.ecc.android.sdk.model.UnifiedSpendingKey
+import cash.z.ecc.android.sdk.model.ZcashNetwork
+import cash.z.ecc.android.sdk.util.WalletClientFactory
+import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import java.io.File
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Real, Rust-backed implementation of [OrchardMigrationSdk].
+ *
+ * Deliberately independent of [cash.z.ecc.android.sdk.Synchronizer]: `WalletCoordinatorFactory`
+ * needs [isSyncBlocked] *before* any `Synchronizer` exists (it gates whether `WalletCoordinator`
+ * creates one at all) — a `Synchronizer`-scoped factory would be circular. Every method here
+ * instead resolves the wallet's db path (via [DatabaseCoordinator], the same helper
+ * `getWalletDbPathForVoting()` uses) lazily, per call, independent of any `Synchronizer`.
+ *
+ * The interface itself has no account parameter on any method, so it already assumes one bound
+ * account per instance — [account] is that bound account, resolved by the caller from whichever
+ * wallet account the migration flow is actually running against (Zodl/Keystone or Zashi, whichever
+ * is currently selected — never auto-picked here). It's nullable only for the one call site that
+ * genuinely has no account selection to make yet: `WalletCoordinatorFactory`'s [isSyncBlocked]
+ * gate, evaluated before any account is chosen, which checks *every* account in the wallet rather
+ * than assuming one. Every other operation requires a non-null [account]: on-launch/background
+ * calls degrade to their "nothing to do" answer (`NotStarted`, `null`, `false`) if it's somehow
+ * missing rather than throwing; calls that only make sense once a wallet exists (`prepareNoteSplit`,
+ * `submitNoteSplit`, the propose/sign/restart family) throw instead.
+ */
+internal class OrchardMigrationSdkImpl(
+    private val context: Context,
+    private val network: ZcashNetwork,
+    private val alias: String,
+    private val account: AccountUuid?,
+    private val migrationBackend: TypesafeMigrationBackend,
+    private val defaultSubmitEndpoint: LightWalletEndpoint,
+    private val preferenceProviderHolder: EncryptedPreferenceProvider,
+) : OrchardMigrationSdk {
+
+    /**
+     * [NetworkPrivacyOptions.useTor] is a per-migration setting, independent of the app's global
+     * Tor toggle (`IsTorEnabledStorageProvider`) — this uses its own [TorClient], in its own
+     * on-disk directory ([migrationTorDir]), rather than sharing the main `Synchronizer`'s. Built
+     * lazily (a Tor runtime is nontrivial to spin up) and only if a broadcast actually asks for it.
+     */
+    private val torClientLazy =
+        SuspendingLazy<Unit, TorClient?> {
+            try {
+                val coordinator = DatabaseCoordinator.getInstance(context)
+                val saplingParamTool = SaplingParamTool.new(context)
+                val backend =
+                    RustBackend.new(
+                        coordinator.fsBlockDbRoot(network, alias),
+                        coordinator.dataDbFile(network, alias),
+                        saplingOutputFile = saplingParamTool.outputParamsFile,
+                        saplingSpendFile = saplingParamTool.spendParamsFile,
+                        zcashNetworkId = network.id,
+                    )
+                TorClient.new(migrationTorDir(context), backend)
+            } catch (e: Exception) {
+                Twig.error(e) { "OrchardMigrationSdk: error instantiating migration Tor client" }
+                null
+            }
+        }
+
+    private suspend fun dbDataPath(): String =
+        withContext(Dispatchers.IO) {
+            DatabaseCoordinator.getInstance(context).dataDbFile(network, alias).absolutePath
+        }
+
+    private fun noAccountAvailable(): Nothing =
+        error("OrchardMigrationSdk: no wallet account available yet")
+
+    /**
+     * Logs entry/success/failure around every call into [migrationBackend] (the JNI boundary into
+     * `zcash_pool_migration`), so a failure deep in the Rust layer is attributable to a specific
+     * SDK operation in logcat instead of surfacing only as an opaque, unlabeled exception higher
+     * up the call stack (e.g. inside a ViewModel's generic error handling).
+     *
+     * Serializes against [MIGRATION_DB_ACCESS_MUTEX] — shared across every [OrchardMigrationSdkImpl]
+     * instance via the companion object, since a fresh instance is constructed per call site (see
+     * the class doc) — so this crate's own [isSyncBlocked] background poll (a separate instance,
+     * ticking every [SYNC_BLOCK_TICK] regardless of whether any migration screen is open) can never
+     * run concurrently with a real migration operation and read/write the shared wallet database at
+     * the same moment. This does not coordinate with
+     * [cash.z.ecc.android.sdk.block.processor.CompactBlockProcessor]'s own sync cycles (no public
+     * hook exists for that — see [logged]'s retry note below) but removes one whole source of
+     * self-inflicted contention entirely.
+     *
+     * Also retries a bounded number of times on an `InsufficientFunds`-shaped failure: this
+     * crate opens its own SQLite connection to the same wallet database
+     * [cash.z.ecc.android.sdk.block.processor.CompactBlockProcessor] periodically writes to, with
+     * no coordination between the two. A sync cycle's write window overlapping a migration read
+     * has been observed in practice to transiently make the spendable balance/notes read back as
+     * empty, resolving itself within a second or two once that cycle finishes — retrying rides out
+     * that window instead of surfacing a spurious failure. A genuine insufficient balance fails the
+     * same way on every attempt and is still reported once retries are exhausted.
+     */
+    private suspend fun <T> logged(operation: String, block: suspend () -> T): T =
+        MIGRATION_DB_ACCESS_MUTEX.withLock { loggedRetryLoop(operation, block) }
+
+    private suspend fun <T> loggedRetryLoop(operation: String, block: suspend () -> T): T {
+        Twig.debug { "MIGRATION_DIAG OrchardMigrationSdk: $operation starting" }
+        var attempt = 1
+        while (true) {
+            try {
+                val result = block()
+                Twig.debug { "MIGRATION_DIAG OrchardMigrationSdk: $operation succeeded" }
+                return result
+            } catch (e: Throwable) {
+                val looksLikeSyncRace = e.message?.contains("InsufficientFunds") == true
+                if (looksLikeSyncRace && attempt <= RACE_RETRY_MAX_ATTEMPTS) {
+                    Twig.error(e) {
+                        "MIGRATION_DIAG OrchardMigrationSdk: $operation failed (attempt $attempt/" +
+                            "$RACE_RETRY_MAX_ATTEMPTS, looks like a sync race) — retrying in $RACE_RETRY_DELAY"
+                    }
+                    delay(RACE_RETRY_DELAY)
+                    attempt++
+                    continue
+                }
+                Twig.error(e) { "MIGRATION_DIAG OrchardMigrationSdk: $operation failed" }
+                throw e
+            }
+        }
+    }
+
+    // ── State ────────────────────────────────────────────────────────────────
+
+    override suspend fun getMigrationState(): MigrationState = logged("getMigrationState") {
+        val dbDataPath = dbDataPath()
+        val account = account ?: return@logged MigrationState.NotStarted
+        migrationBackend.migrationState(dbDataPath, network, account).toPublic()
+    }
+
+    override suspend fun getMigrationProgress(): MigrationProgress? = logged("getMigrationProgress") {
+        val dbDataPath = dbDataPath()
+        val account = account ?: return@logged null
+        migrationBackend.migrationProgress(dbDataPath, network, account)?.toPublic()
+    }
+
+    override suspend fun estimateMigrationRunCount(): Int? = logged("estimateMigrationRunCount") {
+        val dbDataPath = dbDataPath()
+        val account = account ?: return@logged null
+        migrationBackend.estimateMigrationRunCount(dbDataPath, network, account)
+    }
+
+    // ── Note splitting ───────────────────────────────────────────────────────
+
+    override suspend fun isNoteSplitNeeded(): Boolean = logged("isNoteSplitNeeded") {
+        val dbDataPath = dbDataPath()
+        val account = account ?: return@logged false
+        migrationBackend.isNoteSplitNeeded(dbDataPath, network, account)
+    }
+
+    override suspend fun prepareNoteSplit(): NoteSplitProposal = logged("prepareNoteSplit") {
+        val dbDataPath = dbDataPath()
+        val account = account ?: noAccountAvailable()
+        val proposal = migrationBackend.prepareNoteSplit(dbDataPath, network, account)
+        NoteSplitProposal(
+            outputNotes = proposal.outputValuesZatoshi.toList(),
+            fee = proposal.feeZatoshi,
+        )
+    }
+
+    override suspend fun submitNoteSplit(proposal: NoteSplitProposal, usk: UnifiedSpendingKey): TransferResult =
+        logged("submitNoteSplit") {
+            val dbDataPath = dbDataPath()
+            val account = account ?: noAccountAvailable()
+            val prepared = migrationBackend.signNoteSplit(
+                dbDataPath,
+                network,
+                account,
+                proposal.outputNotes.toLongArray(),
+                proposal.fee,
+                usk.copyBytes(),
+            )
+            val rawTx = migrationBackend.extractBroadcastTx(dbDataPath, network, account, prepared.pcztBytes)
+            val submitResult = broadcast(rawTx, prepared.txid, useTor = false, endpoint = defaultSubmitEndpoint)
+            val mapped = mapSubmitResult(submitResult)
+            migrationBackend.recordTransferResult(
+                dbDataPath,
+                network,
+                account,
+                prepared.id,
+                mapped.tag,
+                mapped.retryable,
+                mapped.txIdBytes,
+            )
+            mapped.transferResult
+        }
+
+    // ── External signer (Keystone hardware wallet) ──────────────────────────
+
+    override suspend fun createUnsignedNoteSplitPczt(): ByteArray = logged("createUnsignedNoteSplitPczt") {
+        val dbDataPath = dbDataPath()
+        val account = account ?: noAccountAvailable()
+        migrationBackend.createUnsignedNoteSplitPczt(dbDataPath, network, account)
+    }
+
+    override suspend fun storeSignedNoteSplitPczt(
+        signedPczt: ByteArray,
+        options: NetworkPrivacyOptions
+    ): TransferResult = logged("storeSignedNoteSplitPczt") {
+        val dbDataPath = dbDataPath()
+        val account = account ?: noAccountAvailable()
+        val prepared = migrationBackend.storeSignedNoteSplitPczt(dbDataPath, network, account, signedPczt)
+        val rawTx = migrationBackend.extractBroadcastTx(dbDataPath, network, account, prepared.pcztBytes)
+        val endpoint = options.submissionEndpoint?.let(::parseSubmissionEndpoint) ?: defaultSubmitEndpoint
+        val submitResult = broadcast(rawTx, prepared.txid, useTor = options.useTor, endpoint = endpoint)
+        val mapped = mapSubmitResult(submitResult)
+        migrationBackend.recordTransferResult(
+            dbDataPath,
+            network,
+            account,
+            prepared.id,
+            mapped.tag,
+            mapped.retryable,
+            mapped.txIdBytes,
+        )
+        mapped.transferResult
+    }
+
+    override suspend fun createUnsignedTransferPczts(schedule: MigrationSchedule): List<Pair<String, ByteArray>> =
+        logged("createUnsignedTransferPczts") {
+            val dbDataPath = dbDataPath()
+            val account = account ?: noAccountAvailable()
+            migrationBackend.createUnsignedTransferPczts(dbDataPath, network, account, schedule.toJni())
+                .map { it.id to it.pcztBytes }
+        }
+
+    override suspend fun storeSignedSchedulePczts(signed: List<Pair<String, ByteArray>>) =
+        logged("storeSignedSchedulePczts") {
+            val dbDataPath = dbDataPath()
+            val account = account ?: noAccountAvailable()
+            migrationBackend.storeSignedSchedulePczts(
+                dbDataPath,
+                network,
+                account,
+                Array(signed.size) { signed[it].first },
+                Array(signed.size) { signed[it].second },
+            )
+        }
+
+    override suspend fun buildKeystoneSignBatchQrParts(
+        requestId: ByteArray,
+        splitUnsignedPczt: ByteArray?,
+        transferUnsignedPczts: List<ByteArray>,
+        maxFragmentLen: Int
+    ): List<String> = logged("buildKeystoneSignBatchQrParts") {
+        migrationBackend.buildKeystoneSignBatchQrParts(
+            requestId,
+            splitUnsignedPczt,
+            transferUnsignedPczts.toTypedArray(),
+            maxFragmentLen,
+        ).toList()
+    }
+
+    override suspend fun resetKeystoneSignBatchDecoder() = logged("resetKeystoneSignBatchDecoder") {
+        migrationBackend.resetKeystoneSignBatchDecoder()
+    }
+
+    override suspend fun decodeKeystoneSignBatchPart(
+        part: String,
+        expectedRequestId: ByteArray
+    ): KeystoneBatchDecodeResult = logged("decodeKeystoneSignBatchPart") {
+        migrationBackend.decodeKeystoneSignBatchPart(part, expectedRequestId).toPublic()
+    }
+
+    override suspend fun applyKeystoneBatchSignatures(
+        splitUnsignedPczt: ByteArray?,
+        transferUnsignedPczts: List<ByteArray>,
+        batchSignResponse: ByteArray
+    ): KeystoneBatchSignedPczts = logged("applyKeystoneBatchSignatures") {
+        migrationBackend.applyKeystoneBatchSignatures(
+            splitUnsignedPczt,
+            transferUnsignedPczts.toTypedArray(),
+            batchSignResponse,
+        ).toPublic()
+    }
+
+    // ── Migration proposal ───────────────────────────────────────────────────
+
+    override suspend fun proposeMigrationTransfers(includeResidual: Boolean): MigrationSchedule =
+        logged("proposeMigrationTransfers") {
+            val dbDataPath = dbDataPath()
+            val account = account ?: noAccountAvailable()
+            migrationBackend.proposeMigrationTransfers(dbDataPath, network, account, includeResidual).toPublic()
+        }
+
+    override suspend fun proposeMigrationTransfersFromSplit(splitProposal: NoteSplitProposal): MigrationSchedule =
+        logged("proposeMigrationTransfersFromSplit") {
+            val dbDataPath = dbDataPath()
+            val account = account ?: noAccountAvailable()
+            migrationBackend.proposeMigrationTransfersFromSplit(
+                dbDataPath,
+                network,
+                account,
+                splitProposal.outputNotes.toLongArray(),
+                splitProposal.fee,
+            ).toPublic()
+        }
+
+    override suspend fun proposeImmediateMigration(): MigrationSchedule = logged("proposeImmediateMigration") {
+        val dbDataPath = dbDataPath()
+        val account = account ?: noAccountAvailable()
+        migrationBackend.proposeImmediateMigrationTransfers(dbDataPath, network, account).toPublic()
+    }
+
+    override suspend fun signAndStoreMigrationSchedule(schedule: MigrationSchedule, usk: UnifiedSpendingKey) =
+        logged("signAndStoreMigrationSchedule") {
+            val dbDataPath = dbDataPath()
+            val account = account ?: noAccountAvailable()
+            migrationBackend.signAndStoreMigrationSchedule(
+                dbDataPath,
+                network,
+                account,
+                schedule.toJni(),
+                usk.copyBytes(),
+            )
+        }
+
+    // ── Background execution ─────────────────────────────────────────────────
+
+    override suspend fun isSyncRequiredBeforeNextTransfer(): Boolean = logged("isSyncRequiredBeforeNextTransfer") {
+        val dbDataPath = dbDataPath()
+        val account = account ?: return@logged false
+        migrationBackend.isSyncRequiredBeforeNextTransfer(dbDataPath, network, account)
+    }
+
+    override suspend fun finalizeReadyTransfers(): Int = logged("finalizeReadyTransfers") {
+        val dbDataPath = dbDataPath()
+        val account = account ?: return@logged 0
+        migrationBackend.finalizeReadyTransfers(dbDataPath, network, account)
+    }
+
+    override suspend fun executeNextPendingTransfer(options: NetworkPrivacyOptions): TransferResult? =
+        logged("executeNextPendingTransfer") {
+            val dbDataPath = dbDataPath()
+            val account = account ?: return@logged null
+            // Checked before broadcasting: this is the "was this call itself an out-of-band 'send
+            // now' resume" signal for the post-broadcast privacy buffer below. next_due_transfer()'s
+            // PreparedTransfer carries no schedule window of its own to check per-transfer, so this
+            // uses the aggregate hasOverdueTransfers() signal as the best available proxy.
+            val wasOverdue = migrationBackend.hasOverdueTransfers(dbDataPath, network, account)
+            val prepared = migrationBackend.nextDueTransfer(dbDataPath, network, account) ?: return@logged null
+            val rawTx = migrationBackend.extractBroadcastTx(dbDataPath, network, account, prepared.pcztBytes)
+            val endpoint = options.submissionEndpoint?.let(::parseSubmissionEndpoint) ?: defaultSubmitEndpoint
+            val submitResult = broadcast(rawTx, prepared.txid, useTor = options.useTor, endpoint = endpoint)
+            val mapped = mapSubmitResult(submitResult)
+            migrationBackend.recordTransferResult(
+                dbDataPath,
+                network,
+                account,
+                prepared.id,
+                mapped.tag,
+                mapped.retryable,
+                mapped.txIdBytes,
+            )
+            if (wasOverdue && mapped.transferResult is TransferResult.Success) {
+                preferenceProviderHolder().putString(
+                    EncryptedPreferenceKeys.MIGRATION_SYNC_RESUME_AT.key,
+                    (Clock.System.now().epochSeconds + privacySyncBufferDuration().inWholeSeconds).toString(),
+                )
+            }
+            mapped.transferResult
+        }
+
+    // ── Sync coordination ────────────────────────────────────────────────────
+
+    override fun isSyncBlocked(): Flow<Boolean> =
+        flow {
+            val preferenceProvider = preferenceProviderHolder()
+            emitAll(
+                combine(
+                    tickerFlow(SYNC_BLOCK_TICK),
+                    preferenceProvider.observe(EncryptedPreferenceKeys.MIGRATION_SYNC_RESUME_AT.key),
+                ) { _, _ -> }
+                    .map { isSyncBlockedNow(preferenceProvider) }
+                    .distinctUntilChanged()
+            )
+        }
+
+    override fun privacySyncBufferDuration(): Duration = PRIVACY_SYNC_BUFFER
+
+    // ── On-launch reconciliation ─────────────────────────────────────────────
+
+    override suspend fun hasOverdueTransfers(): Boolean = logged("hasOverdueTransfers") {
+        val dbDataPath = dbDataPath()
+        val account = account ?: return@logged false
+        migrationBackend.hasOverdueTransfers(dbDataPath, network, account)
+    }
+
+    override suspend fun rescheduleOverdueTransfer(): TransferProposal = logged("rescheduleOverdueTransfer") {
+        // No Rust call backs the reschedule decision itself (see the interface doc) — but the
+        // pending transfer's own fields (amount/anchorHeight/expiryHeight) come from
+        // pendingTransferProposal(), a dedicated MigrationContext accessor added specifically for
+        // this: next_due_transfer() only returns an opaque, already-signed PreparedTransfer
+        // (id/txid/pcztBytes), not the proposal it was signed from.
+        val dbDataPath = dbDataPath()
+        val account = account ?: noAccountAvailable()
+        val pending = migrationBackend.pendingTransferProposal(dbDataPath, network, account)?.toPublic()
+            ?: error("OrchardMigrationSdk: no pending transfer to reschedule")
+        val nowSeconds = Clock.System.now().epochSeconds
+        // Target the same natural cadence the engine schedules by default; if that would land at
+        // or past the transfer's own expiry, target just short of it instead — pushing past
+        // expiry isn't a valid reschedule (hasInvalidTransfers/restartCurrentMigrationStep is the
+        // recovery path once even that isn't possible).
+        val newNextExecutableAfterHeight =
+            minOf(nowSeconds + RESCHEDULE_INTERVAL_SECONDS, pending.expiryHeight - 1)
+        pending.copy(nextExecutableAfterHeight = newNextExecutableAfterHeight)
+    }
+
+    override suspend fun hasInvalidTransfers(): Boolean = logged("hasInvalidTransfers") {
+        val dbDataPath = dbDataPath()
+        val account = account ?: return@logged false
+        migrationBackend.hasInvalidTransfers(dbDataPath, network, account)
+    }
+
+    // ── Invalidity recovery ──────────────────────────────────────────────────
+
+    override suspend fun restartCurrentMigrationStep(includeResidual: Boolean): MigrationSchedule =
+        logged("restartCurrentMigrationStep") {
+            val dbDataPath = dbDataPath()
+            val account = account ?: noAccountAvailable()
+            migrationBackend.restartCurrentMigrationStep(dbDataPath, network, account, includeResidual).toPublic()
+        }
+
+    // ── Dust locking ─────────────────────────────────────────────────────────
+
+    override suspend fun lockRemainingOrchardBalance() = logged("lockRemainingOrchardBalance") {
+        val dbDataPath = dbDataPath()
+        val account = account ?: noAccountAvailable()
+        migrationBackend.lockRemainingOrchardBalance(dbDataPath, network, account)
+        Unit
+    }
+
+    private suspend fun isSyncBlockedNow(preferenceProvider: PreferenceProvider): Boolean {
+        val dbDataPath = dbDataPath()
+        // Same mutex as logged() — this poll must never read the wallet DB at the same moment a
+        // real migration operation (propose/sign/execute) does; see logged()'s doc comment.
+        val overdue = MIGRATION_DB_ACCESS_MUTEX.withLock {
+            // No account was bound at construction (the WalletCoordinatorFactory gate case,
+            // evaluated before any account is chosen) — check every account in the wallet rather
+            // than assuming one, so sync stays blocked if *any* of them has an overdue migration
+            // transfer.
+            if (account != null) {
+                migrationBackend.hasOverdueTransfers(dbDataPath, network, account)
+            } else {
+                migrationBackend.getAccountUuids(dbDataPath, network)
+                    .any { migrationBackend.hasOverdueTransfers(dbDataPath, network, it) }
+            }
+        }
+        val resumeAtEpochSeconds =
+            preferenceProvider.getString(EncryptedPreferenceKeys.MIGRATION_SYNC_RESUME_AT.key)?.toLongOrNull()
+        val bufferActive = resumeAtEpochSeconds != null && resumeAtEpochSeconds > Clock.System.now().epochSeconds
+        return overdue || bufferActive
+    }
+
+    // Time passing alone can flip "overdue"/"buffer elapsed" even with no data change, so
+    // isSyncBlocked() needs to re-evaluate periodically, not just when the resume-at timestamp
+    // itself changes.
+    private fun tickerFlow(interval: Duration): Flow<Unit> = flow {
+        while (currentCoroutineContext().isActive) {
+            emit(Unit)
+            delay(interval)
+        }
+    }
+
+    /**
+     * Submits raw consensus transaction bytes directly via [WalletClientFactory], deliberately
+     * bypassing `Broadcaster`/`SdkBroadcaster`: those assume a [cash.z.ecc.android.sdk.model.CreatedTransaction]
+     * that gets stored into the wallet's own transaction repository, which migration transfers
+     * have no equivalent of (the engine tracks its own state via `record_transfer_result`/
+     * `next_due_transfer`) — routing through them would silently register an untracked entry in
+     * `PendingSubmitPlanStore` that the ordinary resubmit loop could never find.
+     */
+    private suspend fun broadcast(
+        rawTx: ByteArray,
+        txId: ByteArray,
+        useTor: Boolean,
+        endpoint: LightWalletEndpoint,
+    ): TransactionSubmitResult {
+        val torClient = if (useTor) torClientLazy.getInstance(Unit) else null
+        val client = WalletClientFactory(context, torClient).create(endpoint)
+        return try {
+            client.submitTransaction(
+                FirstClassByteArray(rawTx),
+                FirstClassByteArray(txId),
+                SdkFlags(isTorEnabled = useTor && torClient != null, isExchangeRateEnabled = false),
+            )
+        } finally {
+            withContext(NonCancellable) { client.dispose() }
+        }
+    }
+
+    private suspend fun migrationTorDir(context: Context): File =
+        File(Files.getZcashNoBackupSubdirectory(context), MIGRATION_TOR_SUBDIR)
+
+    private companion object {
+        // Shared across every OrchardMigrationSdkImpl instance (a fresh one is constructed per
+        // call site — see the class doc), so the isSyncBlocked() background poll and any real
+        // migration operation never touch the wallet database at the same moment. See logged()'s
+        // doc comment for the full rationale.
+        val MIGRATION_DB_ACCESS_MUTEX = Mutex()
+
+        val SYNC_BLOCK_TICK = 15.seconds
+
+        // How many extra attempts logged() makes for an InsufficientFunds-shaped failure before
+        // giving up and reporting it — observed sync-cycle write windows are a few seconds, so two
+        // retries at RACE_RETRY_DELAY apart comfortably rides out one.
+        const val RACE_RETRY_MAX_ATTEMPTS = 2
+        val RACE_RETRY_DELAY = 2.seconds
+
+        // Post-broadcast privacy buffer for the "send now" resume path — a real, fixed value
+        // (unlike the app-side mock's debug-shrunk one): this decouples broadcast timing from
+        // sync-resume timing for privacy, so it should not vary by build type in production code.
+        val PRIVACY_SYNC_BUFFER = 10.minutes
+
+        // Matches the engine's own default target cadence between scheduled transfers (~6h) —
+        // rescheduling to roughly one more natural interval out, same as the cadence a fresh
+        // schedule would already have used.
+        const val RESCHEDULE_INTERVAL_SECONDS = 6 * 60 * 60L
+
+        // Separate from Files.TOR_SUBDIR (the main Synchronizer's shared Tor directory) — a
+        // distinct on-disk Tor client/circuit state for migration broadcasts, per NetworkPrivacyOptions.useTor
+        // being an independent, per-migration setting rather than the app's global Tor toggle.
+        const val MIGRATION_TOR_SUBDIR = "tor_migration"
+    }
+}
+
+/**
+ * No caller sets [NetworkPrivacyOptions.submissionEndpoint] today (the secondary-server UI this
+ * would back doesn't exist yet), so there's no established wire format for it — this assumes the
+ * conventional `host:port` shape and standard TLS, the same as every current lightwalletd
+ * endpoint in this app.
+ */
+private fun parseSubmissionEndpoint(endpoint: String): LightWalletEndpoint {
+    val (host, port) = endpoint.substringBeforeLast(':') to endpoint.substringAfterLast(':').toInt()
+    return LightWalletEndpoint(host, port, isSecure = true)
+}
+
+private class MappedTransferResult(
+    val transferResult: TransferResult,
+    val tag: Int,
+    val retryable: Boolean,
+    val txIdBytes: ByteArray,
+)
+
+/**
+ * Maps a raw submission outcome to the engine's [TransferResult], both as the public value and
+ * as the scalar params `record_transfer_result` needs. Used by both [OrchardMigrationSdkImpl.submitNoteSplit]
+ * and [OrchardMigrationSdkImpl.executeNextPendingTransfer].
+ *
+ * No expiry-height signal is threaded through here — `next_due_transfer()` returns a
+ * `PreparedTransfer`, which (unlike `TransferProposal`) carries no `expiryHeight`, so a
+ * non-network rejection can't yet be told apart from an expired anchor and is treated as
+ * [TransferResult.InvalidNote] (the Rust `MigrationError`/lightwalletd rejection reasons don't
+ * distinguish these either). Disambiguating needs either extending `PreparedTransfer` or a
+ * separate chain-tip lookup — flagged as a follow-up, not a blocker.
+ */
+private fun mapSubmitResult(result: TransactionSubmitResult): MappedTransferResult =
+    when (result) {
+        is TransactionSubmitResult.Success ->
+            MappedTransferResult(
+                transferResult = TransferResult.Success(result.txIdString()),
+                tag = 0,
+                retryable = false,
+                txIdBytes = result.txId.byteArray,
+            )
+        is TransactionSubmitResult.Failure ->
+            if (result.grpcError) {
+                MappedTransferResult(TransferResult.NetworkError(retryable = true), tag = 1, retryable = true, txIdBytes = ByteArray(0))
+            } else {
+                MappedTransferResult(TransferResult.InvalidNote, tag = 2, retryable = false, txIdBytes = ByteArray(0))
+            }
+        is TransactionSubmitResult.NotAttempted ->
+            MappedTransferResult(TransferResult.NetworkError(retryable = true), tag = 1, retryable = true, txIdBytes = ByteArray(0))
+    }
+
+private fun JniMigrationProgress.toPublic(): MigrationProgress =
+    MigrationProgress(
+        completedTransfers = completedTransfers,
+        totalTransfers = totalTransfers,
+        remainingOrchardZatoshi = remainingOrchardValueZatoshi,
+        nextTransferReadyAtHeight = nextTransferReadyAtHeight.takeIf { it != -1L },
+    )
+
+private fun JniAttentionReason.toPublic(): AttentionReason =
+    when (this) {
+        is JniAttentionReason.InvalidTransfer -> AttentionReason.InvalidTransfer(transferId)
+        is JniAttentionReason.TransferExpired -> AttentionReason.TransferExpired
+        is JniAttentionReason.SyncRequiredBeforeNext -> AttentionReason.SyncRequiredBeforeNext
+    }
+
+private fun JniTransferProposal.toPublic(): TransferProposal =
+    TransferProposal(
+        id = id,
+        amountZatoshi = amountZatoshi,
+        anchorHeight = anchorHeight,
+        nextExecutableAfterHeight = nextExecutableAfterHeight,
+        expiryHeight = expiryHeight,
+    )
+
+private fun JniMigrationSchedule.toPublic(): MigrationSchedule =
+    MigrationSchedule(
+        transfers = transfers.map { it.toPublic() },
+        estimatedDurationHours = estimatedDurationHours,
+    )
+
+private fun TransferProposal.toJni(): JniTransferProposal =
+    JniTransferProposal(
+        id = id,
+        amountZatoshi = amountZatoshi,
+        anchorHeight = anchorHeight,
+        nextExecutableAfterHeight = nextExecutableAfterHeight,
+        expiryHeight = expiryHeight,
+    )
+
+private fun MigrationSchedule.toJni(): JniMigrationSchedule =
+    JniMigrationSchedule(
+        transfers = transfers.map { it.toJni() }.toTypedArray(),
+        estimatedDurationHours = estimatedDurationHours,
+    )
+
+private fun JniKeystoneBatchDecodeResult.toPublic(): KeystoneBatchDecodeResult =
+    KeystoneBatchDecodeResult(
+        complete = complete,
+        progress = progress,
+        data = data,
+        firmwareVersion = firmwareVersion,
+    )
+
+private fun JniKeystoneBatchSignedPczts.toPublic(): KeystoneBatchSignedPczts =
+    KeystoneBatchSignedPczts(
+        splitSignedPczt = splitSignedPczt,
+        transferSignedPczts = transferSignedPczts.toList(),
+    )
+
+private fun JniMigrationState.toPublic(): MigrationState =
+    when (this) {
+        is JniMigrationState.NotStarted -> MigrationState.NotStarted
+        is JniMigrationState.SplitPendingConfirmation -> MigrationState.SplitPendingConfirmation
+        is JniMigrationState.ReadyToPropose -> MigrationState.ReadyToPropose
+        is JniMigrationState.InProgress -> MigrationState.InProgress(progress.toPublic())
+        is JniMigrationState.RequiresAttention -> MigrationState.RequiresAttention(reason.toPublic())
+        is JniMigrationState.Complete -> MigrationState.Complete
+    }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
@@ -211,6 +211,7 @@ internal class OrchardMigrationSdkImpl(
         NoteSplitProposal(
             outputNotes = proposal.outputValuesZatoshi.toList(),
             fee = proposal.feeZatoshi,
+            proposalHandle = proposal.proposalHandle,
         )
     }
 
@@ -222,8 +223,7 @@ internal class OrchardMigrationSdkImpl(
                 dbDataPath,
                 network,
                 account,
-                proposal.outputNotes.toLongArray(),
-                proposal.fee,
+                proposal.proposalHandle,
                 usk.copyBytes(),
             )
             val rawTx = migrationBackend.extractBroadcastTx(dbDataPath, network, account, prepared.pcztBytes)
@@ -243,11 +243,12 @@ internal class OrchardMigrationSdkImpl(
 
     // ── External signer (Keystone hardware wallet) ──────────────────────────
 
-    override suspend fun createUnsignedNoteSplitPczt(): ByteArray = logged("createUnsignedNoteSplitPczt") {
-        val dbDataPath = dbDataPath()
-        val account = account ?: noAccountAvailable()
-        migrationBackend.createUnsignedNoteSplitPczt(dbDataPath, network, account)
-    }
+    override suspend fun createUnsignedNoteSplitPczt(proposal: NoteSplitProposal): ByteArray =
+        logged("createUnsignedNoteSplitPczt") {
+            val dbDataPath = dbDataPath()
+            val account = account ?: noAccountAvailable()
+            migrationBackend.createUnsignedNoteSplitPczt(dbDataPath, network, account, proposal.proposalHandle)
+        }
 
     override suspend fun storeSignedNoteSplitPczt(
         signedPczt: ByteArray,
@@ -276,7 +277,7 @@ internal class OrchardMigrationSdkImpl(
         logged("createUnsignedTransferPczts") {
             val dbDataPath = dbDataPath()
             val account = account ?: noAccountAvailable()
-            migrationBackend.createUnsignedTransferPczts(dbDataPath, network, account, schedule.toJni())
+            migrationBackend.createUnsignedTransferPczts(dbDataPath, network, account, schedule.proposalHandle)
                 .map { it.id to it.pcztBytes }
         }
 
@@ -347,8 +348,7 @@ internal class OrchardMigrationSdkImpl(
                 dbDataPath,
                 network,
                 account,
-                splitProposal.outputNotes.toLongArray(),
-                splitProposal.fee,
+                splitProposal.proposalHandle,
             ).toPublic()
         }
 
@@ -366,7 +366,7 @@ internal class OrchardMigrationSdkImpl(
                 dbDataPath,
                 network,
                 account,
-                schedule.toJni(),
+                schedule.proposalHandle,
                 usk.copyBytes(),
             )
         }
@@ -673,6 +673,7 @@ private fun JniMigrationSchedule.toPublic(): MigrationSchedule =
     MigrationSchedule(
         transfers = transfers.map { it.toPublic() },
         estimatedDurationHours = estimatedDurationHours,
+        proposalHandle = proposalHandle,
     )
 
 private fun JniMigrationTransferState.toPublic(): MigrationTransferState =
@@ -686,21 +687,6 @@ private fun JniMigrationTransferStates.toPublic(): MigrationTransferStates =
     MigrationTransferStates(
         transfers = transfers.map { it.toPublic() },
         tipHeight = tipHeight,
-    )
-
-private fun TransferProposal.toJni(): JniTransferProposal =
-    JniTransferProposal(
-        id = id,
-        amountZatoshi = amountZatoshi,
-        anchorHeight = anchorHeight,
-        nextExecutableAfterHeight = nextExecutableAfterHeight,
-        expiryHeight = expiryHeight,
-    )
-
-private fun MigrationSchedule.toJni(): JniMigrationSchedule =
-    JniMigrationSchedule(
-        transfers = transfers.map { it.toJni() }.toTypedArray(),
-        estimatedDurationHours = estimatedDurationHours,
     )
 
 private fun JniKeystoneBatchDecodeResult.toPublic(): KeystoneBatchDecodeResult =

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
@@ -480,6 +480,11 @@ internal class OrchardMigrationSdkImpl(
 
     // ── Dust locking ─────────────────────────────────────────────────────────
 
+    override suspend fun migrationDustThresholdZatoshi(): Long =
+        logged("migrationDustThresholdZatoshi") {
+            migrationBackend.migrationDustThresholdZatoshi()
+        }
+
     override suspend fun lockRemainingOrchardBalance() = logged("lockRemainingOrchardBalance") {
         val dbDataPath = dbDataPath()
         val account = account ?: noAccountAvailable()

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackend.kt
@@ -200,6 +200,8 @@ internal interface TypesafeBackend {
         saplingRoots: List<SubtreeRoot>,
         orchardStartIndex: UInt,
         orchardRoots: List<SubtreeRoot>,
+        ironwoodStartIndex: UInt,
+        ironwoodRoots: List<SubtreeRoot>,
     )
 
     /**

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImpl.kt
@@ -288,7 +288,9 @@ internal class TypesafeBackendImpl(
         saplingStartIndex: UInt,
         saplingRoots: List<SubtreeRoot>,
         orchardStartIndex: UInt,
-        orchardRoots: List<SubtreeRoot>
+        orchardRoots: List<SubtreeRoot>,
+        ironwoodStartIndex: UInt,
+        ironwoodRoots: List<SubtreeRoot>
     ) = backend.putSubtreeRoots(
         saplingStartIndex = saplingStartIndex.toLong(),
         saplingRoots =
@@ -301,6 +303,14 @@ internal class TypesafeBackendImpl(
         orchardStartIndex = orchardStartIndex.toLong(),
         orchardRoots =
             orchardRoots.map {
+                JniSubtreeRoot.new(
+                    rootHash = it.rootHash,
+                    completingBlockHeight = it.completingBlockHeight.value
+                )
+            },
+        ironwoodStartIndex = ironwoodStartIndex.toLong(),
+        ironwoodRoots =
+            ironwoodRoots.map {
                 JniSubtreeRoot.new(
                     rootHash = it.rootHash,
                     completingBlockHeight = it.completingBlockHeight.value

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackend.kt
@@ -202,6 +202,13 @@ internal interface TypesafeMigrationBackend {
         account: AccountUuid
     ): JniTransferProposal?
 
+    /**
+     * The zatoshi value below which a leftover post-migration Orchard balance is treated as dust
+     * rather than a residual worth migrating in its own transfer. A fixed protocol-level
+     * constant, not derived from any wallet/account state.
+     */
+    suspend fun migrationDustThresholdZatoshi(): Long
+
     // ----- External signer (Keystone hardware wallet) -----
 
     suspend fun createUnsignedNoteSplitPczt(

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackend.kt
@@ -134,12 +134,6 @@ internal interface TypesafeMigrationBackend {
         usk: ByteArray
     )
 
-    suspend fun isSyncRequiredBeforeNextTransfer(
-        dbDataPath: String,
-        network: ZcashNetwork,
-        account: AccountUuid
-    ): Boolean
-
     suspend fun finalizeReadyTransfers(
         dbDataPath: String,
         network: ZcashNetwork,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackend.kt
@@ -5,6 +5,7 @@ import cash.z.ecc.android.sdk.internal.model.migration.JniKeystoneBatchSignedPcz
 import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationProgress
 import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationSchedule
 import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationState
+import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationTransferStates
 import cash.z.ecc.android.sdk.internal.model.migration.JniNoteSplitProposal
 import cash.z.ecc.android.sdk.internal.model.migration.JniPreparedTransfer
 import cash.z.ecc.android.sdk.internal.model.migration.JniTransferProposal
@@ -120,11 +121,17 @@ internal interface TypesafeMigrationBackend {
         feeZatoshi: Long
     ): JniMigrationSchedule
 
-    suspend fun proposeImmediateMigrationTransfers(
+    /**
+     * Proposes an ordinary send-max transaction sweeping all spendable Orchard funds into this
+     * account's own Ironwood receiver — bypasses the migration engine entirely. Returns the raw
+     * proposal proto bytes, encoded exactly like an ordinary send's proposal, for decoding via
+     * `cash.z.ecc.android.sdk.model.Proposal.fromByteArray`.
+     */
+    suspend fun proposeImmediateSendMax(
         dbDataPath: String,
         network: ZcashNetwork,
         account: AccountUuid
-    ): JniMigrationSchedule
+    ): ByteArray
 
     suspend fun signAndStoreMigrationSchedule(
         dbDataPath: String,
@@ -152,6 +159,16 @@ internal interface TypesafeMigrationBackend {
         account: AccountUuid,
         includeResidual: Boolean
     ): JniMigrationSchedule
+
+    /**
+     * The live, persisted status of every committed transfer transaction, or `null` if there's
+     * no in-progress migration. See [JniMigrationTransferStates].
+     */
+    suspend fun migrationTransferStates(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): JniMigrationTransferStates?
 
     /**
      * Lists every account's UUID in the wallet database, independent of any live `Synchronizer`.

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackend.kt
@@ -1,0 +1,224 @@
+package cash.z.ecc.android.sdk.internal
+
+import cash.z.ecc.android.sdk.internal.model.migration.JniKeystoneBatchDecodeResult
+import cash.z.ecc.android.sdk.internal.model.migration.JniKeystoneBatchSignedPczts
+import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationProgress
+import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationSchedule
+import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationState
+import cash.z.ecc.android.sdk.internal.model.migration.JniNoteSplitProposal
+import cash.z.ecc.android.sdk.internal.model.migration.JniPreparedTransfer
+import cash.z.ecc.android.sdk.internal.model.migration.JniTransferProposal
+import cash.z.ecc.android.sdk.internal.model.migration.JniUnsignedTransferPczt
+import cash.z.ecc.android.sdk.model.AccountUuid
+import cash.z.ecc.android.sdk.model.ZcashNetwork
+
+@Suppress("TooManyFunctions")
+internal interface TypesafeMigrationBackend {
+    suspend fun migrationState(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): JniMigrationState
+
+    suspend fun migrationProgress(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): JniMigrationProgress?
+
+    suspend fun isNoteSplitNeeded(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): Boolean
+
+    suspend fun estimateMigrationRunCount(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): Int
+
+    suspend fun lockRemainingOrchardBalance(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): Int
+
+    suspend fun hasOverdueTransfers(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): Boolean
+
+    suspend fun hasInvalidTransfers(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): Boolean
+
+    suspend fun prepareNoteSplit(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): JniNoteSplitProposal
+
+    suspend fun signNoteSplit(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid,
+        outputValuesZatoshi: LongArray,
+        feeZatoshi: Long,
+        usk: ByteArray
+    ): JniPreparedTransfer
+
+    suspend fun extractBroadcastTx(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid,
+        pcztBytes: ByteArray
+    ): ByteArray
+
+    /**
+     * [resultTag]: 0 = Success (requires [txId]), 1 = NetworkError (requires [retryable]),
+     * 2 = InvalidNote, 3 = Expired. [txId] is ignored except for tag 0 — pass an empty array
+     * otherwise.
+     */
+    suspend fun recordTransferResult(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid,
+        transferId: String,
+        resultTag: Int,
+        retryable: Boolean,
+        txId: ByteArray
+    )
+
+    suspend fun proposeMigrationTransfers(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid,
+        includeResidual: Boolean
+    ): JniMigrationSchedule
+
+    suspend fun proposeMigrationTransfersFromSplit(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid,
+        outputValuesZatoshi: LongArray,
+        feeZatoshi: Long
+    ): JniMigrationSchedule
+
+    suspend fun proposeImmediateMigrationTransfers(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): JniMigrationSchedule
+
+    suspend fun signAndStoreMigrationSchedule(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid,
+        schedule: JniMigrationSchedule,
+        usk: ByteArray
+    )
+
+    suspend fun isSyncRequiredBeforeNextTransfer(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): Boolean
+
+    suspend fun finalizeReadyTransfers(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): Int
+
+    suspend fun nextDueTransfer(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): JniPreparedTransfer?
+
+    suspend fun restartCurrentMigrationStep(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid,
+        includeResidual: Boolean
+    ): JniMigrationSchedule
+
+    /**
+     * Lists every account's UUID in the wallet database, independent of any live `Synchronizer`.
+     */
+    suspend fun getAccountUuids(
+        dbDataPath: String,
+        network: ZcashNetwork
+    ): List<AccountUuid>
+
+    /**
+     * The pending (due-or-not-yet-due) scheduled transfer's full proposal fields, or `null` if
+     * nothing is scheduled yet (or only the note-split prep transaction is pending).
+     */
+    suspend fun pendingTransferProposal(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): JniTransferProposal?
+
+    // ----- External signer (Keystone hardware wallet) -----
+
+    suspend fun createUnsignedNoteSplitPczt(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): ByteArray
+
+    suspend fun storeSignedNoteSplitPczt(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid,
+        signedPczt: ByteArray
+    ): JniPreparedTransfer
+
+    suspend fun createUnsignedTransferPczts(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid,
+        schedule: JniMigrationSchedule
+    ): Array<JniUnsignedTransferPczt>
+
+    /**
+     * [ids]/[pcztBytesList] are parallel arrays — signed PCZTs matched back to their staged
+     * unsigned originals by id, not by array position (all-or-nothing across whatever set of ids
+     * is provided here).
+     */
+    suspend fun storeSignedSchedulePczts(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid,
+        ids: Array<String>,
+        pcztBytesList: Array<ByteArray>
+    )
+
+    // ----- Keystone batch-signing UR bridge (no wallet database access) -----
+
+    suspend fun buildKeystoneSignBatchQrParts(
+        requestId: ByteArray,
+        splitUnsignedPczt: ByteArray?,
+        transferUnsignedPczts: Array<ByteArray>,
+        maxFragmentLen: Int
+    ): Array<String>
+
+    suspend fun resetKeystoneSignBatchDecoder()
+
+    suspend fun decodeKeystoneSignBatchPart(
+        part: String,
+        expectedRequestId: ByteArray
+    ): JniKeystoneBatchDecodeResult
+
+    suspend fun applyKeystoneBatchSignatures(
+        splitUnsignedPczt: ByteArray?,
+        transferUnsignedPczts: Array<ByteArray>,
+        batchSignResponse: ByteArray
+    ): JniKeystoneBatchSignedPczts
+}

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackend.kt
@@ -44,6 +44,18 @@ internal interface TypesafeMigrationBackend {
         account: AccountUuid
     ): Int
 
+    suspend fun clearMigration(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): Int
+
+    suspend fun debugRescheduleTransfers(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): Int
+
     suspend fun hasOverdueTransfers(
         dbDataPath: String,
         network: ZcashNetwork,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackend.kt
@@ -75,12 +75,16 @@ internal interface TypesafeMigrationBackend {
         account: AccountUuid
     ): JniNoteSplitProposal
 
+    /**
+     * [proposalHandle] identifies the Rust-side cached plan to commit and sign — from the
+     * [JniNoteSplitProposal] the user reviewed. Throws if that plan is missing or superseded by a
+     * later propose/prepare call.
+     */
     suspend fun signNoteSplit(
         dbDataPath: String,
         network: ZcashNetwork,
         account: AccountUuid,
-        outputValuesZatoshi: LongArray,
-        feeZatoshi: Long,
+        proposalHandle: Long,
         usk: ByteArray
     ): JniPreparedTransfer
 
@@ -113,12 +117,17 @@ internal interface TypesafeMigrationBackend {
         includeResidual: Boolean
     ): JniMigrationSchedule
 
+    /**
+     * Renders the transfer schedule of the exact cached plan [proposalHandle] identifies (from
+     * the [JniNoteSplitProposal] the user was just shown) — never re-plans, so the schedule shown
+     * is guaranteed to belong to the same plan as the split. The returned schedule carries the
+     * SAME handle.
+     */
     suspend fun proposeMigrationTransfersFromSplit(
         dbDataPath: String,
         network: ZcashNetwork,
         account: AccountUuid,
-        outputValuesZatoshi: LongArray,
-        feeZatoshi: Long
+        proposalHandle: Long
     ): JniMigrationSchedule
 
     /**
@@ -133,11 +142,16 @@ internal interface TypesafeMigrationBackend {
         account: AccountUuid
     ): ByteArray
 
+    /**
+     * Commits and signs the migration plan [proposalHandle] identifies (from the
+     * [JniMigrationSchedule] the user reviewed). No schedule fields cross the boundary — the Rust
+     * side signs exactly the identified plan or throws if it was superseded.
+     */
     suspend fun signAndStoreMigrationSchedule(
         dbDataPath: String,
         network: ZcashNetwork,
         account: AccountUuid,
-        schedule: JniMigrationSchedule,
+        proposalHandle: Long,
         usk: ByteArray
     )
 
@@ -193,7 +207,8 @@ internal interface TypesafeMigrationBackend {
     suspend fun createUnsignedNoteSplitPczt(
         dbDataPath: String,
         network: ZcashNetwork,
-        account: AccountUuid
+        account: AccountUuid,
+        proposalHandle: Long
     ): ByteArray
 
     suspend fun storeSignedNoteSplitPczt(
@@ -207,7 +222,7 @@ internal interface TypesafeMigrationBackend {
         dbDataPath: String,
         network: ZcashNetwork,
         account: AccountUuid,
-        schedule: JniMigrationSchedule
+        proposalHandle: Long
     ): Array<JniUnsignedTransferPczt>
 
     /**

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackendImpl.kt
@@ -52,6 +52,18 @@ internal class TypesafeMigrationBackendImpl(
         account: AccountUuid
     ): Int = rustBackend().lockRemainingOrchardBalance(dbDataPath, network.id, account.value)
 
+    override suspend fun clearMigration(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): Int = rustBackend().clearMigration(dbDataPath, network.id, account.value)
+
+    override suspend fun debugRescheduleTransfers(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): Int = rustBackend().debugRescheduleTransfers(dbDataPath, network.id, account.value)
+
     override suspend fun hasOverdueTransfers(
         dbDataPath: String,
         network: ZcashNetwork,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackendImpl.kt
@@ -1,0 +1,237 @@
+package cash.z.ecc.android.sdk.internal
+
+import cash.z.ecc.android.sdk.internal.jni.MigrationRustBackend
+import cash.z.ecc.android.sdk.internal.model.migration.JniKeystoneBatchDecodeResult
+import cash.z.ecc.android.sdk.internal.model.migration.JniKeystoneBatchSignedPczts
+import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationProgress
+import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationSchedule
+import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationState
+import cash.z.ecc.android.sdk.internal.model.migration.JniNoteSplitProposal
+import cash.z.ecc.android.sdk.internal.model.migration.JniPreparedTransfer
+import cash.z.ecc.android.sdk.internal.model.migration.JniTransferProposal
+import cash.z.ecc.android.sdk.internal.model.migration.JniUnsignedTransferPczt
+import cash.z.ecc.android.sdk.model.AccountUuid
+import cash.z.ecc.android.sdk.model.ZcashNetwork
+
+@Suppress("TooManyFunctions")
+internal class TypesafeMigrationBackendImpl(
+    private val rustBackendFactory: suspend () -> MigrationRustBackend = { MigrationRustBackend.new() }
+) : TypesafeMigrationBackend {
+    private val rustBackendLazy =
+        SuspendingLazy<Unit, MigrationRustBackend> {
+            rustBackendFactory()
+        }
+
+    override suspend fun migrationState(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): JniMigrationState = rustBackend().migrationState(dbDataPath, network.id, account.value)
+
+    override suspend fun migrationProgress(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): JniMigrationProgress? = rustBackend().migrationProgress(dbDataPath, network.id, account.value)
+
+    override suspend fun isNoteSplitNeeded(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): Boolean = rustBackend().isNoteSplitNeeded(dbDataPath, network.id, account.value)
+
+    override suspend fun estimateMigrationRunCount(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): Int = rustBackend().estimateMigrationRunCount(dbDataPath, network.id, account.value)
+
+    override suspend fun lockRemainingOrchardBalance(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): Int = rustBackend().lockRemainingOrchardBalance(dbDataPath, network.id, account.value)
+
+    override suspend fun hasOverdueTransfers(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): Boolean = rustBackend().hasOverdueTransfers(dbDataPath, network.id, account.value)
+
+    override suspend fun hasInvalidTransfers(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): Boolean = rustBackend().hasInvalidTransfers(dbDataPath, network.id, account.value)
+
+    override suspend fun prepareNoteSplit(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): JniNoteSplitProposal = rustBackend().prepareNoteSplit(dbDataPath, network.id, account.value)
+
+    override suspend fun signNoteSplit(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid,
+        outputValuesZatoshi: LongArray,
+        feeZatoshi: Long,
+        usk: ByteArray
+    ): JniPreparedTransfer =
+        rustBackend().signNoteSplit(dbDataPath, network.id, account.value, outputValuesZatoshi, feeZatoshi, usk)
+
+    override suspend fun extractBroadcastTx(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid,
+        pcztBytes: ByteArray
+    ): ByteArray = rustBackend().extractBroadcastTx(dbDataPath, network.id, account.value, pcztBytes)
+
+    override suspend fun recordTransferResult(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid,
+        transferId: String,
+        resultTag: Int,
+        retryable: Boolean,
+        txId: ByteArray
+    ) = rustBackend().recordTransferResult(
+        dbDataPath,
+        network.id,
+        account.value,
+        transferId,
+        resultTag,
+        retryable,
+        txId
+    )
+
+    override suspend fun proposeMigrationTransfers(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid,
+        includeResidual: Boolean
+    ): JniMigrationSchedule =
+        rustBackend().proposeMigrationTransfers(dbDataPath, network.id, account.value, includeResidual)
+
+    override suspend fun proposeMigrationTransfersFromSplit(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid,
+        outputValuesZatoshi: LongArray,
+        feeZatoshi: Long
+    ): JniMigrationSchedule =
+        rustBackend().proposeMigrationTransfersFromSplit(
+            dbDataPath,
+            network.id,
+            account.value,
+            outputValuesZatoshi,
+            feeZatoshi
+        )
+
+    override suspend fun proposeImmediateMigrationTransfers(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): JniMigrationSchedule =
+        rustBackend().proposeImmediateMigrationTransfers(dbDataPath, network.id, account.value)
+
+    override suspend fun signAndStoreMigrationSchedule(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid,
+        schedule: JniMigrationSchedule,
+        usk: ByteArray
+    ) = rustBackend().signAndStoreMigrationSchedule(dbDataPath, network.id, account.value, schedule, usk)
+
+    override suspend fun isSyncRequiredBeforeNextTransfer(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): Boolean = rustBackend().isSyncRequiredBeforeNextTransfer(dbDataPath, network.id, account.value)
+
+    override suspend fun finalizeReadyTransfers(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): Int = rustBackend().finalizeReadyTransfers(dbDataPath, network.id, account.value)
+
+    override suspend fun nextDueTransfer(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): JniPreparedTransfer? = rustBackend().nextDueTransfer(dbDataPath, network.id, account.value)
+
+    override suspend fun restartCurrentMigrationStep(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid,
+        includeResidual: Boolean
+    ): JniMigrationSchedule =
+        rustBackend().restartCurrentMigrationStep(dbDataPath, network.id, account.value, includeResidual)
+
+    override suspend fun getAccountUuids(
+        dbDataPath: String,
+        network: ZcashNetwork
+    ): List<AccountUuid> =
+        rustBackend().getAccountUuids(dbDataPath, network.id).map { AccountUuid.new(it) }
+
+    override suspend fun pendingTransferProposal(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): JniTransferProposal? = rustBackend().pendingTransferProposal(dbDataPath, network.id, account.value)
+
+    override suspend fun createUnsignedNoteSplitPczt(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): ByteArray = rustBackend().createUnsignedNoteSplitPczt(dbDataPath, network.id, account.value)
+
+    override suspend fun storeSignedNoteSplitPczt(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid,
+        signedPczt: ByteArray
+    ): JniPreparedTransfer =
+        rustBackend().storeSignedNoteSplitPczt(dbDataPath, network.id, account.value, signedPczt)
+
+    override suspend fun createUnsignedTransferPczts(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid,
+        schedule: JniMigrationSchedule
+    ): Array<JniUnsignedTransferPczt> =
+        rustBackend().createUnsignedTransferPczts(dbDataPath, network.id, account.value, schedule)
+
+    override suspend fun storeSignedSchedulePczts(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid,
+        ids: Array<String>,
+        pcztBytesList: Array<ByteArray>
+    ) = rustBackend().storeSignedSchedulePczts(dbDataPath, network.id, account.value, ids, pcztBytesList)
+
+    override suspend fun buildKeystoneSignBatchQrParts(
+        requestId: ByteArray,
+        splitUnsignedPczt: ByteArray?,
+        transferUnsignedPczts: Array<ByteArray>,
+        maxFragmentLen: Int
+    ): Array<String> =
+        rustBackend().buildKeystoneSignBatchQrParts(requestId, splitUnsignedPczt, transferUnsignedPczts, maxFragmentLen)
+
+    override suspend fun resetKeystoneSignBatchDecoder() = rustBackend().resetKeystoneSignBatchDecoder()
+
+    override suspend fun decodeKeystoneSignBatchPart(
+        part: String,
+        expectedRequestId: ByteArray
+    ): JniKeystoneBatchDecodeResult = rustBackend().decodeKeystoneSignBatchPart(part, expectedRequestId)
+
+    override suspend fun applyKeystoneBatchSignatures(
+        splitUnsignedPczt: ByteArray?,
+        transferUnsignedPczts: Array<ByteArray>,
+        batchSignResponse: ByteArray
+    ): JniKeystoneBatchSignedPczts =
+        rustBackend().applyKeystoneBatchSignatures(splitUnsignedPczt, transferUnsignedPczts, batchSignResponse)
+
+    private suspend fun rustBackend() = rustBackendLazy.getInstance(Unit)
+}

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackendImpl.kt
@@ -155,12 +155,6 @@ internal class TypesafeMigrationBackendImpl(
         usk: ByteArray
     ) = rustBackend().signAndStoreMigrationSchedule(dbDataPath, network.id, account.value, schedule, usk)
 
-    override suspend fun isSyncRequiredBeforeNextTransfer(
-        dbDataPath: String,
-        network: ZcashNetwork,
-        account: AccountUuid
-    ): Boolean = rustBackend().isSyncRequiredBeforeNextTransfer(dbDataPath, network.id, account.value)
-
     override suspend fun finalizeReadyTransfers(
         dbDataPath: String,
         network: ZcashNetwork,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackendImpl.kt
@@ -87,11 +87,10 @@ internal class TypesafeMigrationBackendImpl(
         dbDataPath: String,
         network: ZcashNetwork,
         account: AccountUuid,
-        outputValuesZatoshi: LongArray,
-        feeZatoshi: Long,
+        proposalHandle: Long,
         usk: ByteArray
     ): JniPreparedTransfer =
-        rustBackend().signNoteSplit(dbDataPath, network.id, account.value, outputValuesZatoshi, feeZatoshi, usk)
+        rustBackend().signNoteSplit(dbDataPath, network.id, account.value, proposalHandle, usk)
 
     override suspend fun extractBroadcastTx(
         dbDataPath: String,
@@ -130,15 +129,13 @@ internal class TypesafeMigrationBackendImpl(
         dbDataPath: String,
         network: ZcashNetwork,
         account: AccountUuid,
-        outputValuesZatoshi: LongArray,
-        feeZatoshi: Long
+        proposalHandle: Long
     ): JniMigrationSchedule =
         rustBackend().proposeMigrationTransfersFromSplit(
             dbDataPath,
             network.id,
             account.value,
-            outputValuesZatoshi,
-            feeZatoshi
+            proposalHandle
         )
 
     override suspend fun proposeImmediateSendMax(
@@ -151,9 +148,9 @@ internal class TypesafeMigrationBackendImpl(
         dbDataPath: String,
         network: ZcashNetwork,
         account: AccountUuid,
-        schedule: JniMigrationSchedule,
+        proposalHandle: Long,
         usk: ByteArray
-    ) = rustBackend().signAndStoreMigrationSchedule(dbDataPath, network.id, account.value, schedule, usk)
+    ) = rustBackend().signAndStoreMigrationSchedule(dbDataPath, network.id, account.value, proposalHandle, usk)
 
     override suspend fun finalizeReadyTransfers(
         dbDataPath: String,
@@ -196,8 +193,9 @@ internal class TypesafeMigrationBackendImpl(
     override suspend fun createUnsignedNoteSplitPczt(
         dbDataPath: String,
         network: ZcashNetwork,
-        account: AccountUuid
-    ): ByteArray = rustBackend().createUnsignedNoteSplitPczt(dbDataPath, network.id, account.value)
+        account: AccountUuid,
+        proposalHandle: Long
+    ): ByteArray = rustBackend().createUnsignedNoteSplitPczt(dbDataPath, network.id, account.value, proposalHandle)
 
     override suspend fun storeSignedNoteSplitPczt(
         dbDataPath: String,
@@ -211,9 +209,9 @@ internal class TypesafeMigrationBackendImpl(
         dbDataPath: String,
         network: ZcashNetwork,
         account: AccountUuid,
-        schedule: JniMigrationSchedule
+        proposalHandle: Long
     ): Array<JniUnsignedTransferPczt> =
-        rustBackend().createUnsignedTransferPczts(dbDataPath, network.id, account.value, schedule)
+        rustBackend().createUnsignedTransferPczts(dbDataPath, network.id, account.value, proposalHandle)
 
     override suspend fun storeSignedSchedulePczts(
         dbDataPath: String,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackendImpl.kt
@@ -190,6 +190,8 @@ internal class TypesafeMigrationBackendImpl(
         account: AccountUuid
     ): JniTransferProposal? = rustBackend().pendingTransferProposal(dbDataPath, network.id, account.value)
 
+    override suspend fun migrationDustThresholdZatoshi(): Long = rustBackend().migrationDustThresholdZatoshi()
+
     override suspend fun createUnsignedNoteSplitPczt(
         dbDataPath: String,
         network: ZcashNetwork,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackendImpl.kt
@@ -6,6 +6,7 @@ import cash.z.ecc.android.sdk.internal.model.migration.JniKeystoneBatchSignedPcz
 import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationProgress
 import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationSchedule
 import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationState
+import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationTransferStates
 import cash.z.ecc.android.sdk.internal.model.migration.JniNoteSplitProposal
 import cash.z.ecc.android.sdk.internal.model.migration.JniPreparedTransfer
 import cash.z.ecc.android.sdk.internal.model.migration.JniTransferProposal
@@ -140,12 +141,11 @@ internal class TypesafeMigrationBackendImpl(
             feeZatoshi
         )
 
-    override suspend fun proposeImmediateMigrationTransfers(
+    override suspend fun proposeImmediateSendMax(
         dbDataPath: String,
         network: ZcashNetwork,
         account: AccountUuid
-    ): JniMigrationSchedule =
-        rustBackend().proposeImmediateMigrationTransfers(dbDataPath, network.id, account.value)
+    ): ByteArray = rustBackend().proposeImmediateSendMax(dbDataPath, network.id, account.value)
 
     override suspend fun signAndStoreMigrationSchedule(
         dbDataPath: String,
@@ -174,6 +174,12 @@ internal class TypesafeMigrationBackendImpl(
         includeResidual: Boolean
     ): JniMigrationSchedule =
         rustBackend().restartCurrentMigrationStep(dbDataPath, network.id, account.value, includeResidual)
+
+    override suspend fun migrationTransferStates(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): JniMigrationTransferStates? = rustBackend().migrationTransferStates(dbDataPath, network.id, account.value)
 
     override suspend fun getAccountUuids(
         dbDataPath: String,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/block/CompactBlockDownloader.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/block/CompactBlockDownloader.kt
@@ -60,6 +60,10 @@ open class CompactBlockDownloader private constructor(
     ): List<JniBlockMeta> {
         val from = BlockHeightUnsafe.from(heightRange.start)
         val to = BlockHeightUnsafe.from(heightRange.endInclusive)
+        // Temporary diagnostic (IRONWOOD_DIAG) — confirms whether the connected lightwalletd
+        // server is actually populating CompactTx.ironwoodActions yet. Remove once confirmed.
+        var ironwoodDiagBlocksWithActions = 0
+        var ironwoodDiagActionsSeen = 0L
         val filteredFlow =
             lightWalletClient
                 .getBlockRange(
@@ -69,6 +73,15 @@ open class CompactBlockDownloader private constructor(
                     when (response) {
                         is Response.Success -> {
                             Twig.verbose { "Downloading block at height: ${response.result.height} succeeded." }
+                            val ironwoodCount = response.result.ironwoodOutputsCount
+                            if (ironwoodCount > 0u) {
+                                ironwoodDiagBlocksWithActions++
+                                ironwoodDiagActionsSeen += ironwoodCount.toLong()
+                                Twig.debug {
+                                    "IRONWOOD_DIAG block ${response.result.height} has $ironwoodCount " +
+                                        "ironwoodActions"
+                                }
+                            }
                         }
 
                         is Response.Failure -> {
@@ -90,6 +103,10 @@ open class CompactBlockDownloader private constructor(
                         Twig.warn { "Blocks in range $heightRange failed to download with: $it" }
                     } else {
                         Twig.verbose { "All blocks in range $heightRange downloaded successfully" }
+                        Twig.debug {
+                            "IRONWOOD_DIAG range $heightRange: $ironwoodDiagBlocksWithActions block(s) with " +
+                                "ironwoodActions, $ironwoodDiagActionsSeen total ironwoodActions seen"
+                        }
                     }
                 }
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/WalletSummary.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/WalletSummary.kt
@@ -11,7 +11,8 @@ internal data class WalletSummary(
     val scanProgress: ScanProgress,
     val recoveryProgress: RecoveryProgress?,
     val nextSaplingSubtreeIndex: UInt,
-    val nextOrchardSubtreeIndex: UInt
+    val nextOrchardSubtreeIndex: UInt,
+    val nextIronwoodSubtreeIndex: UInt
 ) {
     companion object {
         fun new(jni: JniWalletSummary): WalletSummary =
@@ -26,7 +27,8 @@ internal data class WalletSummary(
                 scanProgress = ScanProgress.new(jni),
                 recoveryProgress = RecoveryProgress.new(jni),
                 nextSaplingSubtreeIndex = jni.nextSaplingSubtreeIndex.toUInt(),
-                nextOrchardSubtreeIndex = jni.nextOrchardSubtreeIndex.toUInt()
+                nextOrchardSubtreeIndex = jni.nextOrchardSubtreeIndex.toUInt(),
+                nextIronwoodSubtreeIndex = jni.nextIronwoodSubtreeIndex.toUInt()
             )
     }
 }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/storage/preference/keys/EncryptedPreferenceKeys.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/storage/preference/keys/EncryptedPreferenceKeys.kt
@@ -1,3 +1,19 @@
 package cash.z.ecc.android.sdk.internal.storage.preference.keys
 
-internal object EncryptedPreferenceKeys
+import cash.z.ecc.android.sdk.internal.storage.preference.model.entry.PreferenceKey
+import cash.z.ecc.android.sdk.internal.storage.preference.model.entry.StringPreferenceDefault
+
+internal object EncryptedPreferenceKeys {
+    /**
+     * Epoch-millis string: when sync may resume after a migration transfer was broadcast via the
+     * immediate ("send now") path. Empty means no buffer is active. See
+     * [cash.z.ecc.android.sdk.OrchardMigrationSdk.isSyncBlocked]'s doc for why this lives here
+     * rather than in the migration engine itself (a network/timing-privacy technique layered on
+     * top of it, not part of it).
+     */
+    val MIGRATION_SYNC_RESUME_AT =
+        StringPreferenceDefault(
+            key = PreferenceKey("migration_sync_resume_at"),
+            defaultValue = ""
+        )
+}

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/AccountBalance.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/AccountBalance.kt
@@ -5,6 +5,7 @@ import cash.z.ecc.android.sdk.internal.model.JniAccountBalance
 data class AccountBalance(
     val sapling: WalletBalance,
     val orchard: WalletBalance,
+    val ironwood: WalletBalance,
     val unshielded: Zatoshi
 ) {
     companion object {
@@ -21,6 +22,12 @@ data class AccountBalance(
                         available = Zatoshi(jni.orchardVerifiedBalance),
                         changePending = Zatoshi(jni.orchardChangePending),
                         valuePending = Zatoshi(jni.orchardValuePending)
+                    ),
+                ironwood =
+                    WalletBalance(
+                        available = Zatoshi(jni.ironwoodVerifiedBalance),
+                        changePending = Zatoshi(jni.ironwoodChangePending),
+                        valuePending = Zatoshi(jni.ironwoodValuePending)
                     ),
                 unshielded = Zatoshi(jni.unshieldedBalance)
             )

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/Proposal.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/Proposal.kt
@@ -58,5 +58,11 @@ class Proposal(
      */
     fun totalFeeRequired(): Zatoshi = Zatoshi(inner.totalFeeRequired())
 
+    /**
+     * Returns whether this proposal directly spends any Orchard note. See
+     * [ProposalUnsafe.usesOrchardInputs] for exactly what's (and isn't) detected.
+     */
+    fun usesOrchardInputs(): Boolean = inner.usesOrchardInputs()
+
     fun toPrettyString(): String = "Transaction count: ${transactionCount()}, Total fee required: ${totalFeeRequired()}"
 }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/TransactionOutput.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/TransactionOutput.kt
@@ -7,5 +7,6 @@ data class TransactionOutput(
 enum class TransactionPool {
     TRANSPARENT,
     SAPLING,
-    ORCHARD
+    ORCHARD,
+    IRONWOOD
 }

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImplTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImplTest.kt
@@ -153,8 +153,7 @@ class OrchardMigrationSdkImplTest {
             dbDataPath: String,
             network: ZcashNetwork,
             account: AccountUuid,
-            outputValuesZatoshi: LongArray,
-            feeZatoshi: Long,
+            proposalHandle: Long,
             usk: ByteArray
         ): JniPreparedTransfer = error("Unused")
 
@@ -186,8 +185,7 @@ class OrchardMigrationSdkImplTest {
             dbDataPath: String,
             network: ZcashNetwork,
             account: AccountUuid,
-            outputValuesZatoshi: LongArray,
-            feeZatoshi: Long
+            proposalHandle: Long
         ): JniMigrationSchedule = error("Unused")
 
         override suspend fun proposeImmediateSendMax(
@@ -204,7 +202,7 @@ class OrchardMigrationSdkImplTest {
             dbDataPath: String,
             network: ZcashNetwork,
             account: AccountUuid,
-            schedule: JniMigrationSchedule,
+            proposalHandle: Long,
             usk: ByteArray
         ) = error("Unused")
 
@@ -247,7 +245,8 @@ class OrchardMigrationSdkImplTest {
         override suspend fun createUnsignedNoteSplitPczt(
             dbDataPath: String,
             network: ZcashNetwork,
-            account: AccountUuid
+            account: AccountUuid,
+            proposalHandle: Long
         ): ByteArray = error("Unused")
 
         override suspend fun storeSignedNoteSplitPczt(
@@ -261,7 +260,7 @@ class OrchardMigrationSdkImplTest {
             dbDataPath: String,
             network: ZcashNetwork,
             account: AccountUuid,
-            schedule: JniMigrationSchedule
+            proposalHandle: Long
         ): Array<JniUnsignedTransferPczt> = error("Unused")
 
         override suspend fun storeSignedSchedulePczts(

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImplTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImplTest.kt
@@ -52,6 +52,36 @@ class OrchardMigrationSdkImplTest {
         }
 
     /**
+     * `migrationDustThresholdZatoshi()` is a pure pass-through to the Rust-side
+     * `MIGRATION_DUST_THRESHOLD_ZATOSHI` constant (100,000 zatoshi / 0.001 ZEC) — no account or
+     * database state involved. This just pins down that the value round-trips through the
+     * typesafe backend unchanged.
+     */
+    @Test
+    fun `migrationDustThresholdZatoshi returns the backend's constant value unchanged`() =
+        runBlocking {
+            val account = AccountUuid.new(ByteArray(16) { it.toByte() })
+            val fakeBackend =
+                FakeTypesafeMigrationBackend(
+                    migrationDustThresholdZatoshiResult = 100_000L
+                )
+            val sdk =
+                OrchardMigrationSdkImpl(
+                    context = fakeAndroidContext(),
+                    network = ZcashNetwork.Testnet,
+                    alias = "OrchardMigrationSdkImplTest",
+                    account = account,
+                    migrationBackend = fakeBackend,
+                    defaultSubmitEndpoint = LightWalletEndpoint("localhost", 9067, true),
+                    preferenceProviderHolder = EncryptedPreferenceProvider(fakeAndroidContext()),
+                )
+
+            val result = sdk.migrationDustThresholdZatoshi()
+
+            assertEquals(100_000L, result)
+        }
+
+    /**
      * A minimal, hand-encoded `cash.z.wallet.sdk.ffi.Proposal` protobuf message (see
      * `backend-lib/src/main/proto/proposal.proto`) — just field 2 (`feeRule`) set to `Zip317` (3),
      * with no steps. `ProposalUnsafe`'s init check only requires a non-default `feeRule`, and
@@ -84,10 +114,13 @@ class OrchardMigrationSdkImplTest {
 
     @Suppress("TooManyFunctions")
     private class FakeTypesafeMigrationBackend(
-        private val proposeImmediateSendMaxResult: ByteArray
+        private val proposeImmediateSendMaxResult: ByteArray = ByteArray(0),
+        private val migrationDustThresholdZatoshiResult: Long = 100_000L
     ) : TypesafeMigrationBackend {
         var proposeImmediateSendMaxCalled = false
         var lastAccount: AccountUuid? = null
+
+        override suspend fun migrationDustThresholdZatoshi(): Long = migrationDustThresholdZatoshiResult
 
         override suspend fun migrationState(
             dbDataPath: String,

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImplTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImplTest.kt
@@ -1,0 +1,295 @@
+package cash.z.ecc.android.sdk.internal
+
+import android.content.Context
+import cash.z.ecc.android.sdk.internal.model.migration.JniKeystoneBatchDecodeResult
+import cash.z.ecc.android.sdk.internal.model.migration.JniKeystoneBatchSignedPczts
+import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationProgress
+import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationSchedule
+import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationState
+import cash.z.ecc.android.sdk.internal.model.migration.JniMigrationTransferStates
+import cash.z.ecc.android.sdk.internal.model.migration.JniPreparedTransfer
+import cash.z.ecc.android.sdk.internal.model.migration.JniTransferProposal
+import cash.z.ecc.android.sdk.internal.model.migration.JniUnsignedTransferPczt
+import cash.z.ecc.android.sdk.internal.storage.preference.EncryptedPreferenceProvider
+import cash.z.ecc.android.sdk.model.AccountUuid
+import cash.z.ecc.android.sdk.model.ZcashNetwork
+import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class OrchardMigrationSdkImplTest {
+    @Test
+    fun `proposeImmediateMigration delegates to the send-max native call and returns an ordinary Proposal`() =
+        runBlocking {
+            val account = AccountUuid.new(ByteArray(16) { it.toByte() })
+            val proposalBytes = fakeProposalBytes()
+            val fakeBackend =
+                FakeTypesafeMigrationBackend(
+                    proposeImmediateSendMaxResult = proposalBytes
+                )
+            val sdk =
+                OrchardMigrationSdkImpl(
+                    context = fakeAndroidContext(),
+                    network = ZcashNetwork.Testnet,
+                    alias = "OrchardMigrationSdkImplTest",
+                    account = account,
+                    migrationBackend = fakeBackend,
+                    defaultSubmitEndpoint = LightWalletEndpoint("localhost", 9067, true),
+                    preferenceProviderHolder = EncryptedPreferenceProvider(fakeAndroidContext()),
+                )
+
+            val result = sdk.proposeImmediateMigration()
+
+            assertTrue(fakeBackend.proposeImmediateSendMaxCalled)
+            assertEquals(account, fakeBackend.lastAccount)
+            assertEquals(proposalBytes.toList(), result.toUnsafe().toByteArray().toList())
+        }
+
+    /**
+     * A minimal, hand-encoded `cash.z.wallet.sdk.ffi.Proposal` protobuf message (see
+     * `backend-lib/src/main/proto/proposal.proto`) — just field 2 (`feeRule`) set to `Zip317` (3),
+     * with no steps. `ProposalUnsafe`'s init check only requires a non-default `feeRule`, and
+     * `Proposal.check()`'s `totalFeeRequired()` folds over an empty `steps` list to 0, so this
+     * round-trips cleanly through `Proposal.fromByteArray`.
+     *
+     * Built by hand (proto3 varint wire format: tag byte `(fieldNumber shl 3) or wireType`,
+     * followed by the varint value) rather than via the generated `ProposalOuterClass` builder,
+     * because the protobuf-lite runtime is an `implementation`-scoped dependency of `backend-lib`
+     * (not exposed transitively) — `sdk-lib` can call into `ProposalUnsafe`'s own API (as
+     * production code already does) but cannot reference `com.google.protobuf.*` supertypes
+     * directly at compile time.
+     */
+    private fun fakeProposalBytes(): ByteArray {
+        val fieldNumber = 2
+        val wireTypeVarint = 0
+        val tag = (fieldNumber shl 3) or wireTypeVarint
+        val feeRuleZip317 = 3
+        return byteArrayOf(tag.toByte(), feeRuleZip317.toByte())
+    }
+
+    private fun fakeAndroidContext(): Context {
+        val tempDir = kotlin.io.path.createTempDirectory("OrchardMigrationSdkImplTest").toFile()
+        val context = mock(Context::class.java)
+        `when`(context.applicationContext).thenReturn(context)
+        `when`(context.noBackupFilesDir).thenReturn(File(tempDir, "no_backup"))
+        `when`(context.getDatabasePath(anyString())).thenReturn(File(tempDir, "databases/unused.db"))
+        return context
+    }
+
+    @Suppress("TooManyFunctions")
+    private class FakeTypesafeMigrationBackend(
+        private val proposeImmediateSendMaxResult: ByteArray
+    ) : TypesafeMigrationBackend {
+        var proposeImmediateSendMaxCalled = false
+        var lastAccount: AccountUuid? = null
+
+        override suspend fun migrationState(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid
+        ): JniMigrationState = error("Unused")
+
+        override suspend fun migrationProgress(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid
+        ): JniMigrationProgress? = error("Unused")
+
+        override suspend fun isNoteSplitNeeded(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid
+        ): Boolean = error("Unused")
+
+        override suspend fun estimateMigrationRunCount(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid
+        ): Int = error("Unused")
+
+        override suspend fun lockRemainingOrchardBalance(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid
+        ): Int = error("Unused")
+
+        override suspend fun clearMigration(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid
+        ): Int = error("Unused")
+
+        override suspend fun debugRescheduleTransfers(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid
+        ): Int = error("Unused")
+
+        override suspend fun hasOverdueTransfers(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid
+        ): Boolean = error("Unused")
+
+        override suspend fun hasInvalidTransfers(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid
+        ): Boolean = error("Unused")
+
+        override suspend fun prepareNoteSplit(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid
+        ) = error("Unused")
+
+        override suspend fun signNoteSplit(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid,
+            outputValuesZatoshi: LongArray,
+            feeZatoshi: Long,
+            usk: ByteArray
+        ): JniPreparedTransfer = error("Unused")
+
+        override suspend fun extractBroadcastTx(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid,
+            pcztBytes: ByteArray
+        ): ByteArray = error("Unused")
+
+        override suspend fun recordTransferResult(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid,
+            transferId: String,
+            resultTag: Int,
+            retryable: Boolean,
+            txId: ByteArray
+        ) = error("Unused")
+
+        override suspend fun proposeMigrationTransfers(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid,
+            includeResidual: Boolean
+        ): JniMigrationSchedule = error("Unused")
+
+        override suspend fun proposeMigrationTransfersFromSplit(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid,
+            outputValuesZatoshi: LongArray,
+            feeZatoshi: Long
+        ): JniMigrationSchedule = error("Unused")
+
+        override suspend fun proposeImmediateSendMax(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid
+        ): ByteArray {
+            proposeImmediateSendMaxCalled = true
+            lastAccount = account
+            return proposeImmediateSendMaxResult
+        }
+
+        override suspend fun signAndStoreMigrationSchedule(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid,
+            schedule: JniMigrationSchedule,
+            usk: ByteArray
+        ) = error("Unused")
+
+        override suspend fun finalizeReadyTransfers(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid
+        ): Int = error("Unused")
+
+        override suspend fun nextDueTransfer(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid
+        ): JniPreparedTransfer? = error("Unused")
+
+        override suspend fun restartCurrentMigrationStep(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid,
+            includeResidual: Boolean
+        ): JniMigrationSchedule = error("Unused")
+
+        override suspend fun migrationTransferStates(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid
+        ): JniMigrationTransferStates? = error("Unused")
+
+        override suspend fun getAccountUuids(
+            dbDataPath: String,
+            network: ZcashNetwork
+        ): List<AccountUuid> = error("Unused")
+
+        override suspend fun pendingTransferProposal(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid
+        ): JniTransferProposal? = error("Unused")
+
+        override suspend fun createUnsignedNoteSplitPczt(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid
+        ): ByteArray = error("Unused")
+
+        override suspend fun storeSignedNoteSplitPczt(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid,
+            signedPczt: ByteArray
+        ): JniPreparedTransfer = error("Unused")
+
+        override suspend fun createUnsignedTransferPczts(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid,
+            schedule: JniMigrationSchedule
+        ): Array<JniUnsignedTransferPczt> = error("Unused")
+
+        override suspend fun storeSignedSchedulePczts(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid,
+            ids: Array<String>,
+            pcztBytesList: Array<ByteArray>
+        ) = error("Unused")
+
+        override suspend fun buildKeystoneSignBatchQrParts(
+            requestId: ByteArray,
+            splitUnsignedPczt: ByteArray?,
+            transferUnsignedPczts: Array<ByteArray>,
+            maxFragmentLen: Int
+        ): Array<String> = error("Unused")
+
+        override suspend fun resetKeystoneSignBatchDecoder() = error("Unused")
+
+        override suspend fun decodeKeystoneSignBatchPart(
+            part: String,
+            expectedRequestId: ByteArray
+        ): JniKeystoneBatchDecodeResult = error("Unused")
+
+        override suspend fun applyKeystoneBatchSignatures(
+            splitUnsignedPczt: ByteArray?,
+            transferUnsignedPczts: Array<ByteArray>,
+            batchSignResponse: ByteArray
+        ): JniKeystoneBatchSignedPczts = error("Unused")
+    }
+}


### PR DESCRIPTION
## Summary

Brings **only** the Orchard → Ironwood pool migration (ZIP 318) onto the 2.5.x line, on top of `prerelease/v2.5.3` (= v2.5.2). This deliberately excludes the 2.6 feature train, Milan's Slipstream sync engine, and the MOB-1488 hardening — none of which belong on 2.5.x.

Base: **v2.5.2** (`prerelease/v2.5.3` @ 27e5083c)

## Cherry-picked commits (10)

Backported from `android-slipstream-ironwood-chp`, in order:

1. `3153bd9a` feat: Orchard -> Ironwood pool migration engine (ZIP 318) — the core migration engine
2. `b9a12384` Add migration schema self-heal and debug clear/reschedule JNI hooks
3. `cbedbeb8` fix: reconcile mark_mined at every migration-state read
4. `f530256e` fix: remove dead isSyncRequiredBeforeNextTransfer gate
5. `61d89107` feat: IMMEDIATE mode proposes an ordinary Orchard-only send-max
6. `694809e2` Protect pending migration transfer anchors from checkpoint pruning *(migration.rs part only — see gaps)*
7. `a9790dd8` Finish send-max backend rename; add live migration transfer-state query
8. `79aca498` Identify migration proposals by an opaque Rust-side handle *(Kris)*
9. `bf18e34b` Port dust-threshold constant + Proposal.usesOrchardInputs()
10. `f1fe14df` Remove dead MigrationProgress.remainingOrchardZatoshi field

## Explicitly excluded

- **Slipstream** engine: `6ea9fb2e` (Slipstream implementation), `1185ac9a` (Fold slipstream-jni), `e1491047` (Performance update)
- **MOB-1488** hardening (5 commits, `9b6c59dc`…`8d9c6a84`)
- **CI-only**: `de31eb64` (cargo fmt job), `64aa849d` (pin toolchain)
- **2.6-only** features (voting, multi-currency, NU 6.2, new checkpoints) — not part of the migration diff, so never pulled in.

## Notable conflict resolutions

- **`backend-lib/Cargo.toml`**: took the migration dependency set (orchard 0.15 Ironwood, pczt 0.8.0-rc.1, `zcash_pool_migration_backend`, shardtree, incrementalmerkletree). `[patch.crates-io]` pins librustzcash git rev `3a10e7f`. `incrementalmerkletree` is kept — it is used directly by `migration_engine.rs`/`migration_keystone.rs` (the stale "voting only" comment was corrected).
- **Removed voting Rust module** (`voting/delegation.rs`, `voting/util.rs`): base v2.5.2 has no voting module at all, and the migration code does not reference it.
- **`EncryptedPreferenceKeys.kt`**: kept only the migration key `MIGRATION_SYNC_RESUME_AT`; dropped `PENDING_SUBMIT_PLANS` (a 2.6 MOB-1146 artifact with no consumer in the migration set).
- **`Cargo.lock`**: taken from the migration commit; expected to be reconciled by the build.

## ⚠️ Known gaps / follow-ups

1. **MOB-1455 anchor-pruning protection is not actively wired.** The working implementation of `694809e2` lived in `slipstream/mod.rs` (feeding `EngineConfig.anchor_retention_height` at every session start). Since Slipstream is excluded, only the typed *reference* query in `migration.rs` remains — the protection against pruning a pending transfer's anchor checkpoint is **not** hooked into the 2.5.x sync path (`CompactBlockProcessor` / `zcash_client_backend`). Needs re-wiring if this scenario is reachable on 2.5.x.
2. **`orchard`'s `unstable-voting-circuits` feature** is kept as originally authored (it is a dependency feature, not voting module code). Can be dropped if confirmed unneeded by the Ironwood pin.
3. **Local build not yet run** — relying on CI to compile the Rust backend (git-rev deps) + Kotlin.
