### PR TITLE
chore: update the librustzcash crates to their latest compatible releases

### DIFF
--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -1110,7 +1110,7 @@ checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
  "heck",
  "indexmap 2.14.0",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -1911,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "halo2_proofs"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05713f117155643ce10975e0bee44a274bcda2f4bb5ef29a999ad67c1fa8d4d3"
+checksum = "5f63a999d9223fa9d3b9db3031fedc316e6039a0ae0f67394408b16ef670c69f"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -2813,9 +2813,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.15.0"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca2ede6a4a77bd729eed3be9303d98a08b217edc85190dcf4dbe004086d5a65"
+checksum = "793e2e8c2323f35f082d1b3467ca8f576d646f9c93aef8c5168809d099245af8"
 dependencies = [
  "aes",
  "bitvec",
@@ -2957,9 +2957,9 @@ dependencies = [
 
 [[package]]
 name = "pasta_curves"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
+checksum = "3437083215c505e867eea5478371feba43d7689d6d15ec0a209eb46fb0d4cda6"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -3315,7 +3315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -3334,7 +3334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3358,7 +3358,7 @@ dependencies = [
  "derive-deftly",
  "libc",
  "paste",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4123,9 +4123,9 @@ dependencies = [
 
 [[package]]
 name = "shardtree"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cc96e9b6b1c307749019e7e2cf9dd29881b1928ce6866e3702a02a4800aa345"
+checksum = "8147447aed7be4736e271825b8c3a4432efb7182e71363169b572371ddef452e"
 dependencies = [
  "bitflags",
  "either",
@@ -6958,9 +6958,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2973d210e74ebd81adc50828fbbb284ab6aaa099308097c42c47dc63cf3420fc"
+checksum = "4034db33a1ce58416430e065b01474b958e4649caa3e06e20654683a95149710"
 dependencies = [
  "corez",
  "document-features",
@@ -6971,9 +6971,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_script"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774d808ab619b0f1887d7b90cd815c356101698d16aa681f3d2d9dea063de475"
+checksum = "2f872800287d118be71bdf6fe8c869c6a6ff6fb0a5762f68fb2af54c97edf0f2"
 dependencies = [
  "bip32",
  "bitflags",


### PR DESCRIPTION
Refreshes `backend-lib/Cargo.lock` so every librustzcash-family crate resolves
to the newest crates.io release coherent with the rest of the set.

**`Cargo.toml` is unchanged.** No version requirement needed raising: the
existing requirements already admit these versions, and every crate whose
requirement *would* have to be raised is blocked (see below). So this is a
lockfile refresh only, 16 insertions and 16 deletions in one file.

## Moved

| crate | from | to |
|---|---|---|
| `orchard` | 0.15.0 | 0.15.4 |
| `shardtree` | 0.7.0 | 0.7.1 |
| `zcash_protocol` | 0.10.0 | 0.10.1 |
| `zcash_script` | 0.4.4 | 0.4.5 |
| `halo2_proofs` | 0.3.2 | 0.3.4 (pulled by orchard 0.15.3) |
| `pasta_curves` | 0.5.1 | 0.5.2 (pulled by orchard 0.15.4) |

All patch releases. None changed an API the JNI backend uses, so no Rust or
Kotlin source changed. In particular **no `Java_*` export changed arity or JVM
type signature**, so no Kotlin `Jni*` model class needed a lockstep edit — the
usual hazard on this boundary, since a mismatch there is a runtime crash rather
than a compile error.

Behaviour-relevant notes from the changelogs:

- **orchard 0.15.4** accelerates batched trial decryption via the new
  `zcash_note_encryption` 0.4.2 `BatchDomain::batch_ka_agree_dec` hook. Shared
  secrets are byte-identical to the per-item path, and the per-output entry
  points this backend calls are untouched.
- **shardtree 0.7.1** fixes stale cached root annotations retained during
  checkpoint truncation, which previously caused spurious `Insert(Conflict)`
  errors or incorrect roots when a truncated region was refilled after a reorg.
  Reached here only indirectly, through `zcash_client_sqlite` rewind.
- **zcash_protocol 0.10.1** is purely additive.
- **zcash_script 0.4.5** ships no changelog; patch bump, compiles clean.

## Deliberately not moved

- `zcash_client_backend` 0.24.0-rc.1, `zcash_client_sqlite` 0.22.0-rc.1,
  `pczt` 0.8.0-rc.1 and `zip321` 0.9.0-rc.1 are **still the highest published
  version** of each crate. The latest *stable* releases (0.23.0 / 0.21.1 /
  0.7.0 / 0.8.0) are older, so "updating" to them would be a downgrade. There
  is no final release to move to yet.
- `zcash_transparent` stays at 0.9 and `zcash_script` at 0.4 despite 0.10.0 and
  0.5.2 being published. The 0.24.0-rc.1 generation requires
  `zcash_transparent ^0.9.0` and `zcash_script ^0.4.3`, so raising either makes
  cargo resolve two semver-incompatible copies. This was tried, not assumed:
  the build failed with `expected zcash_script::script::Code, found a different
  zcash_script::script::Code` (`tor.rs`, `lib.rs`) plus ~11 `TransparentAddress`
  mismatches. Fixing it would need a `[patch.crates-io]` or a git rev, both of
  which this PR deliberately avoids.
- `reddsa` stays at 0.5.1. 0.5.2 is not required by anything in the set and
  drags a 10-crate FROST subtree into the lock.

Everything else in the family is already at its latest release:
`sapling-crypto` 0.7.0, `zcash_address` 0.13.0, `zcash_primitives`/`zcash_proofs`
0.29.0, `zcash_keys` 0.15.0, `zcash_note_encryption` 0.4.2, `zip32` 0.2.1,
`zcash_encoding` 0.4.0, `equihash` 0.3.0, `incrementalmerkletree` 0.8.2.

## Verification

- `cd backend-lib && cargo check --lib` — **0 errors, 0 warnings** (re-run after
  touching `lib.rs` to force a real recompile rather than a cache hit)
- `cargo fmt --check` — clean
- `./scripts/ci-local.sh fast` (detekt + ktlint) — clean

## What was not verified

- `cargo check` ran on the **host target (aarch64-darwin)** only, not a
  cross-compile to the Android NDK targets. It does not prove the
  `armv7`/`aarch64-linux-android` builds link.
- Unit tests were not run, since no Kotlin changed. Note `cargo test` is
  currently red on this branch for a pre-existing, unrelated reason
  (`utils::exception::tests::unknown_any`), fixed by
  [#2016](https://github.com/zcash/zcash-android-wallet-sdk/pull/2016).

## Why draft

The interesting follow-up is not this PR but the next one: once
`zcash_client_backend` 0.24.0 final lands, carrying `zcash_transparent ^0.10`
and `zcash_script ^0.5`, the real API migration that the duplicate-crate errors
above previewed will be needed. This lockfile refresh is the low-risk part.


## TODO

- [ ] Verify the Android NDK cross-compiles (`armv7`, `aarch64-linux-android`);
      only the host target was checked.
- [ ] On `zcash_client_backend` 0.24.0 final: take the whole blocked release
      wave together, `pczt` 0.8.0, `zcash_primitives`/`zcash_proofs` 0.30.0,
      `zcash_transparent` 0.10.0, `zcash_script` 0.5.2. All are gated by
      0.24.0-rc.1's `^0.29.0`/`^0.9.0`/`^0.4.3` requirements.

      Checked 2026-07-24, after `pczt` 0.8.0 and `zcash_primitives`/
      `zcash_proofs` 0.30.0 were published. `pczt` 0.8.0 looks takeable on
      paper (`^0.8.0-rc.1` admits it) but is not: cargo resolves it by *adding*
      `zcash_primitives` 0.30.0 and `zcash_transparent` 0.10.0 alongside 0.29.0
      and 0.9.0, and the build then fails inside `zcash_client_backend` itself
      with `expected PcztParts<_>, found PcztParts<ParamsT>` and
      `TransparentAddress`/`Bip32Derivation` mismatches, each carrying
      "two different versions of crate ... are being used". No feature
      combination avoids it.
- [ ] Re-check `reddsa` 0.5.2 if anything in the set starts requiring it; held
      at 0.5.1 to keep a 10-crate FROST subtree out of the lock.

