### PR TITLE
Move backend-lib onto the published post-RC librustzcash crates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,9 @@ fastlane/readme.md
 # Rust / Cargo
 fraget/
 
+# Claude Code local config and agent worktrees
+.claude/
+
 # other
 DecompileChecker.kt
 backup-dbs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Updated the librustzcash crates to their published releases,
+  `zcash_client_backend 0.24.0-rc.2` and `zcash_client_sqlite 0.22.0-rc.2`.
+
 ## [2.5.2] - 2026-06-03
 
 ### Changed

--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -159,6 +159,8 @@ dependencies = [
  "tor-dirmgr",
  "tor-error",
  "tor-guardmgr",
+ "tor-hsclient",
+ "tor-hscrypto",
  "tor-keymgr",
  "tor-linkspec",
  "tor-llcrypto",
@@ -2813,9 +2815,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.15.0"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca2ede6a4a77bd729eed3be9303d98a08b217edc85190dcf4dbe004086d5a65"
+checksum = "e8b67beade27dbebdbfee0819e23170b0b263dc7b4f558ee936151716baf6e1f"
 dependencies = [
  "aes",
  "bitvec",
@@ -2978,9 +2980,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pczt"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fb3f5ea64b891d40cff8182aca0bd7d063c9460920546fe7066860b781de91"
+checksum = "1d3935cce17fdfba4d70187a2075302e0d576192629e93579c8ac5086948bb15"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -4861,6 +4863,7 @@ dependencies = [
  "tor-bytes",
  "tor-cert",
  "tor-error",
+ "tor-hscrypto",
  "tor-linkspec",
  "tor-llcrypto",
  "tor-memquota",
@@ -5060,6 +5063,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tor-circmgr",
  "tor-error",
+ "tor-hscrypto",
  "tor-linkspec",
  "tor-llcrypto",
  "tor-netdoc",
@@ -5216,6 +5220,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "tor-hsclient"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c0438676badc6265d6f34ce91c9b50fdb4dfe89ab85795f013fbfa80614304"
+dependencies = [
+ "async-trait",
+ "derive-deftly",
+ "derive_more",
+ "educe",
+ "either",
+ "futures",
+ "itertools 0.14.0",
+ "oneshot-fused-workaround",
+ "postage",
+ "rand 0.9.4",
+ "retry-error",
+ "safelog",
+ "slotmap-careful",
+ "strum",
+ "thiserror 2.0.18",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-bytes",
+ "tor-cell",
+ "tor-checkable",
+ "tor-circmgr",
+ "tor-config",
+ "tor-dirclient",
+ "tor-error",
+ "tor-hscrypto",
+ "tor-keymgr",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-memquota",
+ "tor-netdir",
+ "tor-netdoc",
+ "tor-persist",
+ "tor-proto",
+ "tor-protover",
+ "tor-rtcompat",
+ "tracing",
+]
+
+[[package]]
 name = "tor-hscrypto"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5240,6 +5288,7 @@ dependencies = [
  "tor-error",
  "tor-key-forge",
  "tor-llcrypto",
+ "tor-memquota",
  "tor-units",
  "void",
 ]
@@ -5427,7 +5476,9 @@ dependencies = [
  "async-trait",
  "bitflags",
  "derive_more",
+ "digest 0.10.7",
  "futures",
+ "hex",
  "humantime",
  "itertools 0.14.0",
  "num_enum",
@@ -5435,8 +5486,10 @@ dependencies = [
  "serde",
  "strum",
  "thiserror 2.0.18",
+ "time",
  "tor-basic-utils",
  "tor-error",
+ "tor-hscrypto",
  "tor-linkspec",
  "tor-llcrypto",
  "tor-netdoc",
@@ -5467,6 +5520,7 @@ dependencies = [
  "memchr",
  "paste",
  "phf",
+ "rand 0.9.4",
  "serde",
  "serde_with",
  "signature",
@@ -5482,8 +5536,11 @@ dependencies = [
  "tor-cert",
  "tor-checkable",
  "tor-error",
+ "tor-hscrypto",
+ "tor-linkspec",
  "tor-llcrypto",
  "tor-protover",
+ "tor-units",
  "void",
  "weak-table",
  "zeroize",
@@ -5565,6 +5622,7 @@ dependencies = [
  "tor-checkable",
  "tor-config",
  "tor-error",
+ "tor-hscrypto",
  "tor-linkspec",
  "tor-llcrypto",
  "tor-log-ratelim",
@@ -6736,9 +6794,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.1"
+version = "0.24.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb0d78dcc345c36086112886223f6f1d6d224802808f15ac4f3ef144677029a1"
+checksum = "f489078672c0f4399b731cb5d4cd934c7820c51de2b4a1e7d2594857916250f0"
 dependencies = [
  "arti-client",
  "base64",
@@ -6804,9 +6862,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.1"
+version = "0.22.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa9b039e66a3b79f2de45ebf86cd82545232d332631a84f7c017ae21572b8de"
+checksum = "35a2d018a15b2e4374a08f2472f8d4309079cbbfa2f697fbfb864ef6bacd4792"
 dependencies = [
  "bip32",
  "bitflags",
@@ -6842,6 +6900,7 @@ dependencies = [
  "zcash_client_backend",
  "zcash_encoding",
  "zcash_keys",
+ "zcash_pool_migration",
  "zcash_primitives",
  "zcash_protocol",
  "zcash_script",
@@ -6862,9 +6921,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36391ebfce7df2510c6564f79e608ed93f1c0692c6464e2397b248e06dae3912"
+checksum = "cc842e024fe37e52cfd3920826c4a28cc2a023fc9d77351d9c0f310becae3eb7"
 dependencies = [
  "bech32",
  "bip32",
@@ -6904,10 +6963,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "zcash_primitives"
-version = "0.29.0"
+name = "zcash_pool_migration"
+version = "0.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbeccc05bfe63b6dee9e989c6ff5027421741562a4853c36504dd621f6a81b1"
+checksum = "852d7e66febd7ec83aa7fbd254a33872bf1c4cd072bdc74f65f253ec3a2ef8f4"
+dependencies = [
+ "corez",
+ "getset",
+ "libm",
+ "rand_core 0.6.4",
+ "zcash_primitives",
+ "zcash_protocol",
+]
+
+[[package]]
+name = "zcash_primitives"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ca4de11896f704ffe6319c2cd7bc8fc6ab31a55cec80d26def15c009d83678"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6936,9 +7009,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91fb0b420fb66a765f1fa92ab7a6b631aa54c08415415ef6185256826e74fbd"
+checksum = "ea125021aaa749e966989c7f7aaa18afe2f89474573f5f0dfac8b98083a6d095"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6958,9 +7031,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2973d210e74ebd81adc50828fbbb284ab6aaa099308097c42c47dc63cf3420fc"
+checksum = "4034db33a1ce58416430e065b01474b958e4649caa3e06e20654683a95149710"
 dependencies = [
  "corez",
  "document-features",
@@ -6997,9 +7070,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e0f8c142bed366ed5886dcfa8772ec90b5420cc127e6cdb76b6744c53a287b"
+checksum = "547c012778bae17f58007731af074d638aa146ab0ecfc120adebf23d049aff6c"
 dependencies = [
  "bip32",
  "bs58",

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -13,11 +13,11 @@ rust-version = "1.92"
 [dependencies]
 # Zcash dependencies
 orchard = "0.15"
-pczt = { version = "0.8.0-rc.1", features = ["prover", "orchard", "sapling"] }
+pczt = { version = "0.8.0", features = ["prover", "orchard", "sapling"] }
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
-transparent = { package = "zcash_transparent", version = "0.9", default-features = false }
+transparent = { package = "zcash_transparent", version = "0.10", default-features = false }
 zcash_address = "0.13"
-zcash_client_backend = { version = "0.24.0-rc.1", features = [
+zcash_client_backend = { version = "0.24.0-rc.2", features = [
     "orchard",
     "lightwalletd-tonic-tls-webpki-roots",
     "tor",
@@ -25,10 +25,10 @@ zcash_client_backend = { version = "0.24.0-rc.1", features = [
     "unstable",
     "pczt",
 ] }
-zcash_client_sqlite = { version = "0.22.0-rc.1", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
+zcash_client_sqlite = { version = "0.22.0-rc.2", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
 zcash_note_encryption = "0.4.1"
-zcash_primitives = "0.29"
-zcash_proofs = "0.29"
+zcash_primitives = "0.30"
+zcash_proofs = "0.30"
 zcash_protocol = "0.10"
 zcash_script = "0.4"
 zip32 = "0.2"

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -51,7 +51,7 @@ use zcash_client_backend::{
         wallet::{
             self, create_pczt_from_proposal, create_proposed_transactions,
             decrypt_and_store_transaction, extract_and_store_transaction_from_pczt,
-            input_selection::{GreedyInputSelector, SpendPolicy},
+            input_selection::{GreedyInputSelector, LockFilter, LockedInputPolicy, SpendPolicy},
             propose_shielding, propose_transfer,
         },
     },
@@ -1115,12 +1115,17 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_getTotalT
             .map_err(|e| anyhow!("Error while fetching target height: {}", e))?
             .context("Target height not available; scan required.")?;
 
+        // This backend does not use input locking, so exclude locked outputs.
+        // `Exclude` is the policy's default, and selects no locked outputs.
+        let lock_filter = LockFilter::Policy(&LockedInputPolicy::Exclude);
+
         let amount = db_data
             .get_spendable_transparent_outputs(
                 &taddr,
                 target,
                 wallet::ConfirmationsPolicy::MIN,
                 CoinbaseFilter::AllTransparentOutputs,
+                lock_filter,
             )
             .map_err(|e| anyhow!("Error while fetching verified balance: {}", e))?
             .iter()
@@ -2115,6 +2120,11 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeTr
         let request = TransactionRequest::from_uri(&payment_uri)
             .map_err(|e| anyhow!("Error creating transaction request: {:?}", e))?;
 
+        // This backend does not lock the selected inputs, and always builds at
+        // the transaction version implied by the target height.
+        let lock_inputs = None;
+        let proposed_version = None;
+
         let proposal = propose_transfer::<_, _, _, _, Infallible>(
             &mut db_data,
             &network,
@@ -2124,7 +2134,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeTr
             request,
             wallet::ConfirmationsPolicy::default(),
             &SpendPolicy::default(),
-            None,
+            lock_inputs,
+            proposed_version,
         )
         .map_err(|e| anyhow!("Error creating transaction proposal: {}", e))?;
 
@@ -2178,6 +2189,11 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeTr
         ])
         .map_err(|e| anyhow!("Error creating transaction request: {:?}", e))?;
 
+        // This backend does not lock the selected inputs, and always builds at
+        // the transaction version implied by the target height.
+        let lock_inputs = None;
+        let proposed_version = None;
+
         let proposal = propose_transfer::<_, _, _, _, Infallible>(
             &mut db_data,
             &network,
@@ -2187,7 +2203,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeTr
             request,
             wallet::ConfirmationsPolicy::default(),
             &SpendPolicy::default(),
-            None,
+            lock_inputs,
+            proposed_version,
         )
         .map_err(|e| anyhow!("Error creating transaction proposal: {}", e))?;
 
@@ -2343,6 +2360,9 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeSh
         // Always use ZIP 317 fees
         let (change_strategy, input_selector) = zip317_helper(memo);
 
+        // This backend does not lock the selected inputs.
+        let lock_inputs = None;
+
         let proposal = propose_shielding::<_, _, _, _, Infallible>(
             &mut db_data,
             &network,
@@ -2353,6 +2373,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeSh
             account_uuid,
             confirmations_policy,
             CoinbaseFilter::AllTransparentOutputs,
+            lock_inputs,
         )
         .map_err(|e| anyhow!("Error while shielding transaction: {}", e))?;
 
@@ -2394,6 +2415,9 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_createPro
             .map_err(|e| anyhow!("Invalid proposal: {}", e))?
             .try_into_standard_proposal(&network, &db_data)?;
 
+        // Let the proposal's own target height imply the expiry height.
+        let expiry_height = None;
+
         let txids = create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
             &mut db_data,
             &network,
@@ -2402,6 +2426,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_createPro
             &wallet::SpendingKeys::from_unified_spending_key(usk),
             OvkPolicy::Sender,
             &proposal,
+            expiry_height,
         )
         .map_err(|e| anyhow!("Error while creating transactions: {}", e))?;
 
@@ -2443,14 +2468,20 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_createPcz
             .try_into_standard_proposal(&network, &db_data)?;
 
         if proposal.steps().len() == 1 {
+            // Let the proposal's own target height imply the expiry height,
+            // and use the default Orchard-pool output padding.
+            let expiry_height = None;
+            let orchard_pool_padding =
+                zcash_primitives::transaction::builder::BundlePadding::DEFAULT;
+
             let pczt = create_pczt_from_proposal::<_, _, Infallible, _, Infallible, _>(
                 &mut db_data,
                 &network,
                 account_id,
                 OvkPolicy::Sender,
                 &proposal,
-                None,
-                orchard::builder::BundleType::DEFAULT,
+                expiry_height,
+                orchard_pool_padding,
             )
             .map_err(|e| anyhow!("Error creating PCZT from single-step proposal: {}", e))?;
 

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -17,7 +17,9 @@ use zcash_address::{ToAddress, ZcashAddress, unified, unified::Encoding as _};
 use zcash_client_backend::{
     data_api::{
         Account as _, InputSource, MaxSpendMode, WalletRead,
-        wallet::{ConfirmationsPolicy, propose_send_max_transfer},
+        wallet::{
+            ConfirmationsPolicy, input_selection::LockedInputPolicy, propose_send_max_transfer,
+        },
     },
     fees::StandardFeeRule,
     proposal::Proposal,
@@ -125,6 +127,14 @@ pub(crate) fn propose_orchard_to_ironwood(
     // more lax about confirmations than an ordinary send.
     let confirmations_policy = ConfirmationsPolicy::default();
 
+    // This migration does not use input locking, so it never selects locked
+    // outputs. `Exclude` is the policy's default.
+    let locked_input_policy = LockedInputPolicy::Exclude;
+
+    // Do not lock the selected inputs: the proposal is built to be signed and
+    // broadcast, not held open for a later commitment.
+    let lock_inputs = None;
+
     propose_send_max_transfer::<_, _, _, std::convert::Infallible>(
         db_data,
         network,
@@ -135,6 +145,8 @@ pub(crate) fn propose_orchard_to_ironwood(
         memo,
         mode,
         confirmations_policy,
+        &locked_input_policy,
+        lock_inputs,
     )
     .map_err(|e| anyhow!("Error creating the migration proposal: {}", e))
 }

--- a/backend-lib/src/main/rust/tor.rs
+++ b/backend-lib/src/main/rust/tor.rs
@@ -91,7 +91,14 @@ impl TorRuntime {
     pub(crate) fn connect_to_lightwalletd(&self, endpoint: Uri) -> anyhow::Result<LwdConn> {
         let Self { runtime, client } = self.isolated_client();
 
-        let conn = runtime.block_on(async { client.connect_to_lightwalletd(endpoint).await })?;
+        // lightwalletd endpoints are ordinary clearnet hosts, not Tor onion
+        // services, so onion connections are not permitted for them.
+        let allow_onion_services = false;
+        let conn = runtime.block_on(async {
+            client
+                .connect_to_lightwalletd(endpoint, allow_onion_services)
+                .await
+        })?;
 
         Ok(LwdConn {
             runtime,


### PR DESCRIPTION
## Summary

`backend-lib` depended on the frozen crates.io release candidates
`zcash_client_backend 0.24.0-rc.1` and `zcash_client_sqlite 0.22.0-rc.1`,
which predate the breaking send-max and Ironwood API changes. Those changes
have since shipped in the published `0.24.0-rc.2` / `0.22.0-rc.2` release
candidates, so this moves the backend onto the published crates and adapts the
JNI glue. Send-max and Ironwood support keep working; no JNI-visible signatures
change.

The work is in three commits:

1. **Use the published crates** - bump `zcash_client_backend` and
   `zcash_client_sqlite` from `rc.1` to `rc.2`, keep the aligned `pczt 0.8.0` /
   `zcash_transparent 0.10` / `zcash_primitives`/`zcash_proofs 0.30`, and drop
   the temporary `[patch.crates-io]` git pin. The committed `Cargo.lock` now
   resolves every former git-sourced crate from crates.io, with no incidental
   transitive churn.

2. **Adapt the JNI backend** to the parameters added after the RCs:
   - `propose_send_max_transfer` / `propose_transfer`: locked-input policy
     and/or input-lock request
   - `propose_shielding`: input-lock request
   - `create_proposed_transactions`: expiry height
   - `create_pczt_from_proposal`: expiry height + `BundlePadding` (was
     `BundleType`)
   - `get_spendable_transparent_outputs`: lock filter
   - Tor `connect_to_lightwalletd`: allow-onion-services flag

   Every new argument is a named `let` binding passing the value that preserves
   prior behavior: no input locking, default padding, and clearnet-only
   lightwalletd connections.

3. **Ignore** the `.claude` local config and agent worktrees.

## Testing

- `cargo check --lib` against the published `rc.2` crates: clean.
- `./scripts/ci-local.sh quick` (detekt, ktlint, Kotlin compile, native-lib
  cross-build, unit tests): passed. The JNI glue is unchanged from that run;
  only the crate versions moved `rc.1` -> `rc.2`.

## Note

`0.24.0-rc.2` / `0.22.0-rc.2` are the latest published librustzcash releases and
carry the post-`rc.1` send-max and Ironwood APIs. Bump to the final `0.24.0` /
`0.22.0` once those are cut.
