### PR TITLE
Add Ironwood (NU6.3) pool support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ jobs that are runnable on a dev machine:
 
 ```bash
 ./scripts/ci-local.sh fast     # detekt + ktlint (~30s) -- run this first
-./scripts/ci-local.sh quick    # fast + unit tests (~2-5m)
+./scripts/ci-local.sh quick    # fast + unit tests (~5m)
 ./scripts/ci-local.sh full     # everything, including androidTest (~15-30m)
 
 # Or a single stage when iterating:
@@ -22,12 +22,29 @@ jobs that are runnable on a dev machine:
 ./scripts/ci-local.sh demoapp
 ```
 
+`quick` is what actually compiles the Kotlin: `fast` only runs static
+analysis, so it will pass on code that does not compile. Run at least `quick`
+after any change to a Kotlin source file.
+
 ### Environment requirements
 
 - **JDK 17 or 21.** Android Gradle Plugin 8.13.x does not support JDK 25+.
   If your default `java -version` reports 25 or newer, install JDK 21 via
   Homebrew (`brew install openjdk@21`) or SDKMAN! and set `JAVA_HOME` before
   running the script.
+
+  On a machine where `java` is not on `PATH` at all (common on macOS, where
+  the JDK is installed but not linked), export it for the command:
+
+  ```bash
+  export JAVA_HOME=/opt/homebrew/opt/openjdk@21          # brew install openjdk@21
+  export PATH="$JAVA_HOME/bin:$PATH"
+  export ANDROID_HOME="$HOME/Library/Android/sdk"
+  ./scripts/ci-local.sh quick
+  ```
+
+  Android Studio's bundled runtime works too, if you prefer not to install a
+  second JDK: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`.
 - **Android SDK** at `$ANDROID_HOME` or `~/Library/Android/sdk`.
 - For the `androidtest` stage on Apple Silicon, the `aosp` SDK-36 Pixel 2
   system image is downloaded on first run (~1.5 GB).
@@ -92,6 +109,16 @@ prefix is acceptable (`fix: ...`, `chore: ...`). Keep the first line under
 - The SDK and related libraries are Kotlin + Rust. Changes that cross the
   JNI boundary (`backend-lib/src/main/rust/*` and the Kotlin `Jni*` model
   classes) require updating both sides in lockstep.
+- The Rust backend is fastest to check on its own, without Gradle or a JDK:
+
+  ```bash
+  cd backend-lib && cargo check --lib && cargo fmt --check
+  ```
+
+  Note this only proves the Rust compiles. A JNI signature mismatch between
+  Rust and Kotlin is a *runtime* crash, not a compile error on either side,
+  so a Rust-only change that touches a `Java_*` export or an
+  `env.new_object` type signature still needs `./scripts/ci-local.sh quick`.
 - Detekt and ktlint are strict; treat their output as blocking. `detektAll`
   catches `MaxLineLength`, `ReturnCount`, `LongParameterList`, and similar
   issues that won't be apparent from a plain `./gradlew build`.

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/Backend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/Backend.kt
@@ -262,11 +262,14 @@ interface Backend {
      * @throws RuntimeException as a common indicator of the operation failure
      */
     @Throws(RuntimeException::class)
+    @Suppress("LongParameterList")
     suspend fun putSubtreeRoots(
         saplingStartIndex: Long,
         saplingRoots: List<JniSubtreeRoot>,
         orchardStartIndex: Long,
         orchardRoots: List<JniSubtreeRoot>,
+        ironwoodStartIndex: Long,
+        ironwoodRoots: List<JniSubtreeRoot>,
     )
 
     /**

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/FakeRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/FakeRustBackend.kt
@@ -38,6 +38,8 @@ class FakeRustBackend(
         saplingRoots: List<JniSubtreeRoot>,
         orchardStartIndex: Long,
         orchardRoots: List<JniSubtreeRoot>,
+        ironwoodStartIndex: Long,
+        ironwoodRoots: List<JniSubtreeRoot>,
     ) {
         error("Intentionally not implemented yet.")
     }

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/RustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/RustBackend.kt
@@ -287,6 +287,8 @@ class RustBackend private constructor(
         saplingRoots: List<JniSubtreeRoot>,
         orchardStartIndex: Long,
         orchardRoots: List<JniSubtreeRoot>,
+        ironwoodStartIndex: Long,
+        ironwoodRoots: List<JniSubtreeRoot>,
     ) = withContext(SdkDispatchers.DATABASE_IO) {
         putSubtreeRoots(
             dataDbFile.absolutePath,
@@ -294,6 +296,8 @@ class RustBackend private constructor(
             saplingRoots.toTypedArray(),
             orchardStartIndex,
             orchardRoots.toTypedArray(),
+            ironwoodStartIndex,
+            ironwoodRoots.toTypedArray(),
             networkId = networkId
         )
     }
@@ -781,6 +785,8 @@ class RustBackend private constructor(
             saplingRoots: Array<JniSubtreeRoot>,
             orchardStartIndex: Long,
             orchardRoots: Array<JniSubtreeRoot>,
+            ironwoodStartIndex: Long,
+            ironwoodRoots: Array<JniSubtreeRoot>,
             networkId: Int
         )
 

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/JniAccountBalance.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/JniAccountBalance.kt
@@ -19,6 +19,12 @@ import cash.z.ecc.android.sdk.internal.jni.JNI_ACCOUNT_UUID_BYTES_SIZE
  * @param orchardValuePending The value in the account of all remaining received Orchard
  *        notes that either do not have sufficient confirmations to be spendable, or for
  *        which witnesses cannot yet be constructed without additional scanning.
+ * @param ironwoodVerifiedBalance The verified account balance in the Ironwood pool.
+ * @param ironwoodChangePending The value in the account of Ironwood change notes that do
+ *        not yet have sufficient confirmations to be spendable.
+ * @param ironwoodValuePending The value in the account of all remaining received Ironwood
+ *        notes that either do not have sufficient confirmations to be spendable, or for
+ *        which witnesses cannot yet be constructed without additional scanning.
  * @param unshieldedBalance The total account balance in the transparent pool,
  *        including unconfirmed funds, that must be shielded before use.
  * @throws IllegalArgumentException if the values are inconsistent.
@@ -33,6 +39,9 @@ class JniAccountBalance(
     val orchardVerifiedBalance: Long,
     val orchardChangePending: Long,
     val orchardValuePending: Long,
+    val ironwoodVerifiedBalance: Long,
+    val ironwoodChangePending: Long,
+    val ironwoodValuePending: Long,
     val unshieldedBalance: Long,
 ) {
     init {
@@ -56,6 +65,15 @@ class JniAccountBalance(
         }
         require(orchardValuePending >= MIN_INCLUSIVE) {
             "Orchard value pending $orchardValuePending must by equal or above $MIN_INCLUSIVE"
+        }
+        require(ironwoodVerifiedBalance >= MIN_INCLUSIVE) {
+            "Ironwood verified balance $ironwoodVerifiedBalance must by equal or above $MIN_INCLUSIVE"
+        }
+        require(ironwoodChangePending >= MIN_INCLUSIVE) {
+            "Ironwood change pending $ironwoodChangePending must by equal or above $MIN_INCLUSIVE"
+        }
+        require(ironwoodValuePending >= MIN_INCLUSIVE) {
+            "Ironwood value pending $ironwoodValuePending must by equal or above $MIN_INCLUSIVE"
         }
         require(unshieldedBalance >= MIN_INCLUSIVE) {
             "Unshielded balance $unshieldedBalance must by equal or above $MIN_INCLUSIVE"

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/JniWalletSummary.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/JniWalletSummary.kt
@@ -20,6 +20,8 @@ import cash.z.ecc.android.sdk.internal.ext.isInUIntRange
  *        the next range of subtree roots passed to `Backend.putSaplingSubtreeRoots`.
  * @param nextOrchardSubtreeIndex the Orchard subtree index that should start
  *        the next range of subtree roots passed to `Backend.putOrchardSubtreeRoots`.
+ * @param nextIronwoodSubtreeIndex the Ironwood subtree index that should start
+ *        the next range of subtree roots passed to `Backend.putSubtreeRoots`.
  * @throws IllegalArgumentException unless (progressNumerator is nonnegative,
  *         progressDenominator is positive, and the represented ratio is in the
  *         range 0.0 to 1.0 inclusive).
@@ -36,6 +38,7 @@ class JniWalletSummary(
     val recoveryProgressDenominator: Long?,
     val nextSaplingSubtreeIndex: Long,
     val nextOrchardSubtreeIndex: Long,
+    val nextIronwoodSubtreeIndex: Long,
 ) {
     init {
         require(chainTipHeight.isInUIntRange()) {
@@ -88,6 +91,9 @@ class JniWalletSummary(
         }
         require(nextOrchardSubtreeIndex.isInUIntRange()) {
             "Height $nextOrchardSubtreeIndex is outside of allowed UInt range"
+        }
+        require(nextIronwoodSubtreeIndex.isInUIntRange()) {
+            "Height $nextIronwoodSubtreeIndex is outside of allowed UInt range"
         }
     }
 }

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/ZcashProtocol.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/ZcashProtocol.kt
@@ -13,18 +13,22 @@ enum class ZcashProtocol {
     },
     ORCHARD {
         override val poolCode = 3
+    },
+    IRONWOOD {
+        override val poolCode = 4
     };
 
     abstract val poolCode: Int
 
-    fun isShielded() = this == SAPLING || this == ORCHARD
+    fun isShielded() = this == SAPLING || this == ORCHARD || this == IRONWOOD
 
     companion object {
         fun validate(poolTypeCode: Int): Boolean =
             when (poolTypeCode) {
                 TRANSPARENT.poolCode,
                 SAPLING.poolCode,
-                ORCHARD.poolCode -> true
+                ORCHARD.poolCode,
+                IRONWOOD.poolCode -> true
 
                 else -> false
             }
@@ -34,6 +38,7 @@ enum class ZcashProtocol {
                 TRANSPARENT.poolCode -> TRANSPARENT
                 SAPLING.poolCode -> SAPLING
                 ORCHARD.poolCode -> ORCHARD
+                IRONWOOD.poolCode -> IRONWOOD
                 else -> error("Unsupported pool type: $poolCode")
             }
     }

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -1430,6 +1430,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_putSubtre
     sapling_roots: JObjectArray<'local>,
     orchard_start_index: jlong,
     orchard_roots: JObjectArray<'local>,
+    ironwood_start_index: jlong,
+    ironwood_roots: JObjectArray<'local>,
     network_id: jint,
 ) {
     let res = catch_unwind(&mut env, |env| {
@@ -1470,6 +1472,15 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_putSubtre
             orchard::tree::MerkleHashOrchard::read(n)
         })?;
 
+        let ironwood_start_index = if ironwood_start_index >= 0 {
+            ironwood_start_index as u64
+        } else {
+            return Err(anyhow!("Ironwood start index must be nonnegative."));
+        };
+        let ironwood_roots = parse_roots(env, ironwood_roots, |n| {
+            orchard::tree::MerkleHashOrchard::read(n)
+        })?;
+
         db_data
             .put_sapling_subtree_roots(sapling_start_index, &sapling_roots)
             .map_err(|e| anyhow!("Error while storing Sapling subtree roots: {}", e))?;
@@ -1477,6 +1488,10 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_putSubtre
         db_data
             .put_orchard_subtree_roots(orchard_start_index, &orchard_roots)
             .map_err(|e| anyhow!("Error while storing Orchard subtree roots: {}", e))?;
+
+        db_data
+            .put_ironwood_subtree_roots(ironwood_start_index, &ironwood_roots)
+            .map_err(|e| anyhow!("Error while storing Ironwood subtree roots: {}", e))?;
 
         Ok(())
     });
@@ -1579,11 +1594,17 @@ fn encode_account_balance<'a>(
     let orchard_value_pending =
         ZatBalance::from(balance.orchard_balance().value_pending_spendability());
 
+    let ironwood_verified_balance = ZatBalance::from(balance.ironwood_balance().spendable_value());
+    let ironwood_change_pending =
+        ZatBalance::from(balance.ironwood_balance().change_pending_confirmation());
+    let ironwood_value_pending =
+        ZatBalance::from(balance.ironwood_balance().value_pending_spendability());
+
     let unshielded = ZatBalance::from(balance.unshielded_balance().total());
 
     env.new_object(
         JNI_ACCOUNT_BALANCE,
-        "([BJJJJJJJ)V",
+        "([BJJJJJJJJJJ)V",
         &[
             (&env.byte_array_from_slice(account_uuid.expose_uuid().as_bytes())?).into(),
             JValue::Long(sapling_verified_balance.into()),
@@ -1592,6 +1613,9 @@ fn encode_account_balance<'a>(
             JValue::Long(orchard_verified_balance.into()),
             JValue::Long(orchard_change_pending.into()),
             JValue::Long(orchard_value_pending.into()),
+            JValue::Long(ironwood_verified_balance.into()),
+            JValue::Long(ironwood_change_pending.into()),
+            JValue::Long(ironwood_value_pending.into()),
             JValue::Long(unshielded.into()),
         ],
     )
@@ -1637,7 +1661,7 @@ fn encode_wallet_summary<'a>(
     Ok(env.new_object(
         "cash/z/ecc/android/sdk/internal/model/JniWalletSummary",
         format!(
-            "([L{};JJJJLjava/lang/Long;Ljava/lang/Long;JJ)V",
+            "([L{};JJJJLjava/lang/Long;Ljava/lang/Long;JJJ)V",
             JNI_ACCOUNT_BALANCE
         ),
         &[
@@ -1650,6 +1674,7 @@ fn encode_wallet_summary<'a>(
             JValue::Object(&recovery_progress_denominator),
             JValue::Long(summary.next_sapling_subtree_index() as i64),
             JValue::Long(summary.next_orchard_subtree_index() as i64),
+            JValue::Long(summary.next_ironwood_subtree_index() as i64),
         ],
     )?)
 }
@@ -3707,6 +3732,7 @@ fn parse_protocol(code: i32) -> anyhow::Result<ShieldedPool> {
     match code {
         2 => Ok(ShieldedPool::Sapling),
         3 => Ok(ShieldedPool::Orchard),
+        4 => Ok(ShieldedPool::Ironwood),
         _ => Err(anyhow!("Shielded protocol not recognized: {code}")),
     }
 }

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -3729,6 +3729,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_model_TorWalletClient_fet
 //
 
 fn parse_protocol(code: i32) -> anyhow::Result<ShieldedPool> {
+    // The codes below must follow zcash_client_sqlite's own pool-type encoding:
+    // https://github.com/zcash/librustzcash/blob/main/zcash_client_sqlite/src/wallet/encoding.rs#L42
     match code {
         2 => Ok(ShieldedPool::Sapling),
         3 => Ok(ShieldedPool::Orchard),

--- a/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/fixture/JniAccountBalanceFixture.kt
+++ b/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/fixture/JniAccountBalanceFixture.kt
@@ -14,6 +14,9 @@ object JniAccountBalanceFixture {
     const val ORCHARD_VERIFIED_BALANCE: Long = 0L
     const val ORCHARD_CHANGE_PENDING: Long = 0L
     const val ORCHARD_VALUE_PENDING: Long = 0L
+    const val IRONWOOD_VERIFIED_BALANCE: Long = 0L
+    const val IRONWOOD_CHANGE_PENDING: Long = 0L
+    const val IRONWOOD_VALUE_PENDING: Long = 0L
     const val UNSHIELDED_BALANCE: Long = 0L
 
     @Suppress("LongParameterList")
@@ -25,6 +28,9 @@ object JniAccountBalanceFixture {
         orchardVerifiedBalance: Long = ORCHARD_VERIFIED_BALANCE,
         orchardChangePending: Long = ORCHARD_CHANGE_PENDING,
         orchardValuePending: Long = ORCHARD_VALUE_PENDING,
+        ironwoodVerifiedBalance: Long = IRONWOOD_VERIFIED_BALANCE,
+        ironwoodChangePending: Long = IRONWOOD_CHANGE_PENDING,
+        ironwoodValuePending: Long = IRONWOOD_VALUE_PENDING,
         unshieldedBalance: Long = UNSHIELDED_BALANCE,
     ) = JniAccountBalance(
         accountUuid = accountUuid,
@@ -34,6 +40,9 @@ object JniAccountBalanceFixture {
         orchardVerifiedBalance = orchardVerifiedBalance,
         orchardChangePending = orchardChangePending,
         orchardValuePending = orchardValuePending,
+        ironwoodVerifiedBalance = ironwoodVerifiedBalance,
+        ironwoodChangePending = ironwoodChangePending,
+        ironwoodValuePending = ironwoodValuePending,
         unshieldedBalance = unshieldedBalance,
     )
 }

--- a/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/fixture/JniAccountBalanceFixture.kt
+++ b/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/fixture/JniAccountBalanceFixture.kt
@@ -8,16 +8,22 @@ import cash.z.ecc.android.sdk.internal.model.JniAccountBalance
  */
 object JniAccountBalanceFixture {
     val ACCOUNT_UUID: ByteArray = "random_uuid_16_b".toByteArray()
-    const val SAPLING_VERIFIED_BALANCE: Long = 0L
-    const val SAPLING_CHANGE_PENDING: Long = 0L
-    const val SAPLING_VALUE_PENDING: Long = 0L
-    const val ORCHARD_VERIFIED_BALANCE: Long = 0L
-    const val ORCHARD_CHANGE_PENDING: Long = 0L
-    const val ORCHARD_VALUE_PENDING: Long = 0L
-    const val IRONWOOD_VERIFIED_BALANCE: Long = 0L
-    const val IRONWOOD_CHANGE_PENDING: Long = 0L
-    const val IRONWOOD_VALUE_PENDING: Long = 0L
-    const val UNSHIELDED_BALANCE: Long = 0L
+
+    // Every value is distinct on purpose. [JniAccountBalance] is constructed from Rust by
+    // `encode_account_balance`, which passes ten positional `jlong`s under a JVM descriptor
+    // (`([BJJJJJJJJJJ)V`) that cannot distinguish them, and the Kotlin side only checks that each
+    // is non-negative. Identical values would let any permutation of the ten fields, such as
+    // reporting Orchard funds as Ironwood, pass every test that uses this fixture.
+    const val SAPLING_VERIFIED_BALANCE: Long = 1L
+    const val SAPLING_CHANGE_PENDING: Long = 2L
+    const val SAPLING_VALUE_PENDING: Long = 3L
+    const val ORCHARD_VERIFIED_BALANCE: Long = 4L
+    const val ORCHARD_CHANGE_PENDING: Long = 5L
+    const val ORCHARD_VALUE_PENDING: Long = 6L
+    const val IRONWOOD_VERIFIED_BALANCE: Long = 7L
+    const val IRONWOOD_CHANGE_PENDING: Long = 8L
+    const val IRONWOOD_VALUE_PENDING: Long = 9L
+    const val UNSHIELDED_BALANCE: Long = 10L
 
     @Suppress("LongParameterList")
     fun new(

--- a/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/model/JniWalletSummaryTest.kt
+++ b/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/model/JniWalletSummaryTest.kt
@@ -17,6 +17,7 @@ class JniWalletSummaryTest {
                 scanProgressDenominator = 100L,
                 nextSaplingSubtreeIndex = 0L,
                 nextOrchardSubtreeIndex = 0L,
+                nextIronwoodSubtreeIndex = 0L,
                 recoveryProgressNumerator = 1L,
                 recoveryProgressDenominator = 100L
             )
@@ -34,6 +35,7 @@ class JniWalletSummaryTest {
                 scanProgressDenominator = 100L,
                 nextSaplingSubtreeIndex = 0L,
                 nextOrchardSubtreeIndex = 0,
+                nextIronwoodSubtreeIndex = 0L,
                 recoveryProgressNumerator = 1L,
                 recoveryProgressDenominator = 100L
             )
@@ -51,6 +53,7 @@ class JniWalletSummaryTest {
                 scanProgressDenominator = 100L,
                 nextSaplingSubtreeIndex = 0L,
                 nextOrchardSubtreeIndex = 0L,
+                nextIronwoodSubtreeIndex = 0L,
                 recoveryProgressNumerator = 1L,
                 recoveryProgressDenominator = 100L
             )
@@ -68,6 +71,7 @@ class JniWalletSummaryTest {
                 scanProgressDenominator = -1L,
                 nextSaplingSubtreeIndex = 0L,
                 nextOrchardSubtreeIndex = 0L,
+                nextIronwoodSubtreeIndex = 0L,
                 recoveryProgressNumerator = 1L,
                 recoveryProgressDenominator = 100L
             )
@@ -85,6 +89,7 @@ class JniWalletSummaryTest {
                 scanProgressDenominator = 1L,
                 nextSaplingSubtreeIndex = 0L,
                 nextOrchardSubtreeIndex = 0L,
+                nextIronwoodSubtreeIndex = 0L,
                 recoveryProgressNumerator = 100L,
                 recoveryProgressDenominator = 1L
             )
@@ -102,6 +107,7 @@ class JniWalletSummaryTest {
                 scanProgressDenominator = 100L,
                 nextSaplingSubtreeIndex = -1L,
                 nextOrchardSubtreeIndex = -1L,
+                nextIronwoodSubtreeIndex = -1L,
                 recoveryProgressNumerator = 1L,
                 recoveryProgressDenominator = 100L
             )

--- a/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/fixture/SingleCompactBlockFixture.kt
+++ b/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/fixture/SingleCompactBlockFixture.kt
@@ -11,7 +11,7 @@ internal object SingleCompactBlockFixture {
     internal const val DEFAULT_TIME = 0
     internal const val DEFAULT_SAPLING_OUTPUT_COUNT = 1u
     internal const val DEFAULT_ORCHARD_OUTPUT_COUNT = 2u
-    internal const val DEFAULT_IRONWOOD_OUTPUT_COUNT = 0u
+    internal const val DEFAULT_IRONWOOD_OUTPUT_COUNT = 3u
     internal const val DEFAULT_HASH = DEFAULT_HEIGHT
     internal const val DEFAULT_BLOCK_BYTES = DEFAULT_HEIGHT
 

--- a/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/fixture/SingleCompactBlockFixture.kt
+++ b/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/fixture/SingleCompactBlockFixture.kt
@@ -11,6 +11,7 @@ internal object SingleCompactBlockFixture {
     internal const val DEFAULT_TIME = 0
     internal const val DEFAULT_SAPLING_OUTPUT_COUNT = 1u
     internal const val DEFAULT_ORCHARD_OUTPUT_COUNT = 2u
+    internal const val DEFAULT_IRONWOOD_OUTPUT_COUNT = 0u
     internal const val DEFAULT_HASH = DEFAULT_HEIGHT
     internal const val DEFAULT_BLOCK_BYTES = DEFAULT_HEIGHT
 
@@ -25,6 +26,7 @@ internal object SingleCompactBlockFixture {
         time: Int = DEFAULT_TIME,
         saplingOutputsCount: UInt = DEFAULT_SAPLING_OUTPUT_COUNT,
         orchardOutputsCount: UInt = DEFAULT_ORCHARD_OUTPUT_COUNT,
+        ironwoodOutputsCount: UInt = DEFAULT_IRONWOOD_OUTPUT_COUNT,
         blockBytes: ByteArray = heightToFixtureData(DEFAULT_BLOCK_BYTES)
     ): CompactBlockUnsafe =
         CompactBlockUnsafe(
@@ -33,6 +35,7 @@ internal object SingleCompactBlockFixture {
             time = time,
             saplingOutputsCount = saplingOutputsCount,
             orchardOutputsCount = orchardOutputsCount,
+            ironwoodOutputsCount = ironwoodOutputsCount,
             compactBlockBytes = blockBytes
         )
 }

--- a/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/model/CompactBlockUnsafe.kt
+++ b/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/model/CompactBlockUnsafe.kt
@@ -36,17 +36,21 @@ class CompactBlockUnsafe(
         }
 
         private fun getOutputsCounts(vtxList: List<CompactFormats.CompactTx>): CompactBlockOutputsCounts {
-            var outputsCount: UInt = 0u
-            var actionsCount: UInt = 0u
+            var saplingOutputsCount: UInt = 0u
+            var orchardActionsCount: UInt = 0u
             var ironwoodActionsCount: UInt = 0u
 
             vtxList.forEach { compactTx ->
-                outputsCount += compactTx.outputsCount.toUInt()
-                actionsCount += compactTx.actionsCount.toUInt()
+                saplingOutputsCount += compactTx.outputsCount.toUInt()
+                orchardActionsCount += compactTx.actionsCount.toUInt()
                 ironwoodActionsCount += compactTx.ironwoodActionsCount.toUInt()
             }
 
-            return CompactBlockOutputsCounts(outputsCount, actionsCount, ironwoodActionsCount)
+            return CompactBlockOutputsCounts(
+                saplingOutputsCount = saplingOutputsCount,
+                orchardActionsCount = orchardActionsCount,
+                ironwoodActionsCount = ironwoodActionsCount
+            )
         }
     }
 

--- a/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/model/CompactBlockUnsafe.kt
+++ b/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/model/CompactBlockUnsafe.kt
@@ -11,12 +11,14 @@ import cash.z.wallet.sdk.internal.rpc.CompactFormats.CompactBlock
  *
  * It is marked as "unsafe" because it is not guaranteed to be valid.
  */
+@Suppress("LongParameterList")
 class CompactBlockUnsafe(
     val height: Long,
     val hash: ByteArray,
     val time: Int,
     val saplingOutputsCount: UInt,
     val orchardOutputsCount: UInt,
+    val ironwoodOutputsCount: UInt,
     val compactBlockBytes: ByteArray
 ) {
     companion object {
@@ -28,6 +30,7 @@ class CompactBlockUnsafe(
                 time = compactBlock.time,
                 saplingOutputsCount = outputCounts.saplingOutputsCount,
                 orchardOutputsCount = outputCounts.orchardActionsCount,
+                ironwoodOutputsCount = outputCounts.ironwoodActionsCount,
                 compactBlockBytes = compactBlock.toByteArray()
             )
         }
@@ -35,18 +38,21 @@ class CompactBlockUnsafe(
         private fun getOutputsCounts(vtxList: List<CompactFormats.CompactTx>): CompactBlockOutputsCounts {
             var outputsCount: UInt = 0u
             var actionsCount: UInt = 0u
+            var ironwoodActionsCount: UInt = 0u
 
             vtxList.forEach { compactTx ->
                 outputsCount += compactTx.outputsCount.toUInt()
                 actionsCount += compactTx.actionsCount.toUInt()
+                ironwoodActionsCount += compactTx.ironwoodActionsCount.toUInt()
             }
 
-            return CompactBlockOutputsCounts(outputsCount, actionsCount)
+            return CompactBlockOutputsCounts(outputsCount, actionsCount, ironwoodActionsCount)
         }
     }
 
     data class CompactBlockOutputsCounts(
         val saplingOutputsCount: UInt,
-        val orchardActionsCount: UInt
+        val orchardActionsCount: UInt,
+        val ironwoodActionsCount: UInt
     )
 }

--- a/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/model/ShieldedProtocolEnum.kt
+++ b/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/model/ShieldedProtocolEnum.kt
@@ -4,11 +4,13 @@ import cash.z.wallet.sdk.internal.rpc.Service.ShieldedProtocol
 
 enum class ShieldedProtocolEnum {
     SAPLING,
-    ORCHARD;
+    ORCHARD,
+    IRONWOOD;
 
     fun toProtocol() =
         when (this) {
             SAPLING -> ShieldedProtocol.sapling
             ORCHARD -> ShieldedProtocol.orchard
+            IRONWOOD -> ShieldedProtocol.ironwood
         }
 }

--- a/lightwallet-client-lib/src/main/proto/compact_formats.proto
+++ b/lightwallet-client-lib/src/main/proto/compact_formats.proto
@@ -50,12 +50,11 @@ message CompactTx {
     //    valueBalanceSapling + valueBalanceOrchard + sum(vPubNew) - sum(vPubOld) - sum(tOut)
     uint32 fee = 3;
 
+    // The field numbers below must follow lightwalletd's generated bindings:
+    // https://github.com/zcash/lightwalletd/blob/master/walletrpc/compact_formats.pb.go
     repeated CompactSaplingSpend spends = 4;
     repeated CompactSaplingOutput outputs = 5;
     repeated CompactOrchardAction actions = 6;
-    // Ironwood (NU6.3) actions. Ironwood is Orchard note-version V3, so these reuse the
-    // CompactOrchardAction shape but ride a separate stream. Field number 9 matches lightwalletd;
-    // fields 7-8 (transparent vin/vout) are intentionally unused here.
     repeated CompactOrchardAction ironwoodActions = 9;
 }
 

--- a/lightwallet-client-lib/src/main/proto/compact_formats.proto
+++ b/lightwallet-client-lib/src/main/proto/compact_formats.proto
@@ -15,6 +15,7 @@ option swift_prefix = "";
 message ChainMetadata {
     uint32 saplingCommitmentTreeSize = 1; // the size of the Sapling note commitment tree as of the end of this block
     uint32 orchardCommitmentTreeSize = 2; // the size of the Orchard note commitment tree as of the end of this block
+    uint32 ironwoodCommitmentTreeSize = 3; // the size of the Ironwood note commitment tree as of the end of this block
 }
 
 // CompactBlock is a packaging of ONLY the data from a block that's needed to:
@@ -52,6 +53,10 @@ message CompactTx {
     repeated CompactSaplingSpend spends = 4;
     repeated CompactSaplingOutput outputs = 5;
     repeated CompactOrchardAction actions = 6;
+    // Ironwood (NU6.3) actions. Ironwood is Orchard note-version V3, so these reuse the
+    // CompactOrchardAction shape but ride a separate stream. Field number 9 matches lightwalletd;
+    // fields 7-8 (transparent vin/vout) are intentionally unused here.
+    repeated CompactOrchardAction ironwoodActions = 9;
 }
 
 // CompactSaplingSpend is a Sapling Spend Description as described in 7.3 of the Zcash

--- a/lightwallet-client-lib/src/main/proto/service.proto
+++ b/lightwallet-client-lib/src/main/proto/service.proto
@@ -117,11 +117,13 @@ message TreeState {
     uint32 time = 4;        // Unix epoch time when the block was mined
     string saplingTree = 5; // sapling commitment tree state
     string orchardTree = 6; // orchard commitment tree state
+    string ironwoodTree = 7; // ironwood commitment tree state
 }
 
 enum ShieldedProtocol {
     sapling = 0;
     orchard = 1;
+    ironwood = 2;
 }
 
 message GetSubtreeRootsArg {

--- a/lightwallet-client-lib/src/main/proto/service.proto
+++ b/lightwallet-client-lib/src/main/proto/service.proto
@@ -111,6 +111,8 @@ message Exclude {
 
 // The TreeState is derived from the Zcash z_gettreestate rpc.
 message TreeState {
+    // The field numbers below must follow lightwalletd's generated bindings:
+    // https://github.com/zcash/lightwalletd/blob/master/walletrpc/service.pb.go
     string network = 1;     // "main" or "test"
     uint64 height = 2;      // block height
     string hash = 3;        // block id

--- a/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/fixture/AccountBalanceFixture.kt
+++ b/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/fixture/AccountBalanceFixture.kt
@@ -9,14 +9,17 @@ object AccountBalanceFixture {
     val TRANSPARENT_BALANCE: Zatoshi = Zatoshi(8)
     val SAPLING_BALANCE: WalletBalance = WalletBalanceFixture.new(Zatoshi(4), Zatoshi(4), Zatoshi(2))
     val ORCHARD_BALANCE: WalletBalance = WalletBalanceFixture.new(Zatoshi(5), Zatoshi(2), Zatoshi(1))
+    val IRONWOOD_BALANCE: WalletBalance = WalletBalanceFixture.new(Zatoshi(0), Zatoshi(0), Zatoshi(0))
 
     fun new(
         orchardBalance: WalletBalance = ORCHARD_BALANCE,
         saplingBalance: WalletBalance = SAPLING_BALANCE,
-        transparentBalance: Zatoshi = TRANSPARENT_BALANCE
+        transparentBalance: Zatoshi = TRANSPARENT_BALANCE,
+        ironwoodBalance: WalletBalance = IRONWOOD_BALANCE
     ) = AccountBalance(
         saplingBalance,
         orchardBalance,
+        ironwoodBalance,
         transparentBalance
     )
 }

--- a/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/fixture/AccountBalanceFixture.kt
+++ b/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/fixture/AccountBalanceFixture.kt
@@ -9,7 +9,7 @@ object AccountBalanceFixture {
     val TRANSPARENT_BALANCE: Zatoshi = Zatoshi(8)
     val SAPLING_BALANCE: WalletBalance = WalletBalanceFixture.new(Zatoshi(4), Zatoshi(4), Zatoshi(2))
     val ORCHARD_BALANCE: WalletBalance = WalletBalanceFixture.new(Zatoshi(5), Zatoshi(2), Zatoshi(1))
-    val IRONWOOD_BALANCE: WalletBalance = WalletBalanceFixture.new(Zatoshi(0), Zatoshi(0), Zatoshi(0))
+    val IRONWOOD_BALANCE: WalletBalance = WalletBalanceFixture.new(Zatoshi(9), Zatoshi(6), Zatoshi(3))
 
     fun new(
         orchardBalance: WalletBalance = ORCHARD_BALANCE,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
@@ -545,6 +545,7 @@ class SdkSynchronizer private constructor(
                     ZcashProtocol.TRANSPARENT -> TransactionPool.TRANSPARENT
                     ZcashProtocol.SAPLING -> TransactionPool.SAPLING
                     ZcashProtocol.ORCHARD -> TransactionPool.ORCHARD
+                    ZcashProtocol.IRONWOOD -> TransactionPool.IRONWOOD
                 }
             )
         }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessor.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessor.kt
@@ -265,7 +265,7 @@ class CompactBlockProcessor internal constructor(
     suspend fun start() {
         val traceScope = TraceScope("CompactBlockProcessor.start")
 
-        val (saplingStartIndex, orchardStartIndex) = refreshWalletSummary()
+        val (saplingStartIndex, orchardStartIndex, ironwoodStartIndex) = refreshWalletSummary()
 
         updateBirthdayHeight()
 
@@ -282,7 +282,7 @@ class CompactBlockProcessor internal constructor(
 
         // Download note commitment tree data from lightwalletd to decide if we communicate with linear
         // or spend-before-sync node.
-        var subTreeRootResult = getSubtreeRoots(downloader, saplingStartIndex, orchardStartIndex)
+        var subTreeRootResult = getSubtreeRoots(downloader, saplingStartIndex, orchardStartIndex, ironwoodStartIndex)
         Twig.info { "Fetched SubTreeRoot result: $subTreeRootResult" }
 
         Twig.debug { "Setup verified. Processor starting..." }
@@ -316,6 +316,10 @@ class CompactBlockProcessor internal constructor(
                                             orchardSubtreeRootList =
                                                 (subTreeRootResult as GetSubtreeRootsResult.SpendBeforeSync)
                                                     .orchardSubtreeRootList,
+                                            ironwoodStartIndex = ironwoodStartIndex,
+                                            ironwoodSubtreeRootList =
+                                                (subTreeRootResult as GetSubtreeRootsResult.SpendBeforeSync)
+                                                    .ironwoodSubtreeRootList,
                                             lastValidHeight = lowerBoundHeight
                                         )
                                 ) {
@@ -353,7 +357,12 @@ class CompactBlockProcessor internal constructor(
                             GetSubtreeRootsResult.FailureConnection -> {
                                 // SubtreeRoot fetching retry
                                 subTreeRootResult =
-                                    getSubtreeRoots(downloader, saplingStartIndex, orchardStartIndex)
+                                    getSubtreeRoots(
+                                        downloader,
+                                        saplingStartIndex,
+                                        orchardStartIndex,
+                                        ironwoodStartIndex
+                                    )
                                 BlockProcessingResult.Reconnecting
                             }
                         }
@@ -880,7 +889,7 @@ class CompactBlockProcessor internal constructor(
      *
      * @return the next subtree index to fetch.
      */
-    internal suspend fun refreshWalletSummary(): Pair<UInt, UInt> {
+    internal suspend fun refreshWalletSummary(): Triple<UInt, UInt, UInt> {
         when (val result = getWalletSummary(backend)) {
             is GetWalletSummaryResult.Success -> {
                 val scanProgress = result.walletSummary.scanProgress
@@ -889,9 +898,10 @@ class CompactBlockProcessor internal constructor(
                 setProgress(scanProgress, recoveryProgress)
                 setFullyScannedHeight(result.walletSummary.fullyScannedHeight)
                 updateAllBalances(result.walletSummary)
-                return Pair(
+                return Triple(
                     result.walletSummary.nextSaplingSubtreeIndex,
-                    result.walletSummary.nextOrchardSubtreeIndex
+                    result.walletSummary.nextOrchardSubtreeIndex,
+                    result.walletSummary.nextIronwoodSubtreeIndex
                 )
             }
 
@@ -899,7 +909,7 @@ class CompactBlockProcessor internal constructor(
                 // Do not report the progress and balances in case of any error, and
                 // tell the caller to fetch all subtree roots.
                 Twig.info { "Progress from rust: no progress information available, progress type: $result" }
-                return Pair(UInt.MIN_VALUE, UInt.MIN_VALUE)
+                return Triple(UInt.MIN_VALUE, UInt.MIN_VALUE, UInt.MIN_VALUE)
             }
         }
     }
@@ -1327,132 +1337,92 @@ class CompactBlockProcessor internal constructor(
     internal suspend fun getSubtreeRoots(
         downloader: CompactBlockDownloader,
         saplingStartIndex: UInt,
-        orchardStartIndex: UInt
+        orchardStartIndex: UInt,
+        ironwoodStartIndex: UInt
     ): GetSubtreeRootsResult {
         Twig.debug { "Fetching SubtreeRoots..." }
         val traceScope = TraceScope("CompactBlockProcessor.getSubtreeRoots")
 
         var result: GetSubtreeRootsResult = GetSubtreeRootsResult.Linear
 
-        var saplingSubtreeRootList: List<SubtreeRoot> = emptyList()
-        var orchardSubtreeRootList: List<SubtreeRoot> = emptyList()
-
-        retryUpToAndContinue(GET_SUBTREE_ROOTS_RETRIES) {
-            downloader
-                .getSubtreeRoots(
-                    saplingStartIndex,
-                    shieldedProtocol = ShieldedProtocolEnum.SAPLING,
-                    maxEntries = UInt.MIN_VALUE,
-                    serviceMode = ServiceMode.Direct
-                ).onEach { response ->
-                    when (response) {
-                        is Response.Success -> {
-                            Twig.verbose {
-                                "Sapling SubtreeRoot fetched successfully: its completingHeight is: ${
-                                    response.result
-                                        .completingBlockHeight
-                                }"
-                            }
-                        }
-
-                        is Response.Failure -> {
-                            val error =
-                                LightWalletException.GetSubtreeRootsException(
-                                    response.code,
-                                    response.description,
-                                    response.toThrowable()
-                                )
-                            if (response is Response.Failure.Server.Unavailable) {
-                                Twig.error {
-                                    "Fetching Sapling SubtreeRoot failed due to server communication problem with" +
-                                        " failure: ${response.toThrowable()}"
+        // Fetching the subtree roots of a pool differs only in which pool is targeted, so the
+        // three per-pool retry loops share one implementation. `result` and `traceScope` are
+        // captured so a failure reports the same way it did when each loop was written out.
+        suspend fun fetchSubtreeRoots(
+            startIndex: UInt,
+            shieldedProtocol: ShieldedProtocolEnum
+        ): List<SubtreeRoot> {
+            var roots: List<SubtreeRoot> = emptyList()
+            retryUpToAndContinue(GET_SUBTREE_ROOTS_RETRIES) {
+                roots =
+                    downloader
+                        .getSubtreeRoots(
+                            startIndex = startIndex,
+                            shieldedProtocol = shieldedProtocol,
+                            maxEntries = UInt.MIN_VALUE,
+                            serviceMode = ServiceMode.Direct
+                        ).onEach { response ->
+                            when (response) {
+                                is Response.Success -> {
+                                    Twig.verbose {
+                                        "$shieldedProtocol SubtreeRoot fetched successfully: its completingHeight" +
+                                            " is: ${response.result.completingBlockHeight}"
+                                    }
                                 }
-                                result = GetSubtreeRootsResult.FailureConnection
-                            } else {
-                                Twig.error {
-                                    "Fetching Sapling SubtreeRoot failed with failure: ${response.toThrowable()}"
+
+                                is Response.Failure -> {
+                                    val error =
+                                        LightWalletException.GetSubtreeRootsException(
+                                            response.code,
+                                            response.description,
+                                            response.toThrowable()
+                                        )
+                                    if (response is Response.Failure.Server.Unavailable) {
+                                        Twig.error {
+                                            "Fetching $shieldedProtocol SubtreeRoot failed due to server" +
+                                                " communication problem with failure: ${response.toThrowable()}"
+                                        }
+                                        result = GetSubtreeRootsResult.FailureConnection
+                                    } else {
+                                        Twig.error {
+                                            "Fetching $shieldedProtocol SubtreeRoot failed with failure:" +
+                                                " ${response.toThrowable()}"
+                                        }
+                                        result = GetSubtreeRootsResult.OtherFailure(error)
+                                    }
+                                    traceScope.end()
+                                    throw error
                                 }
-                                result = GetSubtreeRootsResult.OtherFailure(error)
                             }
-                            traceScope.end()
-                            throw error
+                        }.filterIsInstance<Response.Success<SubtreeRootUnsafe>>()
+                        .map { response ->
+                            response.result
+                        }.toList()
+                        .map {
+                            SubtreeRoot.new(it)
                         }
-                    }
-                }.filterIsInstance<Response.Success<SubtreeRootUnsafe>>()
-                .map { response ->
-                    response.result
-                }.toList()
-                .map {
-                    SubtreeRoot.new(it)
-                }.let {
-                    saplingSubtreeRootList = it
-                }
+            }
+            return roots
         }
 
-        retryUpToAndContinue(GET_SUBTREE_ROOTS_RETRIES) {
-            downloader
-                .getSubtreeRoots(
-                    startIndex = orchardStartIndex,
-                    shieldedProtocol = ShieldedProtocolEnum.ORCHARD,
-                    maxEntries = UInt.MIN_VALUE,
-                    serviceMode = ServiceMode.Direct
-                ).onEach { response ->
-                    when (response) {
-                        is Response.Success -> {
-                            Twig.verbose {
-                                "Orchard SubtreeRoot fetched successfully: its completingHeight is: ${
-                                    response.result
-                                        .completingBlockHeight
-                                }"
-                            }
-                        }
+        val saplingSubtreeRootList = fetchSubtreeRoots(saplingStartIndex, ShieldedProtocolEnum.SAPLING)
+        val orchardSubtreeRootList = fetchSubtreeRoots(orchardStartIndex, ShieldedProtocolEnum.ORCHARD)
+        val ironwoodSubtreeRootList = fetchSubtreeRoots(ironwoodStartIndex, ShieldedProtocolEnum.IRONWOOD)
 
-                        is Response.Failure -> {
-                            val error =
-                                LightWalletException.GetSubtreeRootsException(
-                                    response.code,
-                                    response.description,
-                                    response.toThrowable()
-                                )
-                            if (response is Response.Failure.Server.Unavailable) {
-                                Twig.error {
-                                    "Fetching Orchard SubtreeRoot failed due to server communication problem with" +
-                                        " failure: ${response.toThrowable()}"
-                                }
-                                result = GetSubtreeRootsResult.FailureConnection
-                            } else {
-                                Twig.error {
-                                    "Fetching Orchard SubtreeRoot failed with failure: ${response.toThrowable()}"
-                                }
-                                result = GetSubtreeRootsResult.OtherFailure(error)
-                            }
-                            traceScope.end()
-                            throw error
-                        }
-                    }
-                }.filterIsInstance<Response.Success<SubtreeRootUnsafe>>()
-                .map { response ->
-                    response.result
-                }.toList()
-                .map {
-                    SubtreeRoot.new(it)
-                }.let {
-                    orchardSubtreeRootList = it
-                }
-        }
-
-        // Intentionally omitting [orchardSubtreeRootList], e.g., for Mainnet usage, we could check it, but on
-        // custom networks without NU5 activation, it wouldn't work. If the Orchard subtree roots are empty, it's
-        // technically still ok (as Orchard activates after Sapling, so on a network that doesn't have NU5
-        // activated, this would behave correctly). In contrast, if the Sapling subtree roots are empty, we
-        // cannot do SbS at all.
+        // Intentionally omitting [orchardSubtreeRootList]/[ironwoodSubtreeRootList], e.g., for Mainnet usage, we
+        // could check it, but on custom networks without NU5/NU6.3 activation, it wouldn't work. If the Orchard or
+        // Ironwood subtree roots are empty, it's technically still ok (both activate after Sapling, so on a network
+        // that doesn't have them activated yet, this would behave correctly). In contrast, if the Sapling subtree
+        // roots are empty, we cannot do SbS at all.
         if (saplingSubtreeRootList.isNotEmpty()) {
             result =
                 GetSubtreeRootsResult.SpendBeforeSync(
                     saplingStartIndex,
                     saplingSubtreeRootList,
                     orchardStartIndex,
-                    orchardSubtreeRootList
+                    orchardSubtreeRootList,
+                    ironwoodStartIndex,
+                    ironwoodSubtreeRootList
                 )
         }
 
@@ -1476,6 +1446,8 @@ class CompactBlockProcessor internal constructor(
         saplingSubtreeRootList: List<SubtreeRoot>,
         orchardStartIndex: UInt,
         orchardSubtreeRootList: List<SubtreeRoot>,
+        ironwoodStartIndex: UInt,
+        ironwoodSubtreeRootList: List<SubtreeRoot>,
         lastValidHeight: BlockHeight
     ): PutSaplingSubtreeRootsResult =
         runCatching {
@@ -1484,11 +1456,13 @@ class CompactBlockProcessor internal constructor(
                 saplingRoots = saplingSubtreeRootList,
                 orchardStartIndex = orchardStartIndex,
                 orchardRoots = orchardSubtreeRootList,
+                ironwoodStartIndex = ironwoodStartIndex,
+                ironwoodRoots = ironwoodSubtreeRootList,
             )
         }.onSuccess {
             Twig.info {
-                "Subtree roots put successfully with saplingStartIndex: $saplingStartIndex and " +
-                    "orchardStartIndex: $orchardStartIndex"
+                "Subtree roots put successfully with saplingStartIndex: $saplingStartIndex, " +
+                    "orchardStartIndex: $orchardStartIndex and ironwoodStartIndex: $ironwoodStartIndex"
             }
         }.onFailure {
             Twig.error { "Sapling subtree roots put failed with: $it" }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/model/GetSubtreeRootsResult.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/model/GetSubtreeRootsResult.kt
@@ -10,7 +10,9 @@ internal sealed class GetSubtreeRootsResult {
         val saplingStartIndex: UInt,
         val saplingSubtreeRootList: List<SubtreeRoot>,
         val orchardStartIndex: UInt,
-        val orchardSubtreeRootList: List<SubtreeRoot>
+        val orchardSubtreeRootList: List<SubtreeRoot>,
+        val ironwoodStartIndex: UInt,
+        val ironwoodSubtreeRootList: List<SubtreeRoot>
     ) : GetSubtreeRootsResult()
 
     data object Linear : GetSubtreeRootsResult()

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackend.kt
@@ -195,11 +195,14 @@ internal interface TypesafeBackend {
      * @throws RuntimeException as a common indicator of the operation failure
      */
     @Throws(RuntimeException::class)
+    @Suppress("LongParameterList")
     suspend fun putSubtreeRoots(
         saplingStartIndex: UInt,
         saplingRoots: List<SubtreeRoot>,
         orchardStartIndex: UInt,
         orchardRoots: List<SubtreeRoot>,
+        ironwoodStartIndex: UInt,
+        ironwoodRoots: List<SubtreeRoot>,
     )
 
     /**

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImpl.kt
@@ -288,7 +288,9 @@ internal class TypesafeBackendImpl(
         saplingStartIndex: UInt,
         saplingRoots: List<SubtreeRoot>,
         orchardStartIndex: UInt,
-        orchardRoots: List<SubtreeRoot>
+        orchardRoots: List<SubtreeRoot>,
+        ironwoodStartIndex: UInt,
+        ironwoodRoots: List<SubtreeRoot>
     ) = backend.putSubtreeRoots(
         saplingStartIndex = saplingStartIndex.toLong(),
         saplingRoots =
@@ -301,6 +303,14 @@ internal class TypesafeBackendImpl(
         orchardStartIndex = orchardStartIndex.toLong(),
         orchardRoots =
             orchardRoots.map {
+                JniSubtreeRoot.new(
+                    rootHash = it.rootHash,
+                    completingBlockHeight = it.completingBlockHeight.value
+                )
+            },
+        ironwoodStartIndex = ironwoodStartIndex.toLong(),
+        ironwoodRoots =
+            ironwoodRoots.map {
                 JniSubtreeRoot.new(
                     rootHash = it.rootHash,
                     completingBlockHeight = it.completingBlockHeight.value

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/WalletSummary.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/WalletSummary.kt
@@ -11,7 +11,8 @@ internal data class WalletSummary(
     val scanProgress: ScanProgress,
     val recoveryProgress: RecoveryProgress?,
     val nextSaplingSubtreeIndex: UInt,
-    val nextOrchardSubtreeIndex: UInt
+    val nextOrchardSubtreeIndex: UInt,
+    val nextIronwoodSubtreeIndex: UInt
 ) {
     companion object {
         fun new(jni: JniWalletSummary): WalletSummary =
@@ -26,7 +27,8 @@ internal data class WalletSummary(
                 scanProgress = ScanProgress.new(jni),
                 recoveryProgress = RecoveryProgress.new(jni),
                 nextSaplingSubtreeIndex = jni.nextSaplingSubtreeIndex.toUInt(),
-                nextOrchardSubtreeIndex = jni.nextOrchardSubtreeIndex.toUInt()
+                nextOrchardSubtreeIndex = jni.nextOrchardSubtreeIndex.toUInt(),
+                nextIronwoodSubtreeIndex = jni.nextIronwoodSubtreeIndex.toUInt()
             )
     }
 }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/AccountBalance.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/AccountBalance.kt
@@ -5,6 +5,7 @@ import cash.z.ecc.android.sdk.internal.model.JniAccountBalance
 data class AccountBalance(
     val sapling: WalletBalance,
     val orchard: WalletBalance,
+    val ironwood: WalletBalance,
     val unshielded: Zatoshi
 ) {
     companion object {
@@ -21,6 +22,12 @@ data class AccountBalance(
                         available = Zatoshi(jni.orchardVerifiedBalance),
                         changePending = Zatoshi(jni.orchardChangePending),
                         valuePending = Zatoshi(jni.orchardValuePending)
+                    ),
+                ironwood =
+                    WalletBalance(
+                        available = Zatoshi(jni.ironwoodVerifiedBalance),
+                        changePending = Zatoshi(jni.ironwoodChangePending),
+                        valuePending = Zatoshi(jni.ironwoodValuePending)
                     ),
                 unshielded = Zatoshi(jni.unshieldedBalance)
             )

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/TransactionOutput.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/TransactionOutput.kt
@@ -7,5 +7,6 @@ data class TransactionOutput(
 enum class TransactionPool {
     TRANSPARENT,
     SAPLING,
-    ORCHARD
+    ORCHARD,
+    IRONWOOD
 }


### PR DESCRIPTION
Exposes the Ironwood shielded pool through the SDK.

Extracted from `feature/2.5.x_migration`, which carries Ironwood support
alongside the Orchard-to-Ironwood migration engine, voting, and slipstream.
**None of those are included here** — this is the Ironwood pool surface only.

## No dependency changes

`maint/v2.5.x` already carries the dependency bump (4843902c), and the
crates.io releases it pins already ship the full Ironwood API:

| crate | version | provides |
|---|---|---|
| `zcash_client_backend` | 0.24.0-rc.1 | `put_ironwood_subtree_roots`, `ironwood_balance`, `next_ironwood_subtree_index` |
| `zcash_client_sqlite` | 0.22.0-rc.1 | `put_ironwood_subtree_roots`, pool code `4` |
| `zcash_protocol` | 0.10 | `ShieldedPool::Ironwood` |

So `Cargo.toml` and `Cargo.lock` are untouched. In particular this drops the
source branch's `[patch.crates-io]` git-rev pin of librustzcash, along with
`zcash_pool_migration_backend`, `ur`, `ur-registry`, `shardtree`,
`incrementalmerkletree`, and `bip0039` — all of which exist on that branch to
serve migration and Keystone batch signing, not Ironwood.

## What changed

Ironwood is Orchard note-version V3: it shares Orchard's commitment-tree
machinery but is a distinct pool with its own note commitment tree, subtree
roots, and balance.

**Rust (`lib.rs`)**

- `putSubtreeRoots` takes an Ironwood start index and root array, parsed with
  the Orchard hash type, forwarded to `put_ironwood_subtree_roots`.
- `encode_account_balance` and `encode_wallet_summary` carry the Ironwood
  balance triple and `next_ironwood_subtree_index`; both JNI constructor
  signatures updated in lockstep with the Kotlin `Jni*` classes.
- `parse_protocol` maps pool code 4 to `ShieldedPool::Ironwood`.

**Kotlin**

- `ZcashProtocol.IRONWOOD` (pool code 4), `TransactionPool.IRONWOOD`,
  `ShieldedProtocolEnum.IRONWOOD`.
- `JniAccountBalance` / `AccountBalance` gain the Ironwood balance;
  `JniWalletSummary` / `WalletSummary` gain `nextIronwoodSubtreeIndex`.
- `Backend.putSubtreeRoots` and `TypesafeBackend.putSubtreeRoots` take the
  Ironwood start index and roots. `CompactBlockProcessor` fetches Ironwood
  subtree roots alongside Sapling and Orchard and passes them through
  `GetSubtreeRootsResult.SpendBeforeSync`. As with Orchard, an empty Ironwood
  root list is not treated as a spend-before-sync failure, since NU6.3
  activates after Sapling.

**Protobuf**

- `ChainMetadata.ironwoodCommitmentTreeSize`, `CompactTx.ironwoodActions`
  (field 9), `TreeState.ironwoodTree`, and `ShieldedProtocol.ironwood`.

Verified field-for-field against the canonical
[`zcash/lightwallet-protocol`](https://github.com/zcash/lightwallet-protocol/blob/main/walletrpc/compact_formats.proto)
(which `lightwalletd` now symlinks to) and against `zcash_client_backend`'s
generated bindings. Both type `ironwoodActions` as `repeated
CompactOrchardAction` at field 9, and neither defines a
`CompactIronwoodAction` — the compact wire encoding is unchanged from Orchard,
so reusing the message is upstream's decision, not a shortcut here.

## Commits

| commit | |
|---|---|
| `e6a10834` | Add Ironwood (NU6.3) pool support |
| `cf187eae` | AGENTS.md: document how to compile locally |
| `d0c88dcb` | Give the Ironwood fixtures distinct, non-zero values |
| `e7b761c8` | Prefix the per-pool counters in getOutputsCounts |
| `3e0a21d2` | Cite lightwalletd's bindings for the TreeState field numbers |
| `7c821bd1` | Cite zcash_client_sqlite's encoding for the pool codes |

### On the fixture values (`d0c88dcb`)

Worth a reviewer's attention, because it is not cosmetic.

`JniAccountBalance` is built from Rust by `encode_account_balance`, which
passes ten positional `jlong`s under a JVM descriptor, `([BJJJJJJJJJJ)V`, that
cannot tell them apart; the Kotlin side only checks each is non-negative. With
`JniAccountBalanceFixture` setting all ten to `0L`, **any permutation of the
ten fields passed every test using it** — including one reporting Orchard funds
as Ironwood, which matters because the two pools have different spend rules.
The values are now `1L`–`10L`.

The Ironwood fixture values inherited from the source branch were `0`
throughout, encoding "the server does not send these yet" rather than a chosen
value. `lightwalletd` disproves that premise: it parses ZIP 229 v6
transactions, exposes `Transaction.IronwoodActionsCount`, filters on
`PoolType_IRONWOOD`, and its own tests build non-empty `IronwoodActions` lists.
The specific replacement values (`3u`, and `(9, 6, 3)`) are arbitrary markers
following the existing Sapling/Orchard fixture convention, not upstream
constants.

## Deviations from the source branch

Two things needed authoring rather than a straight cherry-pick, because
`feature/2.5.x_migration` is not green on either count:

1. **Unit tests did not compile there.** `JniWalletSummaryTest` and
   `JniAccountBalanceFixture` were never threaded through with the new
   required constructor parameters.
2. **Detekt/ktlint fail there.** Five issues were suppressions and line
   wrapping. The sixth: a third copy of the ~50-line per-pool subtree-root
   fetch loop tripped `ThrowsCount`, so the three near-identical loops are
   extracted into one pool-parameterized local helper. The only visible
   behaviour change is the pool name in the log messages.

Also dropped as debug scaffolding rather than Ironwood support:
`RustBackend.rustLogging = Debug`, and the `IRONWOOD_DIAG` temporary logging
in `CompactBlockDownloader` (the branch marks it "safe to remove once
confirmed").

## Validation

Run locally against this branch:

- `cd backend-lib && cargo check --lib` — clean
- `cargo fmt --check` — clean
- `./scripts/ci-local.sh fast` (detekt + ktlint) — pass
- `./scripts/ci-local.sh quick` (compile + unit tests) — pass

Not run: `./scripts/ci-local.sh full` (androidTest on a Gradle managed device).

### Two caveats

**`cargo test` is red on this branch, for a pre-existing reason.**
`utils::exception::tests::unknown_any` fails on `maint/v2.5.x` itself; this
branch does not touch `exception.rs` (`git diff maint/v2.5.x..HEAD --
backend-lib/src/main/rust/utils/exception.rs` is empty). The test's helper
panics via `panic!("{}", val)`, which always yields a `String` payload, so the
`"Unknown error occurred"` fallback it claims to cover is unreachable.
#2016 fixes it and adds the `cargo test` CI job that would have caught it; the
clean ordering is to merge that first and rebase this.

**Slow CI jobs on this branch may be cancelled rather than run.** The workflow
sets `cancel-in-progress: true`, and `static_analysis_android_lint` needs
~25-28 minutes because it cross-compiles Rust for four ABIs before linting. On
a branch pushed to frequently, a green tick can mean the fast jobs passed and
the slow ones never finished. Worth leaving the branch idle before trusting a
full green.
