### PR TITLE
Add an Orchard to Ironwood pool migration proposal

### DIFF
--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/Backend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/Backend.kt
@@ -36,6 +36,14 @@ interface Backend {
     ): ProposalUnsafe
 
     /**
+     * Proposes migrating the account's entire Orchard balance into the Ironwood pool.
+     *
+     * @throws RuntimeException if NU6.3 is not active, if any Orchard note is not yet
+     * spendable, or as a common indicator of the operation failure
+     */
+    suspend fun proposeOrchardToIronwoodMigration(accountUuid: ByteArray): ProposalUnsafe
+
+    /**
      * @throws RuntimeException as a common indicator of the operation failure
      */
     @Throws(RuntimeException::class)

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/FakeRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/FakeRustBackend.kt
@@ -113,6 +113,10 @@ class FakeRustBackend(
         error("Intentionally not implemented yet.")
     }
 
+    override suspend fun proposeOrchardToIronwoodMigration(accountUuid: ByteArray): ProposalUnsafe {
+        error("Intentionally not implemented yet.")
+    }
+
     override suspend fun proposeShielding(
         accountUuid: ByteArray,
         shieldingThreshold: Long,

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/RustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/RustBackend.kt
@@ -436,6 +436,17 @@ class RustBackend private constructor(
             )
         }
 
+    override suspend fun proposeOrchardToIronwoodMigration(accountUuid: ByteArray): ProposalUnsafe =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            ProposalUnsafe.parse(
+                proposeOrchardToIronwoodMigration(
+                    dataDbFile.absolutePath,
+                    accountUuid,
+                    networkId = networkId,
+                )
+            )
+        }
+
     override suspend fun proposeShielding(
         accountUuid: ByteArray,
         shieldingThreshold: Long,
@@ -877,6 +888,13 @@ class RustBackend private constructor(
             dbDataPath: String,
             accountUuid: ByteArray,
             uri: String,
+            networkId: Int,
+        ): ByteArray
+
+        @JvmStatic
+        private external fun proposeOrchardToIronwoodMigration(
+            dbDataPath: String,
+            accountUuid: ByteArray,
             networkId: Int,
         ): ByteArray
 

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -102,6 +102,7 @@ use crate::utils::{
 };
 
 mod eip681;
+mod migration;
 mod tor;
 mod utils;
 
@@ -2189,6 +2190,36 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeTr
             None,
         )
         .map_err(|e| anyhow!("Error creating transaction proposal: {}", e))?;
+
+        Ok(utils::rust_bytes_to_java(
+            env,
+            Proposal::from_standard_proposal(&proposal)
+                .encode_to_vec()
+                .as_ref(),
+        )?
+        .into_raw())
+    });
+    unwrap_exc_or(&mut env, res, ptr::null_mut())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeOrchardToIronwoodMigration<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    account_uuid: JByteArray<'local>,
+    network_id: jint,
+) -> jbyteArray {
+    let res = catch_unwind(&mut env, |env| {
+        let _span = tracing::info_span!("RustBackend.proposeOrchardToIronwoodMigration").entered();
+        let network = parse_network(network_id as u32)?;
+        let mut db_data = wallet_db(env, network, db_data)?;
+        let account_uuid = account_id_from_jni(env, account_uuid)?;
+
+        let proposal =
+            crate::migration::propose_orchard_to_ironwood(&mut db_data, &network, account_uuid)?;
 
         Ok(utils::rust_bytes_to_java(
             env,

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -1,0 +1,140 @@
+//! Orchard to Ironwood pool migration.
+//!
+//! The generic capability this builds on lives upstream:
+//! [`propose_send_max_transfer`] already spends the entire spendable balance of
+//! a caller-chosen set of shielded pools to a single recipient, computing the
+//! fee so that nothing is left over. This module does not reimplement any of
+//! that, nor does it expose the general form. It pins every parameter that
+//! makes the call a migration, and that single instance is all the SDK offers.
+//!
+//! The "no remainder" property is the reason a migration needs send-max rather
+//! than an ordinary transfer: the caller cannot compute the right amount
+//! themselves, because the fee depends on which inputs the selector picks.
+
+use anyhow::anyhow;
+use rand::rngs::OsRng;
+use zcash_address::{ToAddress, ZcashAddress, unified, unified::Encoding as _};
+use zcash_client_backend::{
+    data_api::{
+        Account as _, InputSource, MaxSpendMode, WalletRead,
+        wallet::{ConfirmationsPolicy, propose_send_max_transfer},
+    },
+    fees::StandardFeeRule,
+    proposal::Proposal,
+};
+use zcash_client_sqlite::{AccountUuid, WalletDb, util::SystemClock};
+use zcash_protocol::{
+    ShieldedPool,
+    consensus::{Network, NetworkUpgrade, Parameters},
+    memo::MemoBytes,
+};
+
+/// The wallet database as the JNI layer holds it.
+type Db = WalletDb<rusqlite::Connection, Network, SystemClock, OsRng>;
+
+type MigrationProposal = Proposal<StandardFeeRule, <Db as InputSource>::NoteRef>;
+
+/// Proposes migrating the account's Orchard balance into the Ironwood pool.
+///
+/// Ironwood needs no address type of its own: it shares the Orchard receiver
+/// encoding, and once Ironwood is active `zcash_client_backend` represents a
+/// payment to an Orchard receiver as an Ironwood-pool output, which the
+/// transaction builder places in the Ironwood bundle. Sending the maximum from
+/// Orchard to the account's own internal Orchard receiver is therefore exactly
+/// the pool crossing, with nothing left behind in Orchard.
+///
+/// Uses [`MaxSpendMode::Everything`], so the proposal fails rather than
+/// migrating only part of the balance. `MaxSpendable` would silently skip any
+/// Orchard note that is not yet spendable (`zcash_client_sqlite` maps the two
+/// modes to `Ok(None)` and `Err(IneligibleNotes)` respectively for such a
+/// note), leaving funds in a pool the wallet is trying to leave and reporting
+/// success. The eligibility check covers only the pools being spent, so an
+/// unconfirmed Sapling note does not block this.
+///
+/// Fails if NU6.3 is not yet active. Before activation the identical call is
+/// still accepted by the input selector, but it constructs an *Orchard*-pool
+/// output rather than an Ironwood one (`input_selection.rs` picks the pool on
+/// `ironwood_active_at`), so it would be a self-send that migrates nothing and
+/// costs a fee. Refusing beats silently doing that.
+///
+/// **This is not a private migration.** It produces one transaction whose
+/// value is the account's entire Orchard balance, which any observer can read
+/// off the chain. Splitting a crossing into less-identifying denominations is
+/// a separate mechanism; this deliberately does not attempt it.
+pub(crate) fn propose_orchard_to_ironwood(
+    db_data: &mut Db,
+    network: &Network,
+    account: AccountUuid,
+) -> anyhow::Result<MigrationProposal> {
+    // Before NU6.3 an Orchard-receiver payment is built as an Orchard output,
+    // so this would be a fee-costing no-op rather than a migration. After it,
+    // the Orchard turnstile (a consensus rule) forbids adding value to the
+    // Orchard pool at all, which is what makes the crossing necessary.
+    let chain_tip = db_data
+        .chain_height()
+        .map_err(|e| anyhow!("Error reading the chain tip: {}", e))?
+        .ok_or_else(|| anyhow!("Wallet has not yet scanned any blocks."))?;
+    match network.activation_height(NetworkUpgrade::Nu6_3) {
+        Some(h) if chain_tip >= h => (),
+        _ => {
+            return Err(anyhow!(
+                "Ironwood (NU6.3) is not active yet; there is nothing to migrate to."
+            ));
+        }
+    }
+
+    let orchard_fvk = db_data
+        .get_account(account)
+        .map_err(|e| anyhow!("Error looking up account: {}", e))?
+        .ok_or_else(|| anyhow!("Unknown account."))?
+        .ufvk()
+        .and_then(|ufvk| ufvk.orchard())
+        .cloned()
+        .ok_or_else(|| anyhow!("Account has no Orchard full viewing key."))?;
+
+    // The internal scope is the account's own change address, so the funds
+    // stay with the account rather than being exposed as an external payment.
+    let receiver = orchard_fvk.address_at(0u32, orchard::keys::Scope::Internal);
+    let recipient = ZcashAddress::from_unified(
+        network.network_type(),
+        unified::Address::try_from_items(vec![unified::Receiver::Orchard(
+            receiver.to_raw_address_bytes(),
+        )])
+        .map_err(|e| anyhow!("Unable to construct the migration recipient: {}", e))?,
+    );
+
+    // Orchard only. Sapling and transparent funds are deliberately left where
+    // they are: this migrates one pool, it is not a sweep of the wallet.
+    let spend_pools = [ShieldedPool::Orchard];
+
+    // Always ZIP 317, as everywhere else in this backend.
+    let fee_rule = StandardFeeRule::Zip317;
+
+    // A transfer to oneself has no counterparty to carry a memo for.
+    let memo: Option<MemoBytes> = None;
+
+    // Fail rather than migrate part of the balance. For a note that is not yet
+    // spendable, `zcash_client_sqlite` maps `MaxSpendable` to `Ok(None)` and
+    // `Everything` to `Err(IneligibleNotes)`, so `MaxSpendable` would skip such
+    // notes silently and report a migration that in fact left funds in a pool
+    // the wallet is trying to leave. The check covers only the pools being
+    // spent, so an unconfirmed Sapling note does not block this.
+    let mode = MaxSpendMode::Everything;
+
+    // The wallet-wide default; this migration has no reason to be stricter or
+    // more lax about confirmations than an ordinary send.
+    let confirmations_policy = ConfirmationsPolicy::default();
+
+    propose_send_max_transfer::<_, _, _, std::convert::Infallible>(
+        db_data,
+        network,
+        account,
+        &spend_pools,
+        &fee_rule,
+        recipient,
+        memo,
+        mode,
+        confirmations_policy,
+    )
+    .map_err(|e| anyhow!("Error creating the migration proposal: {}", e))
+}

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
@@ -1012,6 +1012,14 @@ class SdkSynchronizer private constructor(
     ): Proposal = txManager.proposeTransfer(account, recipient, amount, memo)
 
     /**
+     * @throws TransactionEncoderException.ProposalFromParametersException in case the proposal
+     * creation failed
+     */
+    @Throws(TransactionEncoderException.ProposalFromParametersException::class)
+    override suspend fun proposeOrchardToIronwoodMigration(account: Account): Proposal =
+        txManager.proposeOrchardToIronwoodMigration(account)
+
+    /**
      * @throws TransactionEncoderException.ProposalShieldingException in case the proposal creation failed
      *
      * @return the proposal or an exception

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
@@ -295,6 +295,32 @@ interface Synchronizer {
     ): Proposal
 
     /**
+     * Creates a proposal migrating the account's entire Orchard balance into the Ironwood
+     * pool, introduced by NU6.3.
+     *
+     * The proposal spends every Orchard note the account holds and sends the maximum to the
+     * account's own internal receiver, with the fee computed so that no change is left in
+     * Orchard. Sapling and transparent funds are not touched.
+     *
+     * This is deliberately all-or-nothing: if any Orchard note is not yet spendable the
+     * proposal fails rather than migrating part of the balance and reporting success. After
+     * NU6.3 the Orchard turnstile forbids adding value back to the Orchard pool, so funds
+     * left behind would be stranded in a pool the wallet is leaving.
+     *
+     * Note this reveals the account's Orchard balance on-chain: the migration is a single
+     * transaction of exactly that value. It does not attempt to split the crossing into
+     * less-identifying amounts.
+     *
+     * @param account the account whose Orchard funds to migrate.
+     *
+     * @return the proposal or an exception
+     *
+     * @throws TransactionEncoderException.ProposalFromParametersException if NU6.3 is not
+     * active, if any Orchard note is not yet spendable, or if the proposal cannot be created
+     */
+    suspend fun proposeOrchardToIronwoodMigration(account: Account): Proposal
+
+    /**
      * Creates a proposal for fulfilling a payment ZIP-321 URI
      *
      * @param account the account from which to transfer funds.

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackend.kt
@@ -65,6 +65,11 @@ internal interface TypesafeBackend {
         memo: ByteArray? = null
     ): Proposal
 
+    /**
+     * Proposes migrating the account's entire Orchard balance into the Ironwood pool.
+     */
+    suspend fun proposeOrchardToIronwoodMigration(account: Account): Proposal
+
     suspend fun proposeShielding(
         account: Account,
         shieldingThreshold: Long,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImpl.kt
@@ -124,6 +124,11 @@ internal class TypesafeBackendImpl(
             )
         )
 
+    override suspend fun proposeOrchardToIronwoodMigration(account: Account): Proposal =
+        Proposal.fromUnsafe(
+            backend.proposeOrchardToIronwoodMigration(account.accountUuid.value)
+        )
+
     override suspend fun proposeShielding(
         account: Account,
         shieldingThreshold: Long,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/OutboundTransactionManager.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/OutboundTransactionManager.kt
@@ -47,6 +47,15 @@ internal interface OutboundTransactionManager {
     ): Proposal
 
     /**
+     * Creates a proposal migrating the account's entire Orchard balance into Ironwood.
+     *
+     * @param account the account whose Orchard funds to migrate.
+     *
+     * @return the proposal or an exception
+     */
+    suspend fun proposeOrchardToIronwoodMigration(account: Account): Proposal
+
+    /**
      * Creates a proposal for shielding any transparent funds received by the given account.
      *
      * @param account the account for which to shield funds.

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/OutboundTransactionManagerImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/OutboundTransactionManagerImpl.kt
@@ -49,6 +49,9 @@ internal class OutboundTransactionManagerImpl(
         return encoder.proposeTransfer(account, recipient, amount, memoBytes)
     }
 
+    override suspend fun proposeOrchardToIronwoodMigration(account: Account): Proposal =
+        encoder.proposeOrchardToIronwoodMigration(account)
+
     override suspend fun proposeShielding(
         account: Account,
         shieldingThreshold: Zatoshi,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/TransactionEncoder.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/TransactionEncoder.kt
@@ -49,6 +49,12 @@ internal interface TransactionEncoder {
     ): Proposal
 
     /**
+     * Creates a proposal migrating the account's entire Orchard balance into Ironwood.
+     */
+    @Throws(TransactionEncoderException.ProposalFromParametersException::class)
+    suspend fun proposeOrchardToIronwoodMigration(account: Account): Proposal
+
+    /**
      * Creates a proposal for shielding any transparent funds sent to the given account.
      *
      * @param account the account for which to shield funds.

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/TransactionEncoderImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/TransactionEncoderImpl.kt
@@ -65,6 +65,21 @@ internal class TransactionEncoderImpl(
     }
 
     @Throws(TransactionEncoderException.ProposalFromParametersException::class)
+    override suspend fun proposeOrchardToIronwoodMigration(account: Account): Proposal {
+        Twig.debug { "creating proposal to migrate the Orchard balance into Ironwood" }
+
+        return runCatching {
+            backend.proposeOrchardToIronwoodMigration(account)
+        }.onSuccess {
+            Twig.info { "Result of proposeOrchardToIronwoodMigration: ${it.toPrettyString()}" }
+        }.onFailure {
+            Twig.error(it) { "Caught exception while creating the migration proposal." }
+        }.getOrElse {
+            throw TransactionEncoderException.ProposalFromParametersException(it)
+        }
+    }
+
+    @Throws(TransactionEncoderException.ProposalFromParametersException::class)
     override suspend fun proposeTransfer(
         account: Account,
         recipient: String,


### PR DESCRIPTION
Adds `Synchronizer.proposeOrchardToIronwoodMigration(account)`.

Targets `maint/v2.5.x` directly. It does not depend on
[#2029](https://github.com/zcash/zcash-android-wallet-sdk/pull/2029) (the
`zcash_jni` split); the new export lives in `lib.rs` alongside the others, and
will move with the rest when that split lands.

## Why

NU6.3 introduces the Ironwood pool and the Orchard turnstile: value may *leave*
the Orchard pool but never re-enter it (`proposal.rs`: "Payments may never be
directed to the Orchard pool after Ironwood activation"). Orchard funds have to
be moved across once, and moved in full, since anything left behind is stranded
in a pool the wallet is leaving.

## What it does

Spends every Orchard note the account holds and sends the maximum to the
account's own internal receiver, with the fee computed so no change returns to
Orchard. Sapling and transparent funds are untouched — this migrates one pool,
it is not a sweep. The proposal is then built, signed and submitted through the
ordinary path.

**The generic capability is upstream and is not reimplemented.**
`propose_send_max_transfer` already spends the whole balance of a caller-chosen
set of pools with the fee computed to leave nothing over. `migration.rs` only
pins the parameters that make that call a migration, and only that instance
crosses the JNI boundary — there is no general send-max in the SDK's API.

Send-max is what a migration *needs*, because the caller cannot compute the
right amount themselves: the fee depends on which inputs the selector picks.

## Three details that are easy to get wrong

Each was verified against the crate source rather than the changelog prose:

- **The recipient is a unified address carrying only an Orchard receiver.**
  `input_selection.rs:898` matches `Address::Unified(addr)` with
  `addr.has_orchard()`, and represents such a payment as an Ironwood-pool output
  once Ironwood is active. Ironwood needs no address type of its own; it shares
  the Orchard receiver encoding. A receiver encoded another way would not take
  that path.
- **The internal scope is used**, so funds return to the account as change
  rather than appearing as an external payment.
- **The proposal is refused unless NU6.3 is active at the chain tip.** Before
  activation the same call is accepted but builds an *Orchard* output — a
  self-send that migrates nothing and costs a fee.

## All-or-nothing, deliberately

`MaxSpendMode::Everything`, not `MaxSpendable`. For a note that is not yet
spendable, `zcash_client_sqlite` (`wallet/common.rs:524`) maps the two modes to
`Err(IneligibleNotes)` and `Ok(None)` respectively — so `MaxSpendable` would
silently skip such notes and report a successful migration that left funds
behind. The eligibility check covers only the pools being spent, so an
unconfirmed *Sapling* note does not block this.

## Every argument is a named binding

`propose_send_max_transfer` takes nine positional arguments. Rather than
annotate them at the call site, each is bound to a named local with its
rationale above the binding, so the reasoning is found by a reader who asks
what a value is, not only by one reading this particular call:

```rust
// Orchard only. Sapling and transparent funds are deliberately left where
// they are: this migrates one pool, it is not a sweep of the wallet.
let spend_pools = [ShieldedPool::Orchard];
...
let mode = MaxSpendMode::Everything;
```

## Privacy

The migration reveals the account's Orchard balance on-chain: it is a single
transaction of exactly that value. Splitting a crossing into less-identifying
amounts is a separate mechanism and is deliberately not attempted here. This is
recorded in the doc comments so it is not mistaken for a private migration path.

## Validation

- `cargo check --lib` — 0 errors, 0 warnings
- `cargo fmt --check` — clean
- `nm` on the built cdylib — 79 exported `Java_*` symbols, 78 from `maint`
  plus `..._RustBackend_proposeOrchardToIronwoodMigration`
- `./scripts/ci-local.sh quick` — detekt, ktlint and Kotlin unit tests pass

`scripts/check-jni-symbols.sh` and `check-jni-move.sh` are not available on this
base; they arrive with #2029. The `nm` count above is the manual equivalent.
Once #2029 lands, this branch inherits them and the baseline needs a one-symbol
`--update`.

## No tests yet, and what they should be

**Nothing here is covered by a test, and nothing exercises a real JNI call.**
The Rust compiles, the symbol is exported, and the Kotlin chain compiles against
it. That is the whole of the evidence.

The gap is worth closing, and there is a usable harness for it.
`zcash_client_sqlite` ships a `test-dependencies` feature exposing
`TestBuilder`/`TestDsl`, which builds a real SQLite wallet with synthetic blocks
and notes at chosen heights — no network and no device. Upstream tests its own
send-max that way (`data_api/testing/pool.rs`), including a
`propose_send_max_transfer` helper and `MaxSpendMode::Everything`.

Because the heights are chosen, the chain tip can be placed past NU6.3, which
makes the three behaviours that actually matter testable:

1. **Pre-activation guard** — tip below NU6.3 yields the error, not a proposal.
   Cheapest, and currently unexercised.
2. **The crossing** — tip above NU6.3 with Orchard notes present: assert the
   proposal's output pool is **Ironwood**. This is the claim the feature rests
   on, and it is presently inferred from reading `input_selection.rs` rather
   than demonstrated.
3. **`Everything` semantics** — an unconfirmed Orchard note yields
   `IneligibleNotes` rather than a partial migration.

Two decisions before that can happen: it needs a `zcash_client_sqlite`
dev-dependency with `features = ["test-dependencies"]`, and `cargo test` does
not run in CI on this branch until
[#2016](https://github.com/zcash/zcash-android-wallet-sdk/pull/2016) lands.

Darkside is a possible end-to-end route later — `darksidewalletd` does support
Ironwood (`startIronwoodCommitmentTreeSize` in `darkside.proto`) — but it is not
in CI and the repo pins no revision of it.
