### PR TITLE
Migrate to zcash_client_backend 0.24, zcash_primitives 0.29 et al.

### DIFF
--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -159,6 +159,8 @@ dependencies = [
  "tor-dirmgr",
  "tor-error",
  "tor-guardmgr",
+ "tor-hsclient",
+ "tor-hscrypto",
  "tor-keymgr",
  "tor-linkspec",
  "tor-llcrypto",
@@ -1101,7 +1103,7 @@ checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
  "heck",
  "indexmap 2.14.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -1215,7 +1217,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1445,8 +1447,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1465,7 +1466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1482,8 +1483,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1582,6 +1582,18 @@ name = "fluid-let"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "749cff877dc1af878a0b31a41dd221a753634401ea0ef2f87b62d3171522485a"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin",
+]
 
 [[package]]
 name = "fnv"
@@ -2375,7 +2387,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2591,6 +2603,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "ndk-sys"
 version = "0.5.0+25.2.9519653"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2662,7 +2683,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2813,9 +2834,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.14.0"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54f8d29bfb1e76a9d4e868a1a08cce2e57dd2bdc66232982822ad3114b91ab3"
+checksum = "793e2e8c2323f35f082d1b3467ca8f576d646f9c93aef8c5168809d099245af8"
 dependencies = [
  "aes",
  "bitvec",
@@ -2957,9 +2978,9 @@ dependencies = [
 
 [[package]]
 name = "pasta_curves"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
+checksum = "3437083215c505e867eea5478371feba43d7689d6d15ec0a209eb46fb0d4cda6"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -2978,9 +2999,8 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pczt"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4712bd8688e1d1aa0eb0e78dc5c846bc2d70dcd1de544ecf053516df174c4fcd"
+version = "0.8.0-rc.1"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -3112,9 +3132,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pir-client"
-version = "0.3.0"
+version = "0.4.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edef04868dc19983199d26c205129b86fd95e2856e3f7a7c096438e7debafb69"
+checksum = "666111370cf8a3fb2fa41a2442accc9d283226c1229828ff92c253dda1eb51e3"
 dependencies = [
  "anyhow",
  "ff",
@@ -3131,9 +3151,9 @@ dependencies = [
 
 [[package]]
 name = "pir-types"
-version = "0.2.0"
+version = "0.3.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27fca477d53f99bc04e449bb984231bb383c41ddc24a0304ecea48563c17e25b"
+checksum = "87a9ba9677931ac73da6d7726af28357da8f2e3d635a3e186c92a7f41382fe3e"
 dependencies = [
  "anyhow",
  "ff",
@@ -3347,7 +3367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -3366,7 +3386,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3753,7 +3773,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4149,9 +4169,9 @@ dependencies = [
 
 [[package]]
 name = "shardtree"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "359e552886ae54d1642091645980d83f7db465fd9b5b0248e3680713c1773388"
+checksum = "8147447aed7be4736e271825b8c3a4432efb7182e71363169b572371ddef452e"
 dependencies = [
  "bitflags",
  "either",
@@ -4282,7 +4302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4290,6 +4310,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -4457,7 +4480,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4884,6 +4907,7 @@ dependencies = [
  "tor-bytes",
  "tor-cert",
  "tor-error",
+ "tor-hscrypto",
  "tor-linkspec",
  "tor-llcrypto",
  "tor-memquota",
@@ -5083,6 +5107,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tor-circmgr",
  "tor-error",
+ "tor-hscrypto",
  "tor-linkspec",
  "tor-llcrypto",
  "tor-netdoc",
@@ -5239,6 +5264,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "tor-hsclient"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c0438676badc6265d6f34ce91c9b50fdb4dfe89ab85795f013fbfa80614304"
+dependencies = [
+ "async-trait",
+ "derive-deftly",
+ "derive_more",
+ "educe",
+ "either",
+ "futures",
+ "itertools 0.14.0",
+ "oneshot-fused-workaround",
+ "postage",
+ "rand 0.9.4",
+ "retry-error",
+ "safelog",
+ "slotmap-careful",
+ "strum",
+ "thiserror 2.0.18",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-bytes",
+ "tor-cell",
+ "tor-checkable",
+ "tor-circmgr",
+ "tor-config",
+ "tor-dirclient",
+ "tor-error",
+ "tor-hscrypto",
+ "tor-keymgr",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-memquota",
+ "tor-netdir",
+ "tor-netdoc",
+ "tor-persist",
+ "tor-proto",
+ "tor-protover",
+ "tor-rtcompat",
+ "tracing",
+]
+
+[[package]]
 name = "tor-hscrypto"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5263,6 +5332,7 @@ dependencies = [
  "tor-error",
  "tor-key-forge",
  "tor-llcrypto",
+ "tor-memquota",
  "tor-units",
  "void",
 ]
@@ -5450,7 +5520,9 @@ dependencies = [
  "async-trait",
  "bitflags",
  "derive_more",
+ "digest 0.10.7",
  "futures",
+ "hex",
  "humantime",
  "itertools 0.14.0",
  "num_enum",
@@ -5458,8 +5530,10 @@ dependencies = [
  "serde",
  "strum",
  "thiserror 2.0.18",
+ "time",
  "tor-basic-utils",
  "tor-error",
+ "tor-hscrypto",
  "tor-linkspec",
  "tor-llcrypto",
  "tor-netdoc",
@@ -5490,6 +5564,7 @@ dependencies = [
  "memchr",
  "paste",
  "phf",
+ "rand 0.9.4",
  "serde",
  "serde_with",
  "signature",
@@ -5505,8 +5580,11 @@ dependencies = [
  "tor-cert",
  "tor-checkable",
  "tor-error",
+ "tor-hscrypto",
+ "tor-linkspec",
  "tor-llcrypto",
  "tor-protover",
+ "tor-units",
  "void",
  "weak-table",
  "zeroize",
@@ -5588,6 +5666,7 @@ dependencies = [
  "tor-checkable",
  "tor-config",
  "tor-error",
+ "tor-hscrypto",
  "tor-linkspec",
  "tor-llcrypto",
  "tor-log-ratelim",
@@ -6017,8 +6096,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vote-commitment-tree"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cac5881d522e752d764520d78b7a2fb674eaab4e394fabd1b976cf5f1a7a26c"
+source = "git+https://github.com/zodl-inc/zcash_voting.git?rev=a4daaf77f793b35a98a3d811b920a01b95fbfa7a#a4daaf77f793b35a98a3d811b920a01b95fbfa7a"
 dependencies = [
  "anyhow",
  "ff",
@@ -6034,8 +6112,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba358e900080169be7be851f4aab556b1c1e2ca3d195d71ad2ef5a71abd00f81"
+source = "git+https://github.com/zodl-inc/zcash_voting.git?rev=a4daaf77f793b35a98a3d811b920a01b95fbfa7a#a4daaf77f793b35a98a3d811b920a01b95fbfa7a"
 dependencies = [
  "base64",
  "ff",
@@ -6049,9 +6126,9 @@ dependencies = [
 
 [[package]]
 name = "voting-circuits"
-version = "0.8.0"
+version = "0.9.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d8bd9964ce4aef9152a66ad8950af529de4bbbd875bfd9e5d95534abc50df9"
+checksum = "1f116ea00a3fd0be51027a4d809953b88338020ac8f40ec9f5ec087b21a7a5c8"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -6256,7 +6333,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6834,9 +6911,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58342d0aaa8e2fa98849636f52800ac4bf020574c944c974742fc933db58cac2"
+version = "0.13.0"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
 dependencies = [
  "bech32",
  "bs58",
@@ -6848,9 +6924,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04583f0945d5ff80eee80c1844fb0af8b7cc46a0ac26d5e12c4ccd474bec0f03"
+version = "0.24.0-rc.1"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
 dependencies = [
  "arti-client",
  "base64",
@@ -6859,9 +6934,9 @@ dependencies = [
  "bls12_381",
  "bs58",
  "byteorder",
- "crossbeam-channel",
  "document-features",
  "dynosaur",
+ "flume",
  "fs-mistrust",
  "futures-util",
  "getset",
@@ -6891,7 +6966,6 @@ dependencies = [
  "shardtree",
  "subtle",
  "time",
- "time-core",
  "tokio",
  "tokio-rustls",
  "tonic",
@@ -6917,9 +6991,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a304b10b63df9df511ee198f9ffb14ccddd7a185e64fdb8bd65e8043c6e1258f"
+version = "0.22.0-rc.1"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
 dependencies = [
  "bip32",
  "bitflags",
@@ -6955,6 +7028,7 @@ dependencies = [
  "zcash_client_backend",
  "zcash_encoding",
  "zcash_keys",
+ "zcash_pool_migration_backend",
  "zcash_primitives",
  "zcash_protocol",
  "zcash_script",
@@ -6965,8 +7039,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
 dependencies = [
  "corez",
  "hex",
@@ -6975,9 +7048,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbcdfbb5c8edb247439d72a397abaae9b7dd14a1c070e7e4fc3536924f9065f"
+version = "0.15.0"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
 dependencies = [
  "bech32",
  "bip32",
@@ -7005,9 +7077,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_note_encryption"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77efec759c3798b6e4d829fcc762070d9b229b0f13338c40bf993b7b609c2272"
+checksum = "e1cb1b9170c94370e3d66c5cc0877661db743337588b64de7711239eed462198"
 dependencies = [
  "chacha20",
  "chacha20poly1305",
@@ -7017,10 +7089,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_pool_migration_backend"
+version = "0.1.0"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+dependencies = [
+ "corez",
+ "getset",
+ "libm",
+ "rand_core 0.6.4",
+ "zcash_primitives",
+ "zcash_protocol",
+]
+
+[[package]]
 name = "zcash_primitives"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c69e07f5eb3f682a6467b4b08ee4956f1acd1e886d70b21c4766953b3a1beba2"
+version = "0.29.0"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7049,9 +7133,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de6b0ca82e08a9d38b1121f87c5b180b5feac19fecba074cb582882210d2371"
+version = "0.29.0"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7071,9 +7154,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bec496a0bd62dae98c4b26f51c5dab112d0c5350bbc2ccfdfd05bb3454f714d"
+version = "0.10.0"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
 dependencies = [
  "corez",
  "document-features",
@@ -7110,9 +7192,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15df1908b428d4edeb7c7caae5692e05e2e92e5c38007a40b20ac098efdffd96"
+version = "0.9.0"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
 dependencies = [
  "bip32",
  "bs58",
@@ -7135,13 +7216,14 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0f6ac52e66228393eab773dcec0eacbb6e1c768e0b6e0675d89d3a78ef53f1"
+version = "1.0.0"
+source = "git+https://github.com/zodl-inc/zcash_voting.git?rev=a4daaf77f793b35a98a3d811b920a01b95fbfa7a#a4daaf77f793b35a98a3d811b920a01b95fbfa7a"
 dependencies = [
  "anyhow",
+ "base64",
  "blake2b_simd",
  "bytes",
+ "ed25519-dalek",
  "ff",
  "group",
  "halo2_gadgets",
@@ -7160,22 +7242,30 @@ dependencies = [
  "pczt",
  "pir-client",
  "pir-types",
+ "prost",
  "rand 0.8.6",
  "rusqlite",
+ "rustls",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "sinsemilla",
  "subtle",
  "thiserror 2.0.18",
  "tokio",
+ "tonic",
+ "uuid",
  "valar-spiral-rs",
  "valar-ypir",
  "vote-commitment-tree",
  "vote-commitment-tree-client",
  "voting-circuits",
+ "zcash_client_backend",
+ "zcash_client_sqlite",
  "zcash_keys",
  "zcash_primitives",
  "zcash_protocol",
+ "zeroize",
  "zip32",
 ]
 
@@ -7250,9 +7340,8 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fef061351aa99792deb8f62b00426863a317ca2cb124c9de85550e3ef0f0f2f"
+version = "0.9.0-rc.1"
+source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
 dependencies = [
  "base64",
  "nom",

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -17,12 +17,20 @@ android-test-fixtures = []
 
 [dependencies]
 # Zcash dependencies
-orchard = { version = "=0.14.0", features = ["unstable-voting-circuits"] }
-pczt = { version = "0.7", features = ["prover", "orchard", "sapling"] }
+orchard = { version = "0.15", features = ["unstable-voting-circuits"] }
+pczt = { version = "0.8.0-rc.1", features = ["prover", "orchard", "sapling"] }
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
-transparent = { package = "zcash_transparent", version = "0.8", default-features = false }
-zcash_address = "0.12"
-zcash_client_backend = { version = "0.23", features = [
+# zcash_transparent, zcash_address, zcash_client_backend, zcash_client_sqlite, zcash_primitives,
+# zcash_proofs and zcash_protocol are bumped to the minor line the librustzcash rev pinned in the
+# [patch.crates-io] block below actually publishes (0.9/0.13/0.24.0-rc.1/0.22.0-rc.1/0.29/0.29/0.10
+# respectively) so that patch block is actually used. A `[patch]` only replaces the resolved crate
+# when its version satisfies the requirement string declared here; a requirement that is only
+# compatible with the *published* generation the patch replaces makes cargo silently ignore the
+# patch for that crate and pull a second, unpatched copy from crates.io instead, splitting the
+# graph into two incompatible copies of the same types.
+transparent = { package = "zcash_transparent", version = "0.9", default-features = false }
+zcash_address = "0.13"
+zcash_client_backend = { version = "0.24.0-rc.1", features = [
     "orchard",
     "lightwalletd-tonic-tls-webpki-roots",
     "tor",
@@ -30,11 +38,11 @@ zcash_client_backend = { version = "0.23", features = [
     "unstable",
     "pczt",
 ] }
-zcash_client_sqlite = { version = "0.21", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
+zcash_client_sqlite = { version = "0.22.0-rc.1", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
 zcash_note_encryption = "0.4.1"
-zcash_primitives = "0.28"
-zcash_proofs = "0.28"
-zcash_protocol = "0.9"
+zcash_primitives = "0.29"
+zcash_proofs = "0.29"
+zcash_protocol = "0.10"
 zcash_script = "0.4"
 zip32 = "0.2"
 eip681 = "0.1.0"
@@ -99,27 +107,38 @@ xz2 = { version = "0.1", features = ["static"] }
 # The transitive `voting-circuits` dependency contains the share-reveal circuit
 # and the Poseidon-based `share_nullifier_hash` implementation:
 # https://github.com/valargroup/voting-circuits/blob/v0.8.0/voting-circuits/src/share_reveal/circuit.rs
-# Default features stay disabled. The `client-pir` feature is needed for
-# delegation proof precompute and proof generation. The `client-tree-sync`
-# feature is needed for vote commitment tree sync and VAN witnesses.
-# Expected PIR/tree-sync networking transitives include `pir-client`, `pir-types`,
-# `valar-ypir`, `valar-spiral-rs`, `vote-commitment-tree-client`, and
-# `hyper-rustls`.
-zcash_voting = { version = "=0.11.0", default-features = false, features = [
-    "client-pir",
-    "client-tree-sync",
-] }
+#
+# Bumped 0.11.0 -> 1.0.0 alongside the librustzcash generation bump: 0.11.0's `action.rs` calls
+# `pczt::Pczt::parse`/`extract_pczt_sighash` assuming the published pczt 0.7 signatures, which the
+# patched librustzcash rev changed. 1.0.0 also folded every previously-optional dependency
+# (pir-client, pir-types, valar-ypir, valar-spiral-rs, vote-commitment-tree(-client),
+# voting-circuits) into unconditional deps - it has no `features` table at all - so the former
+# `client-pir`/`client-tree-sync` feature list and `default-features = false` are dropped; those
+# capabilities are unconditionally compiled in now. The crates.io release of 1.0.0 pulls its own
+# zcash_protocol 0.9, so it is redirected to the zodl-inc fork in [patch.crates-io] below.
+zcash_voting = "1.0.0"
 
-## Uncomment this to test librustzcash changes locally
-#[patch.crates-io]
-#pczt = { package = "pczt", path = '../../clones/librustzcash/pczt' }
-#transparent = { package = "zcash_transparent", path = '../../clones/librustzcash/zcash_protocol' }
-#zcash_address = { path = '../../clones/librustzcash/components/zcash_address' }
-#zcash_client_backend = { path = '../../clones/librustzcash/zcash_client_backend' }
-#zcash_client_sqlite = { path = '../../clones/librustzcash/zcash_client_sqlite' }
-#zcash_primitives = { path = '../../clones/librustzcash/zcash_primitives' }
-#zcash_proofs = { path = '../../clones/librustzcash/zcash_proofs' }
-#zcash_protocol = { path = '../../clones/librustzcash/zcash_protocol' }
+[patch.crates-io]
+# Pin the whole librustzcash family to a single rev so every crate in the graph shares one copy of
+# each type. The published 0.24.0-rc.1 / 0.22.0-rc.1 generation is not yet fully released, so the
+# git rev is the only internally-consistent source for the set.
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+zip321 = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+pczt = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+equihash = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
+# Pin zcash_voting to the zodl-inc fork rev built against this same librustzcash rev, so it shares
+# one copy of zcash_protocol/orchard/zcash_keys with the patched graph (crates.io zcash_voting
+# 1.0.0 pulls its own zcash_protocol 0.9.0, splitting the graph) and exposes the API the voting
+# module is written against.
+zcash_voting = { git = "https://github.com/zodl-inc/zcash_voting.git", rev = "a4daaf77f793b35a98a3d811b920a01b95fbfa7a" }
 
 ## Uncomment this to test someone else's librustzcash changes in a branch
 #[patch.crates-io]

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -42,16 +42,17 @@ use zcash_address::{
 use zcash_client_backend::{
     address::{Address, UnifiedAddress},
     data_api::{
-        Account, AccountBalance, AccountBirthday, AccountPurpose, BirthdayError, InputSource,
-        OutputStatusFilter, SeedRelevance, TransactionDataRequest, TransactionStatus,
-        TransactionStatusFilter, TransparentKeyOrigin, TransparentOutputFilter,
-        WalletCommitmentTrees, WalletRead, WalletSummary, WalletWrite, Zip32Derivation,
+        Account, AccountBalance, AccountBirthday, AccountPurpose, BirthdayError, CoinbaseFilter,
+        InputSource, OutputStatusFilter, SeedRelevance, TransactionDataRequest, TransactionStatus,
+        TransactionStatusFilter, TransparentKeyOrigin, WalletCommitmentTrees, WalletRead,
+        WalletSummary, WalletWrite, Zip32Derivation,
         chain::{CommitmentTreeRoot, ScanSummary, scan_cached_blocks},
         scanning::{ScanPriority, ScanRange},
         wallet::{
             self, create_pczt_from_proposal, create_proposed_transactions,
             decrypt_and_store_transaction, extract_and_store_transaction_from_pczt,
-            input_selection::GreedyInputSelector, propose_shielding, propose_transfer,
+            input_selection::{GreedyInputSelector, LockFilter, SpendPolicy},
+            propose_shielding, propose_transfer,
         },
     },
     encoding::AddressCodec,
@@ -78,11 +79,11 @@ use zcash_client_sqlite::{
 use zcash_primitives::{
     block::BlockHash,
     merkle_tree::HashSer,
-    transaction::{Transaction, TxId},
+    transaction::{Transaction, TxId, components::orchard::bundle_version_for_branch},
 };
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::{
-    ShieldedProtocol,
+    ShieldedPool,
     consensus::{
         BlockHeight, BranchId, Network,
         Network::{MainNetwork, TestNetwork},
@@ -1119,7 +1120,10 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_getTotalT
                 &taddr,
                 target,
                 wallet::ConfirmationsPolicy::MIN,
-                TransparentOutputFilter::All,
+                CoinbaseFilter::AllTransparentOutputs,
+                // Balance display, not a spend selection - show the true total regardless of any
+                // lock another in-flight proposal might hold, matching pre-locking behavior.
+                LockFilter::Unfiltered,
             )
             .map_err(|e| anyhow!("Error while fetching verified balance: {}", e))?
             .iter()
@@ -1359,7 +1363,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_rewindToH
         let mut db_data = wallet_db(env, network, db_data)?;
 
         let height = BlockHeight::try_from(height)?;
-        let rewind_result = db_data.rewind_to_height(height);
+        let rewind_result = db_data.truncate_to_height(height);
 
         Ok(encode_rewind_result(env, height, rewind_result)?.into_raw())
     });
@@ -1965,6 +1969,9 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_putUtxo<'
                 script_pubkey,
             },
             Some(BlockHeight::from(height as u32)),
+            None,
+            None,
+            None,
         )
         .ok_or_else(|| anyhow!("UTXO is not P2PKH or P2SH"))?;
 
@@ -2051,7 +2058,7 @@ fn zip317_helper<DbT>(
         MultiOutputChangeStrategy::new(
             StandardFeeRule::Zip317,
             change_memo,
-            ShieldedProtocol::Orchard,
+            ShieldedPool::Orchard,
             DustOutputPolicy::default(),
             SplitPolicy::with_min_output_value(
                 NonZeroUsize::new(4).expect("4 is nonzero"),
@@ -2094,6 +2101,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeTr
             &change_strategy,
             request,
             wallet::ConfirmationsPolicy::default(),
+            &SpendPolicy::default(),
+            None,
             None,
         )
         .map_err(|e| anyhow!("Error creating transaction proposal: {}", e))?;
@@ -2156,6 +2165,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeTr
             &change_strategy,
             request,
             wallet::ConfirmationsPolicy::default(),
+            &SpendPolicy::default(),
+            None,
             None,
         )
         .map_err(|e| anyhow!("Error creating transaction proposal: {}", e))?;
@@ -2291,7 +2302,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeSh
             &from_addrs,
             account_uuid,
             confirmations_policy,
-            TransparentOutputFilter::All,
+            CoinbaseFilter::AllTransparentOutputs,
+            None,
         )
         .map_err(|e| anyhow!("Error while shielding transaction: {}", e))?;
 
@@ -2331,7 +2343,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_createPro
 
         let proposal = Proposal::decode(utils::java_bytes_to_rust(env, &proposal)?.as_slice())
             .map_err(|e| anyhow!("Invalid proposal: {}", e))?
-            .try_into_standard_proposal(&db_data)?;
+            .try_into_standard_proposal(&network, &db_data)?;
 
         let txids = create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
             &mut db_data,
@@ -2380,7 +2392,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_createPcz
 
         let proposal = Proposal::decode(utils::java_bytes_to_rust(env, &proposal)?.as_slice())
             .map_err(|e| anyhow!("Invalid proposal: {}", e))?
-            .try_into_standard_proposal(&db_data)?;
+            .try_into_standard_proposal(&network, &db_data)?;
 
         if proposal.steps().len() == 1 {
             let pczt = create_pczt_from_proposal::<_, _, Infallible, _, Infallible, _>(
@@ -2389,10 +2401,18 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_createPcz
                 account_id,
                 OvkPolicy::Sender,
                 &proposal,
+                None,
+                orchard::builder::BundleType::DEFAULT,
             )
             .map_err(|e| anyhow!("Error creating PCZT from single-step proposal: {}", e))?;
 
-            Ok(utils::rust_bytes_to_java(env, &pczt.serialize())?.into_raw())
+            Ok(utils::rust_bytes_to_java(
+                env,
+                &pczt
+                    .serialize()
+                    .map_err(|e| anyhow!("Failed to serialize PCZT: {:?}", e))?,
+            )?
+            .into_raw())
         } else {
             Err(anyhow!(
                 "Multi-step proposals are not yet supported for PCZT generation."
@@ -2439,7 +2459,13 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_redactPcz
             })
             .finish();
 
-        Ok(utils::rust_bytes_to_java(env, &pczt_with_proofs.serialize())?.into_raw())
+        Ok(utils::rust_bytes_to_java(
+            env,
+            &pczt_with_proofs
+                .serialize()
+                .map_err(|e| anyhow!("Failed to serialize PCZT: {:?}", e))?,
+        )?
+        .into_raw())
     });
     unwrap_exc_or(&mut env, res, ptr::null_mut())
 }
@@ -2486,11 +2512,21 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_addProofs
 
         let pczt = parse_pczt(env, pczt)?;
 
+        // The Orchard circuit version is fixed by the consensus branch under which the
+        // transaction will be mined; derive it from the branch id carried by the PCZT.
+        let orchard_circuit_version = BranchId::try_from(*pczt.global().consensus_branch_id())
+            .ok()
+            .and_then(|branch_id| bundle_version_for_branch(branch_id, orchard::ValuePool::Orchard))
+            .map(|bundle_version| bundle_version.circuit_version());
+
         let mut prover = Prover::new(pczt);
 
         if prover.requires_orchard_proof() {
+            let circuit_version = orchard_circuit_version.ok_or_else(|| {
+                anyhow!("PCZT requires an Orchard proof but its consensus branch does not support Orchard")
+            })?;
             prover = prover
-                .create_orchard_proof(&orchard::circuit::ProvingKey::build())
+                .create_orchard_proof(&orchard::circuit::ProvingKey::build(circuit_version))
                 .map_err(|e| anyhow!("Failed to create Orchard proof for PCZT: {:?}", e))?;
         }
         assert!(!prover.requires_orchard_proof());
@@ -2508,7 +2544,13 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_addProofs
 
         let pczt_with_proofs = prover.finish();
 
-        Ok(utils::rust_bytes_to_java(env, &pczt_with_proofs.serialize())?.into_raw())
+        Ok(utils::rust_bytes_to_java(
+            env,
+            &pczt_with_proofs
+                .serialize()
+                .map_err(|e| anyhow!("Failed to serialize PCZT: {:?}", e))?,
+        )?
+        .into_raw())
     });
     unwrap_exc_or(&mut env, res, ptr::null_mut())
 }
@@ -2554,7 +2596,9 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_extractAn
             &mut db_data,
             pczt,
             Some((&spend_vk, &output_vk)),
-            Some(&orchard::circuit::VerifyingKey::build()),
+            // Passing `None` lets the extractor build the verifying key for the
+            // circuit version fixed by the bundle's own `BundleVersion`.
+            None,
         )
         .map_err(|e| anyhow!("Failed to extract transaction from PCZT: {:?}", e))?;
 
@@ -3667,10 +3711,10 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_model_TorWalletClient_fet
 // Utility functions
 //
 
-fn parse_protocol(code: i32) -> anyhow::Result<ShieldedProtocol> {
+fn parse_protocol(code: i32) -> anyhow::Result<ShieldedPool> {
     match code {
-        2 => Ok(ShieldedProtocol::Sapling),
-        3 => Ok(ShieldedProtocol::Orchard),
+        2 => Ok(ShieldedPool::Sapling),
+        3 => Ok(ShieldedPool::Orchard),
         _ => Err(anyhow!("Shielded protocol not recognized: {code}")),
     }
 }

--- a/backend-lib/src/main/rust/tor.rs
+++ b/backend-lib/src/main/rust/tor.rs
@@ -91,7 +91,20 @@ impl TorRuntime {
     pub(crate) fn connect_to_lightwalletd(&self, endpoint: Uri) -> anyhow::Result<LwdConn> {
         let Self { runtime, client } = self.isolated_client();
 
-        let conn = runtime.block_on(async { client.connect_to_lightwalletd(endpoint).await })?;
+        // `allow_onion_services` used to be inferred internally by `zcash_client_backend` from
+        // the endpoint host; it's now an explicit caller decision, so re-derive the same `.onion`
+        // check here to keep supporting custom onion lightwalletd servers without changing this
+        // method's signature.
+        let allow_onion_services = endpoint
+            .host()
+            .map(|h| h.ends_with(".onion"))
+            .unwrap_or(false);
+
+        let conn = runtime.block_on(async {
+            client
+                .connect_to_lightwalletd(endpoint, allow_onion_services)
+                .await
+        })?;
 
         Ok(LwdConn {
             runtime,
@@ -168,13 +181,13 @@ impl LwdConn {
 
     /// Calls the given closure with UTXOS corresponding to the given t-address within the given
     /// block range.
-    pub(crate) fn with_taddress_utxos(
+    pub(crate) fn with_taddress_utxos<AccountId>(
         &mut self,
         params: &impl consensus::Parameters,
         address: TransparentAddress,
         start: Option<BlockHeight>,
         limit: Option<u32>,
-        mut f: impl FnMut(WalletTransparentOutput) -> anyhow::Result<()>,
+        mut f: impl FnMut(WalletTransparentOutput<AccountId>) -> anyhow::Result<()>,
     ) -> anyhow::Result<()> {
         let request = service::GetAddressUtxosArg {
             addresses: vec![address.encode(params)],
@@ -197,6 +210,9 @@ impl LwdConn {
                         Script(script::Code(result.script)),
                     ),
                     Some(BlockHeight::from(u32::try_from(result.height)?)),
+                    None,
+                    None,
+                    None,
                 )
                 .ok_or(anyhow!(
                     "Received UTXO that doesn't correspond to a valid P2PKH or P2SH address"

--- a/backend-lib/src/main/rust/voting.rs
+++ b/backend-lib/src/main/rust/voting.rs
@@ -26,7 +26,7 @@ use voting::storage::{RoundPhase, RoundState, RoundSummary, VoteRecord, VotingDb
 use voting::tree_sync::VoteTreeSync;
 use voting::types::{
     DelegationPirPrecomputeResult, DelegationProofResult, DelegationSubmissionData, GovernancePczt,
-    NoopProgressReporter, NoteInfo, ProofProgressReporter, SharePayload, VoteCommitmentBundle,
+    NoopProgressReporter, NoteInfo, ProgressReporter, SharePayload, VoteCommitmentBundle,
     WireEncryptedShare, WitnessData,
 };
 

--- a/backend-lib/src/main/rust/voting/helpers.rs
+++ b/backend-lib/src/main/rust/voting/helpers.rs
@@ -556,7 +556,7 @@ pub(super) fn java_witness_data(
 pub(super) fn java_van_witness(
     env: &mut JNIEnv<'_>,
     witness: &JObject<'_>,
-) -> anyhow::Result<voting::tree_sync::VanWitness> {
+) -> anyhow::Result<voting::vote::VanWitness> {
     let auth_path = java_byte_array_list_field(env, witness, "authPath")?;
     if auth_path.len() != VAN_WITNESS_PATH_DEPTH {
         return Err(anyhow!(
@@ -571,7 +571,7 @@ pub(super) fn java_van_witness(
         .map(|(index, bytes)| fixed_bytes(bytes, &format!("authPath[{index}]")))
         .collect::<anyhow::Result<Vec<_>>>()?;
 
-    Ok(voting::tree_sync::VanWitness {
+    Ok(voting::vote::VanWitness {
         auth_path,
         position: jlong_to_u32(env.get_field(witness, "position", "J")?.j()?, "position")?,
         anchor_height: jlong_to_u32(
@@ -1129,7 +1129,7 @@ fn make_jni_witness_data<'local>(
 // stay explicit instead of being modeled as TryFrom conversions.
 pub(super) fn make_jni_van_witness<'local>(
     env: &mut JNIEnv<'local>,
-    witness: voting::tree_sync::VanWitness,
+    witness: voting::vote::VanWitness,
 ) -> anyhow::Result<jobject> {
     let class = env.find_class(JNI_VAN_WITNESS)?;
     let auth_path = witness
@@ -1728,7 +1728,7 @@ fn make_jni_fixed_byte_array_vec<'local>(
 /// Runs the voting note chunker and returns total count, total eligible weight,
 /// and each bundle's quantized voting weight.
 pub(super) fn bundle_setup_from_notes(notes: &[NoteInfo]) -> anyhow::Result<(u32, u64, Vec<u64>)> {
-    let chunk_result = voting::types::chunk_notes(notes);
+    let chunk_result = voting::note_bundling::chunk_notes(notes);
     let bundle_weights = chunk_result
         .bundles
         .iter()
@@ -1753,7 +1753,7 @@ pub(super) fn bundled_notes_for_index(
     notes: &[NoteInfo],
     bundle_index: u32,
 ) -> anyhow::Result<Vec<NoteInfo>> {
-    let chunk_result = voting::types::chunk_notes(notes);
+    let chunk_result = voting::note_bundling::chunk_notes(notes);
     let bundle_index = usize::try_from(bundle_index)
         .map_err(|_| anyhow!("bundle_index is too large for this platform: {bundle_index}"))?;
 

--- a/backend-lib/src/main/rust/voting/progress.rs
+++ b/backend-lib/src/main/rust/voting/progress.rs
@@ -9,7 +9,9 @@ struct JniProgressReporter {
     callback: GlobalRef,
 }
 
-impl ProofProgressReporter for JniProgressReporter {
+// zcash_voting 1.0.0 renamed this trait from `ProofProgressReporter` to `ProgressReporter`;
+// the single `on_progress(&self, progress: f64)` method is unchanged.
+impl ProgressReporter for JniProgressReporter {
     fn on_progress(&self, progress: f64) {
         // zcash_voting 0.5.9 calls this at coarse milestones outside the spawned
         // Halo2 proving closure. Attach on each callback so the bridge remains
@@ -34,7 +36,7 @@ impl ProofProgressReporter for JniProgressReporter {
 pub(super) fn progress_reporter_from_callback(
     env: &mut JNIEnv<'_>,
     callback: &JObject<'_>,
-) -> anyhow::Result<Box<dyn ProofProgressReporter>> {
+) -> anyhow::Result<Box<dyn ProgressReporter>> {
     if callback.is_null() {
         Ok(Box::new(NoopProgressReporter))
     } else {

--- a/backend-lib/src/main/rust/voting/share_tracking.rs
+++ b/backend-lib/src/main/rust/voting/share_tracking.rs
@@ -16,13 +16,17 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_com
     blind: JByteArray<'local>,
 ) -> jbyteArray {
     let res = catch_unwind(&mut env, |env| {
-        let nullifier = voting::share_tracking::compute_share_nullifier(
+        // zcash_voting 1.0.0 moved this from `share_tracking::compute_share_nullifier` to
+        // `share::compute_nullifier`, and tightened its return type from `Vec<u8>` to
+        // `[u8; SHARE_NULLIFIER_BYTES]`, so the length check below is now done by the type
+        // system. The (vote_commitment, share_index, primary_blind) argument shape is
+        // unchanged, so the JNI signature is unaffected.
+        let nullifier = voting::share::compute_nullifier(
             &java_fixed_bytes::<VOTE_COMMITMENT_BYTES>(env, &vote_commitment, "voteCommitment")?,
             jint_to_u32(share_index, "share_index")?,
             &java_fixed_bytes::<BLIND_BYTES>(env, &blind, "blind")?,
         )
         .map_err(|e| anyhow!("compute_share_nullifier: {}", e))?;
-        let nullifier = fixed_bytes::<SHARE_NULLIFIER_BYTES>(nullifier, "shareNullifier")?;
         Ok(env.byte_array_from_slice(&nullifier)?.into_raw())
     });
     unwrap_exc_or(&mut env, res, std::ptr::null_mut())

--- a/backend-lib/src/main/rust/voting/util.rs
+++ b/backend-lib/src/main/rust/voting/util.rs
@@ -14,6 +14,10 @@ fn tree_state_fixture(orchard_tree: String) -> zcash_client_backend::proto::serv
         time: 0,
         sapling_tree: String::new(),
         orchard_tree,
+        // New field on the lightwalletd `TreeState` message in this librustzcash generation.
+        // This branch's voting notes are still Orchard notes, so the fixture leaves the
+        // Ironwood tree empty and keeps populating `orchard_tree` as before.
+        ironwood_tree: String::new(),
     }
 }
 

--- a/backend-lib/src/main/rust/voting/vote.rs
+++ b/backend-lib/src/main/rust/voting/vote.rs
@@ -154,7 +154,7 @@ fn require_delegation_ready_for_vote(
     db: &VotingDbHandle,
     round_id: &str,
     bundle_index: u32,
-    witness: &voting::tree_sync::VanWitness,
+    witness: &voting::vote::VanWitness,
 ) -> anyhow::Result<()> {
     // Callers hold VotingDbHandle::access_lock while this read-check sequence
     // runs. Managed handles for the same DB path and wallet share that lock, so


### PR DESCRIPTION
Moves `prerelease/snapshot-v2.6.6` from the zcash_client_backend 0.23
generation onto the 0.24.0-rc.1 one, pinned by git rev, so Ironwood support and
the Orchard-to-Ironwood migration can be backported afterwards. This is the
dependency migration only; no Ironwood, no migration engine, no Slipstream.

The work is extracted from #2021 (`android-slipstream-ironwood-chp`), where the
same migration is entangled across three feature commits: `3153bd9a`
(noop-sk, migration engine), `6ea9fb2e` (Nesence, Slipstream) and `1185ac9a`
(Kris Nuttycombe, Ironwood pin advance). Credit for the underlying dependency
and API work belongs to them; every commit here carries them as co-authors.

## Status: BLOCKED, do not merge, decision needed

`cargo check --lib` does **not** pass yet. The non-voting surface is fully
migrated and clean; the voting JNI layer does not compile, and finishing it is a
design decision rather than a mechanical adaptation. Details in
"The voting blocker" below.

## What is done

`backend-lib/Cargo.toml`, `Cargo.lock`, `lib.rs`, `tor.rs` and the
rename-level drift in `voting/` are migrated. Zero errors and zero warnings
outside the voting module.

Version requirements are bumped alongside the new `[patch.crates-io]` block
rather than left on the old minor lines. A `[patch]` only replaces the resolved
crate when its version satisfies the requirement declared in `[dependencies]`;
a requirement only compatible with the published generation the patch replaces
makes cargo silently ignore the patch and pull a second, unpatched copy from
crates.io, splitting the graph into two incompatible copies of the same types.

Deliberately **not** brought across from #2021, because nothing on this branch
needs them: `zcash_pool_migration_backend`, `slipstream-core`, `tokio`,
`tracing-android`, `ur`, `ur-registry`, `shardtree`, and the `signer` feature on
`pczt`. `incrementalmerkletree` is kept because `voting/notes.rs` uses it.

### librustzcash API changes adapted

| Change | Resolution |
| --- | --- |
| `TransparentOutputFilter` -> `CoinbaseFilter` | `::All` -> `::AllTransparentOutputs` |
| `WalletDb::rewind_to_height` | -> `truncate_to_height` |
| `WalletTransparentOutput` generic over `AccountId`; `from_parts` gained `recipient_account`, `recipient_key_scope`, `funding_account` | JNI and Tor UTXO paths have none of them; pass `None`. `LwdConn::with_taddress_utxos` becomes generic over `AccountId` |
| `get_spendable_transparent_outputs` gained a `LockFilter` | `LockFilter::Unfiltered`: the one caller is a balance display, not a spend selection, so it must report the true total regardless of any lock an in-flight proposal holds |
| `propose_transfer` gained `&SpendPolicy` and `lock_inputs` | `SpendPolicy::default()` preserves the previous fully-shielded selection; `None` takes no locks |
| `propose_shielding` gained `lock_inputs` | `None` |
| `Proposal::try_into_standard_proposal` gained consensus parameters | pass `&network` |
| `create_proposed_transactions`' last argument | now an optional expiry height rather than a proposed tx version; `None` preserves behaviour either way |
| `create_pczt_from_proposal` gained a target expiry height and an Orchard `BundleType` | `None` and `BundleType::DEFAULT` |
| `Pczt::serialize` returns a `Result` | mapped into the existing `anyhow` error path at all three call sites |
| Orchard `ProvingKey::build` takes an `OrchardCircuitVersion` | derived from the consensus branch carried by the PCZT via `bundle_version_for_branch` |
| Orchard `VerifyingKey::build` likewise | pass `None` so the extractor derives it from the bundle's own `BundleVersion` |
| `ShieldedProtocol` -> `ShieldedPool` | rename |
| `connect_to_lightwalletd` gained `allow_onion_services` | re-derive the same `.onion` host check at the call site, so custom onion lightwalletd servers keep working without changing the wrapper's signature |
| lightwalletd `TreeState` gained `ironwood_tree` | the `android-test-fixtures` fixture leaves it empty and keeps populating `orchard_tree`; this branch's voting notes are still Orchard notes |

Each follows #2021's resolution, so the two branches stay convergent. Most also
match `maint/v2.5.x` `4843902c`; the note-locking arguments, `LockFilter`,
`allow_onion_services` and `ironwood_tree` are newer than that commit's pin and
follow #2021 only.

### zcash_voting 1.0 rename-level drift adapted

`types::ProofProgressReporter` -> `types::ProgressReporter`;
`share_tracking::compute_share_nullifier` -> `share::compute_nullifier` (return
type tightened from `Vec<u8>` to a fixed-size array, so the explicit length
check is now done by the type system); `tree_sync::VanWitness` ->
`vote::VanWitness`; `types::chunk_notes` -> `note_bundling::chunk_notes`.

## The voting blocker

On this branch voting is **not** feature-gated: `zcash_voting` is a hard
dependency and `voting.rs` plus its 12 submodules compile unconditionally. So
unlike #2021 (which made `chp-voting` optional and off by default) the voting
code must compile against the new stack.

`zcash_voting` 1.0 is a deliberate breaking redesign (`0b5fffb feat!: v2 voting
api`), landed *before* the librustzcash realignment, so no fork rev exists that
carries the old 0.11 API on the new librustzcash. Keeping 0.11 unpatched is not
an option either: it pins orchard 0.14 / zcash_protocol 0.9 / pczt 0.7 and would
split the graph.

20 errors remain, all in `voting/`. They are not renames:

- `decompose::decompose_weight` was **deleted** from the crate.
- `vote_commitment::sign_cast_vote` and `hotkey::spending_key_from_hotkey_seed`
  became `pub(crate)`, so `signCastVoteNative` has no public path and cannot be
  reimplemented locally without duplicating hotkey derivation.
- `VotingDb` lost or privatised `setup_bundles`, `generate_hotkey`,
  `store_vote_tx_hash`, `store_commitment_bundle`, `get_delegation_submission`,
  `get_delegation_submission_with_keystone_sig`, `build_vote_commitment` and
  `record_share_delegation`, replaced by a different composition
  (`CommittedVote`, `VoteRecovery`, `VoteSigner`,
  `get_delegation_submission_with_signature`).
- `VotingHotkey` is now opaque (was a struct with `secret_key` / `public_key` /
  `address` fields), `VoteRecord` lost `submitted`, and `VanWitness::auth_path`
  changed element type.

#2021's port of this **does** compile (verified: `cargo check --lib --features
chp-voting` on `android-slipstream-ironwood-chp` is clean and warning-free), so
a working reference exists. But adopting it is a design change, not a
dependency bump:

1. **It changes the JNI ABI.** #2021 removes `decomposeWeightNative`,
   `signCastVoteNative` and `storeCommitmentBundleNative`, adds
   `recordVcPositionNative`, `recoverCommittedVoteNative` and
   `scheduledShareSubmitAtNative`, and changes `buildVoteCommitmentNative`'s
   parameter list. Kotlin binds by symbol name and resolves lazily, so this
   needs lockstep changes in `VotingRustBackend.kt`,
   `TypesafeVotingBackend.kt`, `TypesafeVotingBackendImpl.kt` and the
   androidTest sources.
2. **It changes hotkey key management.** `buildVoteCommitmentNative` moves from
   a wallet-derived `hotkey_seed` to a 64-byte stored hotkey secret produced by
   `generate_random_voting_hotkey`. That is a change to what secret material
   callers must hold and persist, with a migration implication for existing
   users. It must not ride along inside a dependency bump.

### Options

- **A. Port voting to the v2 API following #2021.** Yields a fully working
  branch, keeps convergence with #2021, but pulls in the ABI and hotkey
  key-management changes above plus their Kotlin lockstep, and imports Ironwood
  semantics this branch otherwise does not have.
- **B. Feature-gate voting off by default, as #2021 did.** Makes
  `cargo check --lib` clean immediately and keeps this PR a true dependency
  bump, deferring the voting port to its own reviewed PR. This is the
  recommended option, but it is a design change to this branch's shape and is
  not being done unilaterally.

## Validation

- `cargo check --lib` — 20 errors, all in `voting/`; zero errors and zero
  warnings elsewhere.
- `cargo check --lib --all-features` — same 20; the `android-test-fixtures`
  `TreeState` fixture is fixed and no longer contributes errors.
- `cargo fmt --check` — clean (plain `cargo fmt`, repo-pinned toolchain, never
  `+nightly`).
- `cargo test --lib` — cannot run until the crate compiles.
- **JNI export symbol diff: empty.** All 138 `Java_*` exports are byte-identical
  to `origin/prerelease/snapshot-v2.6.6` at source level, so no Kotlin change is
  required by anything in this PR. (Compared from source rather than from `nm`,
  since the cdylib cannot be linked yet.)
