### PR TITLE
[#2032] AGENTS.md: semantic types and key-material redaction rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,12 +80,92 @@ git pull origin main
 git worktree add ../fix-something -b fix/something main
 ```
 
+## Security-critical API rules
+
+These rules exist because violations have shipped before. They are not
+stylistic.
+
+### Semantic types for public APIs (MUST)
+
+Every public API parameter that carries a domain value — key material,
+seeds, addresses, memos, account identifiers — MUST use its semantic
+wrapper type. Never accept or pass bare `String` or `ByteArray` for these
+values in the public surface. A primitive-typed parameter lets a typo or
+autocomplete slip a key into a memo field, and lets invalid input travel
+all the way to the Rust backend before failing.
+
+- Gold-standard pattern to copy: `UnifiedSpendingKey`
+  (`sdk-lib/.../sdk/model/UnifiedSpendingKey.kt`) — private constructor,
+  rust-backed validation on construction (`validateUnifiedSpendingKey`),
+  bytes held in `FirstClassByteArray`, and `toString()` redacted so the key
+  can never leak through logs. New key-material types MUST follow it.
+- Known weak spot: `UnifiedFullViewingKey` is currently a bare
+  `data class(val encoding: String)` with no construction-time validation.
+  Do not treat it as a pattern to copy; new or changed types must validate
+  on construction through the backend so invalid values are rejected before
+  reaching deeper API calls.
+- **All parsing and validation is librustzcash's job, surfaced through the
+  JNI layer.** NEVER implement your own inline parser, regex, prefix check,
+  or encoding check for key material or addresses in Kotlin. If the
+  validation entry point you need does not exist, expose the librustzcash
+  function through `backend-lib` (`Backend.kt`) and `TypesafeBackend`, and
+  call that.
+- Known gaps — do not extend them: seeds as raw `ByteArray`
+  (`DerivationTool`), addresses and memos as `String` on `Synchronizer`
+  (`proposeTransfer`, `validateAddress`, ...), and the UFVK as `String` in
+  `DerivationTool.deriveUnifiedAddress` / `derivePrivateUseMetadataKey`.
+  Any new API takes the semantic type; conversion from raw input happens at
+  the app-facing edge.
+- Reduction to raw `String`/`ByteArray` happens only in
+  `TypesafeBackendImpl` at the JNI boundary (e.g. `setup.ufvk.encoding`).
+  That is the existing pattern — keep it there and nowhere else.
+- This does not conflict with the "soft validation for `Jni*` classes" note
+  below: that note covers data flowing *out of* Rust into `Jni*` holders;
+  this section covers caller input flowing *toward* Rust.
+
+### Key material in errors and logs (MUST)
+
+- Rust side: NEVER interpolate caller-supplied input into `anyhow!` /
+  exception messages. Counterexample not to repeat: `parse_ufvk`
+  (`backend-lib/src/main/rust/lib.rs`) embeds the full input in
+  `Value "{ufvk_string}" did not decode as a valid UFVK`. The correct
+  pattern, used elsewhere in `lib.rs`, embeds only the error (`{:?}` on
+  `e`), never the input.
+- Kotlin side: exception messages must not splice `cause?.message` from JNI
+  `RuntimeException`s — those messages originate in Rust and may echo key
+  material. Counterexample: `InitializeException.ImportAccountException`
+  (`sdk-lib/.../exception/Exceptions.kt`) builds
+  `"... due to: ${cause?.message}"`. Keep the cause as the chained
+  throwable; keep the message fixed and generic.
+- Do not pass backend throwables to `Twig` whole (e.g.
+  `Twig.error(it) { ... }` on a JNI failure) — log a fixed message instead.
+  Users copy logs and error dialogs into support emails without knowing
+  what is embedded in them.
+- Changes to error paths that cross the JNI boundary must be checked on
+  both the Rust and Kotlin sides in lockstep, same as any other JNI change.
+
 ## Commit message conventions
 
-The project uses ticket-prefixed commit messages for tracked work, e.g.
-`MOB-1100: Fixed runtime crashes`. For untracked fixes, a short imperative
-prefix is acceptable (`fix: ...`, `chore: ...`). Keep the first line under
-72 characters; include context in the body.
+Tracked work uses ticket-prefixed commit messages. Two ticket systems are
+in use, and they are equivalent in format — reference whichever ticket the
+work was assigned from:
+
+- `MOB-1100: Fixed runtime crashes` — Linear tickets, internal to the
+  wallet team. A MOB- ticket may or may not have a correlated GitHub issue.
+- `[#258] Fixed runtime crashes` — GitHub issues (the format described in
+  `CONTRIBUTING.md`); use this when the work references a GitHub issue.
+
+For untracked fixes, a short imperative prefix is acceptable (`fix: ...`,
+`chore: ...`). Keep the first line under 72 characters; include context in
+the body.
+
+## PRs and changelog
+
+- PRs that reference a GitHub issue should link it (`[#issue]` in the
+  title/commits per `CONTRIBUTING.md`); PRs for Linear-tracked work
+  reference the MOB- ticket instead.
+- All enhancements and bug fixes need an entry in `CHANGELOG.md`
+  (see `CONTRIBUTING.md` and `docs/CODE_REVIEW_GUIDELINES.md`).
 
 ## Other notes
 
@@ -94,7 +174,10 @@ prefix is acceptable (`fix: ...`, `chore: ...`). Keep the first line under
   classes) require updating both sides in lockstep.
 - Detekt and ktlint are strict; treat their output as blocking. `detektAll`
   catches `MaxLineLength`, `ReturnCount`, `LongParameterList`, and similar
-  issues that won't be apparent from a plain `./gradlew build`.
+  issues that won't be apparent from a plain `./gradlew build`. Configs live
+  in `tools/detekt.yml` and `tools/.editorconfig`; the authoritative style
+  references are the Kotlin Coding Conventions and AOSP Java conventions
+  (see `docs/CODE_REVIEW_GUIDELINES.md`).
 - When touching `Jni*` data classes that are constructed from Rust via
   `env.new_object`, keep the JVM signature (`(JJJ)V` etc.) in sync and
   avoid adding `require` blocks that crash on edge-case inputs -- the


### PR DESCRIPTION
Closes #2032.

## Summary

Adds a **Security-critical API rules** section to `AGENTS.md` with two MUST-rules for coding agents:

- **Semantic types for public APIs** — every public API parameter carrying a domain value (key material, seeds, addresses, memos, account identifiers) must use its semantic wrapper type, never bare `String`/`ByteArray`. `UnifiedSpendingKey` is cited as the gold-standard pattern (private ctor, rust-backed validation on construction, `FirstClassByteArray`, redacted `toString()`); the hollow `UnifiedFullViewingKey` is called out as a pattern not to copy. All parsing/validation is librustzcash's job surfaced through the JNI layer — agents must never hand-roll parsers/regex/encoding checks in Kotlin; missing validation entry points get exposed through `Backend.kt`/`TypesafeBackend`. Includes a clarification that this doesn't conflict with the existing "soft validation for `Jni*` classes" note (that covers data flowing out of Rust; this covers caller input flowing toward Rust).
- **Key material in errors and logs** — no caller input in rust `anyhow!` messages (`parse_ufvk` is the counterexample: it embeds the full UFVK in `Value "{ufvk_string}" did not decode...`), no `cause?.message` splicing from JNI `RuntimeException`s (`ImportAccountException` counterexample), no whole backend throwables passed to `Twig`.

Also:
- Clarifies commit conventions: `MOB-` (Linear, wallet-team internal) and `[#issue]` (GitHub) are both valid — reference whichever ticket the work was assigned from; `fix:`/`chore:` stays for untracked fixes.
- Adds the `CHANGELOG.md` entry requirement and PR/issue linkage (from `CONTRIBUTING.md` / `docs/CODE_REVIEW_GUIDELINES.md`).
- Points at the lint configs (`tools/detekt.yml`, `tools/.editorconfig`) and the authoritative style references.

Docs-only change; no code is modified. Follow-up code fixes (validating `UnifiedFullViewingKey` on construction, de-echoing `parse_ufvk`, fixing `ImportAccountException`/`Twig.error`) will be filed separately. Note: `docs/Setup.md` still says "JVM 19 or greater", which is stale against the AGP-8.13 JDK 17/21 constraint documented here — left untouched in this PR.

## Test plan

Docs-only; no CHANGELOG entry since this is not an SDK behavior change. Spot-checked every file/symbol reference cited in the new sections against the current tree (`validateUnifiedSpendingKey`, `parse_ufvk` call sites, `derivePrivateUseMetadataKey`, `TypesafeBackendImpl` ufvk encoding site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N1aPHht8weWhi5owF7sjXj