### PR TITLE
Port CI managed-device, TreeState proto citation, and compile-locally docs from maint/v2.5.x

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -352,26 +352,11 @@ jobs:
           name: Test Android modules with FTL results
           path: ~/artifacts
 
-  # DISABLED: the emulator.wtf organization has exhausted its credits, so this job fails on every
-  # run with `Http error 402: You've run out of free credits on emulator.wtf`. The plugin then
-  # parses that error body as a test-run response, so what actually surfaces is the misleading
-  # `com.google.gson.JsonSyntaxException: Missing required properties: testRunId`. Nothing about
-  # the build or the tests is wrong.
-  #
-  # To re-enable: configure billing at
-  # https://emulator.wtf/o/005b7bef-ece6-4af6-a3e6-62c245489044/billing, then restore the
-  # `if:` condition recorded below.
-  #
-  # Note that disabling this does NOT fall back to Firebase Test Lab: test_android_modules_ftl is
-  # gated on the emulator.wtf API key being *absent*, and the key is still set — it is the credits
-  # that ran out. Device-test coverage is therefore zero, which is unchanged from the status quo
-  # (the job was already failing rather than testing), but it is zero rather than merely red.
-  # Removing EMULATOR_WTF_API_KEY from the repository secrets would route these tests to FTL
-  # instead, if that tradeoff is preferred over fixing the billing.
-  test_android_modules_wtf:
-    # Original condition: needs.check_emulator_wtf_secrets.outputs.has-secrets == 'true'
-    if: false
-    needs: [ validate_gradle_wrapper, check_emulator_wtf_secrets ]
+  # Runs the Android instrumentation suites on a Gradle Managed Device: a
+  # hardware-accelerated emulator booted inside the runner. This replaces the
+  # former emulator.wtf cloud job and depends on no external test service.
+  test_android_modules_emulator:
+    needs: [validate_gradle_wrapper]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -383,6 +368,15 @@ jobs:
           # No job here pushes or otherwise re-uses the checkout credential, so keep it
           # out of .git/config where it would be picked up by artifact uploads.
           persist-credentials: false
+      # ubuntu-latest exposes /dev/kvm, but the default udev rules do not grant
+      # the runner user access to it. This rule opens it so the managed-device
+      # emulator can use KVM acceleration instead of falling back to software.
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Setup
         id: setup
         timeout-minutes: 30
@@ -391,12 +385,38 @@ jobs:
           rust-cache: true
           slipstream-app-id: ${{ secrets.SLIPSTREAM_APP_ID }}
           slipstream-app-private-key: ${{ secrets.SLIPSTREAM_APP_PRIVATE_KEY }}
-      - name: Build and test
-        timeout-minutes: 30
-        env:
-          ORG_GRADLE_PROJECT_ZCASH_EMULATOR_WTF_API_KEY: ${{ secrets.EMULATOR_WTF_API_KEY }}
+      # The hosted runner's Android SDK does not include the emulator package,
+      # which a Gradle Managed Device requires. AGP auto-installs the system
+      # image but not the emulator, so without this the pixel2MinSetup task
+      # fails at VersionedSdkLoader.getEmulatorDirectoryProvider().get() with
+      # "Cannot query the value of this property because it has no value
+      # available". Install it explicitly.
+      - name: Install Android emulator
+        timeout-minutes: 5
         run: |
-          ./gradlew testDebugWithEmulatorWtf
+          yes | "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" "emulator"
+      # pixel2Min is the Gradle Managed Device defined in
+      # zcash-sdk.android-conventions.gradle.kts (Pixel 2, API ANDROID_MIN_SDK_VERSION).
+      # Scoped to the same four modules the former emulator.wtf job covered;
+      # the unqualified task would also pull in darkside-test-lib (needs a live
+      # darkside server) and the demo-app modules. maxConcurrentDevices=1 keeps a
+      # single emulator booted at a time so the runner is not overwhelmed by four
+      # parallel emulators; in-runner emulators run serially, hence the higher
+      # timeout than the former cloud job.
+      # emulator.gpu=swiftshader_indirect forces software rendering. The hosted
+      # runner is headless, and AGP's default '-gpu auto-no-window' intermittently
+      # falls back to 'auto', which needs a real GPU and fails to boot the
+      # emulator (EmulatorStartFailedException during snapshot creation).
+      - name: Build and test
+        timeout-minutes: 45
+        run: |
+          ./gradlew \
+            :sdk-lib:pixel2MinDebugAndroidTest \
+            :lightwallet-client-lib:pixel2MinDebugAndroidTest \
+            :sdk-incubator-lib:pixel2MinDebugAndroidTest \
+            :backend-lib:pixel2MinDebugAndroidTest \
+            -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=1 \
+            -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect
       - name: Collect Artifacts
         if: ${{ always() }}
         timeout-minutes: 1
@@ -406,13 +426,19 @@ jobs:
         run: |
           mkdir ${ARTIFACTS_DIR_PATH}
 
-          zip -r ${TEST_RESULTS_ZIP_PATH} . -i \*/build/test-results/\*
+          # Managed-device runs write results/reports under build/outputs and
+          # build/reports/androidTests, not build/test-results, so include those
+          # too to make failures inspectable from the artifact.
+          zip -r ${TEST_RESULTS_ZIP_PATH} . \
+            -i \*/build/test-results/\* \
+            \*/build/outputs/androidTest-results/\* \
+            \*/build/reports/androidTests/\*
       - name: Upload Artifacts
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         timeout-minutes: 1
         with:
-          name: Test Android modules with WTF results
+          name: Test Android modules with emulator results
           path: ~/artifacts
 
   demo_app_release_build:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ jobs that are runnable on a dev machine:
 
 ```bash
 ./scripts/ci-local.sh fast     # detekt + ktlint (~30s) -- run this first
-./scripts/ci-local.sh quick    # fast + unit tests (~2-5m)
+./scripts/ci-local.sh quick    # fast + unit tests (~5m)
 ./scripts/ci-local.sh full     # everything, including androidTest (~15-30m)
 
 # Or a single stage when iterating:
@@ -22,12 +22,29 @@ jobs that are runnable on a dev machine:
 ./scripts/ci-local.sh demoapp
 ```
 
+`quick` is what actually compiles the Kotlin: `fast` only runs static
+analysis, so it will pass on code that does not compile. Run at least `quick`
+after any change to a Kotlin source file.
+
 ### Environment requirements
 
 - **JDK 17 or 21.** Android Gradle Plugin 8.13.x does not support JDK 25+.
   If your default `java -version` reports 25 or newer, install JDK 21 via
   Homebrew (`brew install openjdk@21`) or SDKMAN! and set `JAVA_HOME` before
   running the script.
+
+  On a machine where `java` is not on `PATH` at all (common on macOS, where
+  the JDK is installed but not linked), export it for the command:
+
+  ```bash
+  export JAVA_HOME=/opt/homebrew/opt/openjdk@21          # brew install openjdk@21
+  export PATH="$JAVA_HOME/bin:$PATH"
+  export ANDROID_HOME="$HOME/Library/Android/sdk"
+  ./scripts/ci-local.sh quick
+  ```
+
+  Android Studio's bundled runtime works too, if you prefer not to install a
+  second JDK: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`.
 - **Android SDK** at `$ANDROID_HOME` or `~/Library/Android/sdk`.
 - For the `androidtest` stage on Apple Silicon, the `aosp` SDK-36 Pixel 2
   system image is downloaded on first run (~1.5 GB).
@@ -92,6 +109,16 @@ prefix is acceptable (`fix: ...`, `chore: ...`). Keep the first line under
 - The SDK and related libraries are Kotlin + Rust. Changes that cross the
   JNI boundary (`backend-lib/src/main/rust/*` and the Kotlin `Jni*` model
   classes) require updating both sides in lockstep.
+- The Rust backend is fastest to check on its own, without Gradle or a JDK:
+
+  ```bash
+  cd backend-lib && cargo check --lib && cargo fmt --check
+  ```
+
+  Note this only proves the Rust compiles. A JNI signature mismatch between
+  Rust and Kotlin is a *runtime* crash, not a compile error on either side,
+  so a Rust-only change that touches a `Java_*` export or an
+  `env.new_object` type signature still needs `./scripts/ci-local.sh quick`.
 - Detekt and ktlint are strict; treat their output as blocking. `detektAll`
   catches `MaxLineLength`, `ReturnCount`, `LongParameterList`, and similar
   issues that won't be apparent from a plain `./gradlew build`.

--- a/lightwallet-client-lib/src/main/proto/service.proto
+++ b/lightwallet-client-lib/src/main/proto/service.proto
@@ -111,6 +111,8 @@ message Exclude {
 
 // The TreeState is derived from the Zcash z_gettreestate rpc.
 message TreeState {
+    // The field numbers below must follow lightwalletd's generated bindings:
+    // https://github.com/zcash/lightwalletd/blob/master/walletrpc/service.pb.go
     string network = 1;     // "main" or "test"
     uint64 height = 2;      // block height
     string hash = 3;        // block id


### PR DESCRIPTION
Human comment: simple PR. I've got agents backporting changes from 2.5.x

-----------------

Ports three self-contained changes that landed on `maint/v2.5.x` but are not
yet on this branch, per the standing "maint changes get backported" rule. Each
is its own commit with `Backport-of` / `Backport-method` trailers.

## What's ported

1. **CI: replace the emulator.wtf job with a Gradle Managed Device**
   (`Backport-of: 5b8a5a22`). Replaces `test_android_modules_wtf`
   (`testDebugWithEmulatorWtf`, needs a paid `EMULATOR_WTF_API_KEY`) with
   `test_android_modules_emulator`, which runs the four instrumentation suites
   on the `pixel2Min` Gradle Managed Device already defined in
   `zcash-sdk.android-conventions.gradle.kts`. This is what keeps CI from
   staying red on the emulator.wtf service failure.
2. **Cite lightwalletd's bindings for the TreeState field numbers**
   (`Backport-of: 3e0a21d2`). Two-line comment in `service.proto`.
3. **AGENTS.md: document how to compile locally** (`Backport-of: cf187eae`).
   Adds the "`quick` compiles the Kotlin", the java-not-on-`PATH` export block,
   and the `cargo check --lib` Rust shortcut with the JNI-mismatch-is-a-runtime-
   crash caveat.

## Not a clean cherry-pick (why the trailers say "reimplemented")

- **CI**: this branch's `pull-request.yml` has diverged from maint's, with
  different `actions/checkout` and `actions/upload-artifact` pins and a
  `rust-cache: true` Setup input. The job semantics are transplanted while
  keeping this branch's own pins. Only the wtf job is replaced; the
  `check_emulator_wtf_secrets` job and the Firebase Test Lab job are left
  exactly as maint left them.
- **AGENTS.md**: this branch's `AGENTS.md` has diverged (it carries the
  worktree-layout and commit-convention sections maint lacks), so the guidance
  is applied at matching anchors.
- The proto change is textually identical to maint's, hence `cherry-pick`.

## Known follow-up (deliberately not in this PR)

`AGENTS.md` still references the now-removed `test_android_modules_wtf` job and
"paid services (`emulator.wtf`)" (the intro and the "What cannot be run locally"
section). Those were left untouched here to keep commit 3 a faithful port of
`cf187eae`; happy to fold a consistency update in if preferred.

## Verification

`pull-request.yml` parses as valid YAML and the jobs list resolves to
`test_android_modules_emulator` (wtf job gone, FTL + secret-check unchanged).
