### PR TITLE
CI: replace the emulator.wtf job with a Gradle Managed Device

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -275,9 +275,11 @@ jobs:
           name: Test Android modules with FTL results
           path: ~/artifacts
 
-  test_android_modules_wtf:
-    if: needs.check_emulator_wtf_secrets.outputs.has-secrets == 'true'
-    needs: [ validate_gradle_wrapper, check_emulator_wtf_secrets ]
+  # Runs the Android instrumentation suites on a Gradle Managed Device: a
+  # hardware-accelerated emulator booted inside the runner. This replaces the
+  # former emulator.wtf cloud job and depends on no external test service.
+  test_android_modules_emulator:
+    needs: [validate_gradle_wrapper]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -285,16 +287,51 @@ jobs:
       - name: Checkout
         timeout-minutes: 1
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      # ubuntu-latest exposes /dev/kvm, but the default udev rules do not grant
+      # the runner user access to it. This rule opens it so the managed-device
+      # emulator can use KVM acceleration instead of falling back to software.
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Setup
         id: setup
         timeout-minutes: 30
         uses: ./.github/actions/setup
-      - name: Build and test
-        timeout-minutes: 30
-        env:
-          ORG_GRADLE_PROJECT_ZCASH_EMULATOR_WTF_API_KEY: ${{ secrets.EMULATOR_WTF_API_KEY }}
+      # The hosted runner's Android SDK does not include the emulator package,
+      # which a Gradle Managed Device requires. AGP auto-installs the system
+      # image but not the emulator, so without this the pixel2MinSetup task
+      # fails at VersionedSdkLoader.getEmulatorDirectoryProvider().get() with
+      # "Cannot query the value of this property because it has no value
+      # available". Install it explicitly.
+      - name: Install Android emulator
+        timeout-minutes: 5
         run: |
-          ./gradlew testDebugWithEmulatorWtf
+          yes | "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" "emulator"
+      # pixel2Min is the Gradle Managed Device defined in
+      # zcash-sdk.android-conventions.gradle.kts (Pixel 2, API ANDROID_MIN_SDK_VERSION).
+      # Scoped to the same four modules the former emulator.wtf job covered;
+      # the unqualified task would also pull in darkside-test-lib (needs a live
+      # darkside server) and the demo-app modules. maxConcurrentDevices=1 keeps a
+      # single emulator booted at a time so the runner is not overwhelmed by four
+      # parallel emulators; in-runner emulators run serially, hence the higher
+      # timeout than the former cloud job.
+      # emulator.gpu=swiftshader_indirect forces software rendering. The hosted
+      # runner is headless, and AGP's default '-gpu auto-no-window' intermittently
+      # falls back to 'auto', which needs a real GPU and fails to boot the
+      # emulator (EmulatorStartFailedException during snapshot creation).
+      - name: Build and test
+        timeout-minutes: 45
+        run: |
+          ./gradlew \
+            :sdk-lib:pixel2MinDebugAndroidTest \
+            :lightwallet-client-lib:pixel2MinDebugAndroidTest \
+            :sdk-incubator-lib:pixel2MinDebugAndroidTest \
+            :backend-lib:pixel2MinDebugAndroidTest \
+            -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=1 \
+            -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect
       - name: Collect Artifacts
         if: ${{ always() }}
         timeout-minutes: 1
@@ -304,13 +341,19 @@ jobs:
         run: |
           mkdir ${ARTIFACTS_DIR_PATH}
 
-          zip -r ${TEST_RESULTS_ZIP_PATH} . -i \*/build/test-results/\*
+          # Managed-device runs write results/reports under build/outputs and
+          # build/reports/androidTests, not build/test-results, so include those
+          # too to make failures inspectable from the artifact.
+          zip -r ${TEST_RESULTS_ZIP_PATH} . \
+            -i \*/build/test-results/\* \
+            \*/build/outputs/androidTest-results/\* \
+            \*/build/reports/androidTests/\*
       - name: Upload Artifacts
         if: ${{ always() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         timeout-minutes: 1
         with:
-          name: Test Android modules with WTF results
+          name: Test Android modules with emulator results
           path: ~/artifacts
 
   demo_app_release_build:


### PR DESCRIPTION
Backport of [#1996](https://github.com/zcash/zcash-android-wallet-sdk/pull/1996)
(merged to `main` as `ec308823`) onto `maint/v2.5.x`.

## Why

`maint/v2.5.x` carries the same `test_android_modules_wtf` job and the same
failure. emulator.wtf returns a payload the Gradle plugin cannot deserialize:

```
> com.google.gson.JsonSyntaxException: java.lang.IllegalStateException:
    Missing required properties: testRunId
```

No test ever runs. `check_emulator_wtf_secrets` passes, so the API key is
present; the service response itself is malformed. The failure is
byte-identical on `main`, so it is service-side and branch-independent — it is
simply what keeps CI red on this branch.

`test_android_modules_emulator` replaces it, booting an emulator inside the
runner via a Gradle Managed Device (`pixel2Min`, already defined in
`zcash-sdk.android-conventions.gradle.kts` on this branch) and depending on no
external test service.

## Reimplemented, not cherry-picked

The cherry-pick conflicted on both of #1996's files:

```
UU .github/workflows/pull-request.yml
DU backend-lib/src/androidTest/.../jni/VotingRustBackendTest.kt
```

The second is a modify/delete — that test **does not exist on this branch**,
and the cherry-pick left the file in the working tree. Keeping it would have
imported a voting test onto a branch with no voting. So this was reimplemented
against this branch's actual workflow, and the commit records that with

```
Backport-of: ec30882354213468115343a9b90fbce9e6dcb108
Backport-method: reimplemented
```

so a later merge back into `main` can tell this apart from a cherry-pick (a
cherry-pick shares a patch-id and drops out on its own; a reimplementation is a
textually different commit making the same change, and will conflict with its
twin unless the merger knows they are the same work).

### Differences from main's version, and why

- **`with: rust-cache: true` on the Setup step is dropped.** This branch's
  `./.github/actions/setup` declares no `inputs:` block at all, so that input
  would be silently ignored rather than honoured.
- **The `actions/checkout` and `upload-artifact` pins are this branch's**
  (`de0fac2e…`, `bbbca2dd…`), not main's. They differ.
- **The prettier-driven requoting** (`'` to `"`) that rides along in the merged
  diff is not ported. It is unrelated churn, and this workflow has diverged
  from main's anyway.

`check_emulator_wtf_secrets` is kept, because `test_android_modules_ftl` still
gates on it.

## Validation

Verified locally:

- The workflow parses (PyYAML). 12 jobs; `test_android_modules_wtf` is gone
  and `test_android_modules_emulator` is present.
- The new job has its seven steps (Checkout, Enable KVM, Setup, Install Android
  emulator, Build and test, Collect Artifacts, Upload Artifacts), `needs:
  [validate_gradle_wrapper]`, and no secret gate.
- The checkout and upload-artifact pins are unchanged from this branch's
  existing ones (they appear as context, not additions, in the diff).

**Not verified locally, and only a CI run on this base can establish it:**
whether the emulator actually boots on the runner and the four suites pass.
That is the substance of the change, and it is why this is a PR rather than a
direct push.

## Follow-up

Per the backport rule, this also needs replicating onto
`prerelease/snapshot-v2.6.6`, tracked separately. Note that branch is 182
commits away from `maint/v2.5.x` and **does** contain
`VotingRustBackendTest.kt`, so both halves of #1996 are likely to apply there —
it will not be the same port as this one.
