### PR TITLE
[MOB-1488] Make Slipstream walletSummary Ironwood fields non-optional

### DIFF
--- a/backend-lib/src/main/rust/slipstream/summary.rs
+++ b/backend-lib/src/main/rust/slipstream/summary.rs
@@ -17,11 +17,17 @@
 //! recovering host sees the per-tick climb.
 //!
 //! **Ironwood forward fields** (`SlipstreamAccountBalance.ironwood`,
-//! `SlipstreamWalletSummary.nextIronwoodSubtreeIndex`) are populated whenever the linked
-//! librustzcash generation is ironwood-capable, wired from `balance.ironwood_balance()` / the
-//! summary's `next_ironwood_subtree_index()` (marked inline). They fall back to `null` only for
-//! an engine/JNI build that predates ironwood support, and (deliberately) during recovery, where
-//! the collapsed net already includes ironwood value (marked inline).
+//! `SlipstreamWalletSummary.nextIronwoodSubtreeIndex`) are wired from the linked
+//! `zcash_client_backend` summary via `balance.ironwood_balance()` /
+//! `summary.next_ironwood_subtree_index()` — the same accessors the mainline
+//! `encode_account_balance` (`lib.rs:1647`) / `encode_wallet_summary` (`lib.rs:1727`) use.
+//! Those accessors landed with the Ironwood balance plumbing in the linked librustzcash, so
+//! the migrated Orchard→Ironwood funds recorded in the wallet DB surface in the reported
+//! balance without an "ironwood engine tag" AAR — the balance read walks the wallet DB
+//! directly, independent of the `slipstream-core` scan engine. During recovery the ironwood
+//! pool is reported as zero (not the real balance): the collapsed recovery net is pool-agnostic
+//! and already folds in ironwood value, so surfacing it again as a pool would double-count it
+//! (marked inline).
 
 use anyhow::anyhow;
 use std::num::NonZeroU32;
@@ -54,7 +60,7 @@ const JNI_WALLET_SUMMARY: &str = "com/zodl/slipstream/model/SlipstreamWalletSumm
 const POOL_BALANCE_CTOR: &str = "(JJJ)V";
 const ACCOUNT_BALANCE_CTOR: &str = "([BLcom/zodl/slipstream/model/SlipstreamPoolBalance;Lcom/zodl/slipstream/model/SlipstreamPoolBalance;Lcom/zodl/slipstream/model/SlipstreamPoolBalance;J)V";
 const SCAN_PROGRESS_CTOR: &str = "(JJ)V";
-const WALLET_SUMMARY_CTOR: &str = "([Lcom/zodl/slipstream/model/SlipstreamAccountBalance;JJLcom/zodl/slipstream/model/SlipstreamScanProgress;Lcom/zodl/slipstream/model/SlipstreamScanProgress;JJLjava/lang/Long;)V";
+const WALLET_SUMMARY_CTOR: &str = "([Lcom/zodl/slipstream/model/SlipstreamAccountBalance;JJLcom/zodl/slipstream/model/SlipstreamScanProgress;Lcom/zodl/slipstream/model/SlipstreamScanProgress;JJJ)V";
 
 /// [E-1] One cached upstream wallet summary + the engine facts it was captured under. Refresh
 /// triggers: a range boundary (`ranges_completed` moved), a state change, or — outside a scan
@@ -194,15 +200,16 @@ pub(crate) fn wallet_summary_object<'local>(
         let obj = if is_recovering {
             // Direction-B collapse (rust/src/ffi.rs:399): the whole clamped recovery net
             // becomes orchard `spendableValue`, every other component zero; `total()` == net.
-            // ironwood stays null here deliberately (not a forward-field gap): the recovery net
-            // comes from `slipstream_v_recovery_balance` (core/src/reconcile.rs:96-103), which
-            // sums pool-agnostic `v_transactions.account_balance_delta` — ironwood value is
-            // already folded into that single collapsed net, so adding an ironwood pool object
-            // here would double-count it.
+            // ironwood is reported as a zero pool here deliberately (not a forward-field gap):
+            // the recovery net comes from `slipstream_v_recovery_balance`
+            // (core/src/reconcile.rs:96-103), which sums pool-agnostic
+            // `v_transactions.account_balance_delta` — ironwood value is already folded into that
+            // single collapsed net, so surfacing it again as a pool object would double-count it.
             let net = recovery_nets.get(uuid_bytes).copied().unwrap_or(0);
             let sapling = pool_balance(env, 0, 0, 0)?;
             let orchard = pool_balance(env, net.max(0), 0, 0)?;
-            account_balance(env, uuid_bytes, &sapling, &orchard, &JObject::null(), 0)?
+            let ironwood = pool_balance(env, 0, 0, 0)?;
+            account_balance(env, uuid_bytes, &sapling, &orchard, &ironwood, 0)?
         } else {
             let sapling = pool_balance(
                 env,
@@ -216,18 +223,16 @@ pub(crate) fn wallet_summary_object<'local>(
                 zat(balance.orchard_balance().change_pending_confirmation()),
                 zat(balance.orchard_balance().value_pending_spendability()),
             )?;
-            let unshielded = zat(balance.unshielded_balance().total());
-            // FORWARD FIELD (§9.2): populated because the linked librustzcash pin is
-            // ironwood-capable — `balance.ironwood_balance()` folds `ironwood_received_notes`
-            // the same way `lib.rs:1647-1651` (`encode_account_balance`) does for the mainline
-            // getWalletSummary JNI. Stays null only for an engine/JNI build that predates
-            // ironwood support.
+            // Ironwood is read with the same `zcash_client_backend` accessors the mainline
+            // `encode_account_balance` uses (`balance.ironwood_balance()`, lib.rs:1647-1651), so
+            // the migrated Orchard→Ironwood funds recorded in the wallet DB surface here.
             let ironwood = pool_balance(
                 env,
                 zat(balance.ironwood_balance().spendable_value()),
                 zat(balance.ironwood_balance().change_pending_confirmation()),
                 zat(balance.ironwood_balance().value_pending_spendability()),
             )?;
+            let unshielded = zat(balance.unshielded_balance().total());
             account_balance(env, uuid_bytes, &sapling, &orchard, &ironwood, unshielded)?
         };
         env.set_object_array_element(&acc_array, i as i32, &obj)?;
@@ -247,15 +252,9 @@ pub(crate) fn wallet_summary_object<'local>(
     let fully_scanned = i64::from(u32::from(summary.fully_scanned_height()));
     let next_sapling = summary.next_sapling_subtree_index() as i64;
     let next_orchard = summary.next_orchard_subtree_index() as i64;
-    // FORWARD FIELD (§9.2): boxed because the linked librustzcash pin is ironwood-capable —
-    // mirrors the `java/lang/Long` boxing `lib.rs:1696-1706` uses for the recovery-progress
-    // Option fields. `next_ironwood_subtree_index()` itself is not optional (always a valid
-    // index once a summary exists), so it is always boxed, never left null.
-    let next_ironwood = env.new_object(
-        "java/lang/Long",
-        "(J)V",
-        &[JValue::Long(summary.next_ironwood_subtree_index() as i64)],
-    )?;
+    // `next_ironwood_subtree_index()` is present in the linked summary type (the mainline
+    // `encode_wallet_summary` reads it, lib.rs:1727), reported as a plain long like sapling/orchard.
+    let next_ironwood = summary.next_ironwood_subtree_index() as i64;
 
     let summary_obj = env.new_object(
         JNI_WALLET_SUMMARY,
@@ -270,7 +269,7 @@ pub(crate) fn wallet_summary_object<'local>(
             JValue::Object(&recovery_obj),
             JValue::Long(next_sapling),
             JValue::Long(next_orchard),
-            JValue::Object(&next_ironwood),
+            JValue::Long(next_ironwood),
         ],
     )?;
     Ok(summary_obj.into_raw())

--- a/sdk-lib/src/main/java/com/zodl/slipstream/internal/EngineMapping.kt
+++ b/sdk-lib/src/main/java/com/zodl/slipstream/internal/EngineMapping.kt
@@ -48,10 +48,9 @@ private fun SlipstreamPoolBalance.maskIfStale(mask: Boolean): SlipstreamPoolBala
 
 /**
  * Maps the engine's phase-resolving summary to the SDK's public balance model. `ironwood` is
- * read straight from the engine's own `SlipstreamAccountBalance.ironwood` FORWARD FIELD; the JNI
- * populates it whenever the linked librustzcash generation is ironwood-capable (DECISIONS.md D4).
- * It is null only for an engine/JNI build that predates ironwood support, in which case it
- * surfaces as a zero balance here.
+ * read straight from the engine's own `SlipstreamAccountBalance.ironwood` field, which the JNI
+ * layer populates from the linked librustzcash summary (`balance.ironwood_balance()`), so migrated
+ * Orchard→Ironwood funds recorded in the wallet DB surface here.
  */
 internal fun SlipstreamWalletSummary.toAccountBalances(
     isRecovering: Boolean,
@@ -63,8 +62,7 @@ internal fun SlipstreamWalletSummary.toAccountBalances(
             AccountBalance(
                 sapling = ab.sapling.maskIfStale(mask).toWalletBalance(),
                 orchard = ab.orchard.maskIfStale(mask).toWalletBalance(),
-                ironwood = ab.ironwood?.maskIfStale(mask)?.toWalletBalance()
-                    ?: WalletBalance(Zatoshi(0), Zatoshi(0), Zatoshi(0)),
+                ironwood = ab.ironwood.maskIfStale(mask).toWalletBalance(),
                 unshielded = Zatoshi(ab.unshielded)
             )
     }

--- a/sdk-lib/src/main/java/com/zodl/slipstream/model/SlipstreamWalletSummary.kt
+++ b/sdk-lib/src/main/java/com/zodl/slipstream/model/SlipstreamWalletSummary.kt
@@ -37,12 +37,8 @@ data class SlipstreamAccountBalance(
     val accountUuid: ByteArray,
     val sapling: SlipstreamPoolBalance,
     val orchard: SlipstreamPoolBalance,
-    /**
-     * FORWARD FIELD: unspent Ironwood (Orchard note-version V3) outputs. Populated whenever the
-     * linked librustzcash generation is ironwood-capable; null only when the AAR's engine/JNI
-     * tag predates ironwood support (`FFI_JNI_CONTRACT.md` section 9.2).
-     */
-    val ironwood: SlipstreamPoolBalance?,
+    /** Unspent Ironwood (Orchard note-version V3) outputs; zero when the account holds none. */
+    val ironwood: SlipstreamPoolBalance,
     /** All unspent transparent outputs regardless of confirmations (zero-conf shieldable). */
     val unshielded: Long
 )
@@ -79,9 +75,5 @@ data class SlipstreamWalletSummary(
     val recoveryProgress: SlipstreamScanProgress?,
     val nextSaplingSubtreeIndex: Long,
     val nextOrchardSubtreeIndex: Long,
-    /**
-     * FORWARD FIELD: populated whenever the linked librustzcash generation is ironwood-capable;
-     * null only when the AAR's engine/JNI tag predates ironwood support.
-     */
-    val nextIronwoodSubtreeIndex: Long?
+    val nextIronwoodSubtreeIndex: Long
 )

--- a/sdk-lib/src/test/java/com/zodl/slipstream/internal/EngineMappingTest.kt
+++ b/sdk-lib/src/test/java/com/zodl/slipstream/internal/EngineMappingTest.kt
@@ -99,33 +99,51 @@ class EngineMappingTest {
                 recoveryProgress = null,
                 nextSaplingSubtreeIndex = 0,
                 nextOrchardSubtreeIndex = 0,
-                nextIronwoodSubtreeIndex = null
+                nextIronwoodSubtreeIndex = 0
             )
         val balances = summary.toAccountBalances(isRecovering = false, tipFresh = true)
         assertTrue(balances.containsKey(AccountUuid.new(uuidA)))
         assertTrue(balances.containsKey(AccountUuid.new(uuidB)))
     }
 
+    @Test
+    fun ironwood_balance_surfaces_when_tip_fresh() {
+        val uuid = ByteArray(16) { it.toByte() }
+        val summary =
+            summaryWith(
+                uuid,
+                sapling = SlipstreamPoolBalance(0, 0, 0),
+                ironwood = SlipstreamPoolBalance(99, 0, 0)
+            )
+
+        val balances = summary.toAccountBalances(isRecovering = false, tipFresh = true)
+        val balance = balances.getValue(AccountUuid.new(uuid))
+
+        assertEquals(99L, balance.ironwood.available.value)
+    }
+
     private fun accountBalance(
         uuid: ByteArray,
         sapling: SlipstreamPoolBalance,
         orchard: SlipstreamPoolBalance,
-        unshielded: Long
-    ) = SlipstreamAccountBalance(uuid, sapling, orchard, ironwood = null, unshielded = unshielded)
+        unshielded: Long,
+        ironwood: SlipstreamPoolBalance = SlipstreamPoolBalance(0, 0, 0)
+    ) = SlipstreamAccountBalance(uuid, sapling, orchard, ironwood = ironwood, unshielded = unshielded)
 
     private fun summaryWith(
         uuid: ByteArray,
         sapling: SlipstreamPoolBalance,
         orchard: SlipstreamPoolBalance = SlipstreamPoolBalance(0, 0, 0),
-        unshielded: Long = 0
+        unshielded: Long = 0,
+        ironwood: SlipstreamPoolBalance = SlipstreamPoolBalance(0, 0, 0)
     ) = SlipstreamWalletSummary(
-        accountBalances = arrayOf(accountBalance(uuid, sapling, orchard, unshielded)),
+        accountBalances = arrayOf(accountBalance(uuid, sapling, orchard, unshielded, ironwood)),
         chainTipHeight = 0,
         fullyScannedHeight = 0,
         scanProgress = null,
         recoveryProgress = null,
         nextSaplingSubtreeIndex = 0,
         nextOrchardSubtreeIndex = 0,
-        nextIronwoodSubtreeIndex = null
+        nextIronwoodSubtreeIndex = 0
     )
 }


### PR DESCRIPTION
The preceding commit wires the Ironwood pool balance and subtree index through the Slipstream walletSummary JNI but leaves both forward fields nullable (java/lang/Long boxing, JObject::null() in recovery, the Kotlin models' `?` plus EngineMapping's null-coalesce). That nullability is now vestigial: the whole dependency graph is force-pinned to one ironwood-capable librustzcash via [patch.crates-io], and the balance read walks the wallet DB directly (get_wallet_summary) independent of the slipstream-core engine tag, so the accessors are always present. Even pre-ironwood an account's Ironwood balance is definitionally zero, so null never carried information zero did not — it was a fossil of the era when slipstream-jni shipped as a separately -versioned .so, closed by the merge into backend-lib.

Flatten both fields to non-null: drop the java/lang/Long boxing (ctor descriptor ...JJJ)V), report a zero ironwood pool in the recovery branch instead of JObject::null() (still no double-count of the collapsed recovery net, since it emits zero rather than the ironwood balance), and drop EngineMapping's null-coalesce. Add a regression test that a real Ironwood balance surfaces.

<!-- Write any additional comments here when opening the pull request -->

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [ ] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [README.md](../blob/main/README.md), [Architecture.md](../blob/main/docs/Architecture.md), etc.)
- [ ] **Run the demo app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [README.md](../blob/main/README.md), [Architecture.md](/blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the demo app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the SDK, some aspects require manual testing. If you had to manually test 
something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the demo app to look for build failures or crashes, humans running the demo app are 
more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._