### PR TITLE
CHANGELOG: record Ironwood support and the 0.24 migration for 2.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,16 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Ironwood (NU6.3) shielded pool support: the SDK now exposes the Ironwood pool
+  (balance, subtree roots, sync) alongside Sapling and Orchard.
+- `Synchronizer.proposeOrchardToIronwoodMigration`, which builds a proposal that
+  moves the account's entire Orchard balance across the NU6.3 turnstile into the
+  Ironwood pool.
+
 ### Changed
+- Migrated to the `zcash_client_backend 0.24` / `zcash_client_sqlite 0.22` API
+  line, adapting the backend to the send-max and builder API changes.
 - Updated the librustzcash crates to their published releases,
   `zcash_client_backend 0.24.0-rc.2` and `zcash_client_sqlite 0.22.0-rc.2`.
 


### PR DESCRIPTION
## Summary

The changelog was never updated for the feature work that landed on
`maint/v2.5.x` after 2.5.2. This adds the missing entries under `[Unreleased]`,
so the next `Prepare SDK release 2.5.3` commit stamps them with the version and
date.

Entries added (from `v2.5.2..maint/v2.5.x`):

- **Added** - Ironwood (NU6.3) shielded pool support (`e6a10834`).
- **Added** - `Synchronizer.proposeOrchardToIronwoodMigration` (`b580c660`).
- **Changed** - migration to the `zcash_client_backend 0.24` /
  `zcash_client_sqlite 0.22` API line and the backend adaptation (`4843902c`).

The `Updated the librustzcash crates to their published releases` entry is
already on `maint/v2.5.x` (merged in #2046), so this PR does not repeat it; it
sits directly below the new migration entry.

## Not included

The remaining post-2.5.2 commits are internal and not user-facing, so they are
intentionally left out of the changelog: the Ironwood test-fixture values
(`d0c88dcb`), the `getOutputsCounts` counter renaming (`e7b761c8`), the
pool-code / TreeState / field-number source citations (`7c821bd1`, `3e0a21d2`),
the `AGENTS.md` local-compile notes (`cf187eae`), and the CI emulator-job swap
(`5b8a5a22`). Say the word if any of these should be surfaced.
