### PR TITLE
CI: check and test the Rust backend with --all-features

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -21,10 +21,17 @@ runs:
         echo "y" | $SDKMANAGER "ndk;27.0.12077973"
     - name: Setup Rust
       shell: bash
+      # Use the channel pinned in rust-toolchain.toml (the single source of truth) rather than a
+      # hardcoded version. rustup honors the toolchain file in-repo regardless, so a hardcoded
+      # version here installs components onto a toolchain the build never runs: that is why
+      # `cargo clippy` failed with "'cargo-clippy' is not installed for the toolchain 1.92.0"
+      # while clippy had been installed for 1.84.1.
       run: |
-        rustup install 1.84.1
-        rustup default 1.84.1
-        rustup target add armv7-linux-androideabi aarch64-linux-android i686-linux-android x86_64-linux-android
+        CHANNEL="$(grep -oP 'channel\s*=\s*"\K[^"]+' rust-toolchain.toml)"
+        rustup toolchain install "${CHANNEL}"
+        rustup default "${CHANNEL}"
+        rustup target add --toolchain "${CHANNEL}" armv7-linux-androideabi aarch64-linux-android i686-linux-android x86_64-linux-android
+        rustup component add --toolchain "${CHANNEL}" clippy
     - name: Configure Gradle
       shell: bash
       run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -183,6 +183,54 @@ jobs:
           name: Android Lint static analysis results
           path: ~/artifacts
 
+  # Runs the Rust unit tests. static_analysis_clippy compiles them via --tests but never
+  # executes them, so without this a failing test can sit unnoticed indefinitely.
+  test_rust_unit:
+    needs: validate_gradle_wrapper
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        timeout-minutes: 1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - name: Setup
+        id: setup
+        timeout-minutes: 30
+        uses: ./.github/actions/setup
+        with:
+          rust-cache: true
+      - name: Test
+        timeout-minutes: 15
+        working-directory: backend-lib
+        run: |
+          cargo test --all-features
+
+  # --all-features matters: code behind a cargo feature (for example the
+  # android-test-fixtures gate the Android build enables) is invisible to a
+  # default-feature check, so a merge can break it while `cargo check` stays green.
+  # --tests extends the same coverage to test-only code.
+  static_analysis_clippy:
+    needs: validate_gradle_wrapper
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        timeout-minutes: 1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - name: Setup
+        id: setup
+        timeout-minutes: 30
+        uses: ./.github/actions/setup
+        with:
+          rust-cache: true
+      - name: Clippy
+        timeout-minutes: 15
+        working-directory: backend-lib
+        run: |
+          cargo clippy --tests --all-features -- -W clippy::all -D warnings
+
   test_android_modules_unit:
     needs: [ validate_gradle_wrapper ]
     runs-on: ubuntu-latest

--- a/backend-lib/src/main/rust/eip681.rs
+++ b/backend-lib/src/main/rust/eip681.rs
@@ -119,7 +119,7 @@ fn encode_eip681_transaction_request<'a>(
             let gas_price_hex = u256_option_to_jstring(env, native.gas_price())?;
 
             Ok(env.new_object(
-                &format!("{}$Native", JNI_CLASS_PREFIX),
+                format!("{}$Native", JNI_CLASS_PREFIX),
                 "(Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
                 &[
                     JValue::Object(&schema_prefix),
@@ -141,7 +141,7 @@ fn encode_eip681_transaction_request<'a>(
             let value_hex = env.new_string(format!("{:#x}", erc20.value_atomic()))?;
 
             Ok(env.new_object(
-                &format!("{}$Erc20", JNI_CLASS_PREFIX),
+                format!("{}$Erc20", JNI_CLASS_PREFIX),
                 "(Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
                 &[
                     JValue::Object(&schema_prefix),
@@ -154,7 +154,7 @@ fn encode_eip681_transaction_request<'a>(
             )?)
         }
         TransactionRequest::Unrecognised(_) => {
-            Ok(env.new_object(&format!("{}$Unrecognised", JNI_CLASS_PREFIX), "()V", &[])?)
+            Ok(env.new_object(format!("{}$Unrecognised", JNI_CLASS_PREFIX), "()V", &[])?)
         }
     }
 }

--- a/backend-lib/src/main/rust/utils/exception.rs
+++ b/backend-lib/src/main/rust/utils/exception.rs
@@ -109,11 +109,19 @@ mod tests {
 
     #[test]
     fn unknown_any() {
-        let error = panic_error(1);
+        let error = panic_any_error(1u32);
         assert_eq!("Unknown error occurred", any_to_string(&error));
     }
 
     fn panic_error<T: fmt::Display + Send + 'static>(val: T) -> Box<dyn Any + Send> {
         panic::catch_unwind(panic::AssertUnwindSafe(|| panic!("{}", val))).unwrap_err()
+    }
+
+    // Panics with `val` itself as the payload. `panic_error` cannot reach
+    // `any_to_string`'s fallback branch: `panic!("{}", val)` formats the value, so the
+    // payload is always a `String` and downcasting succeeds. Only a payload that is
+    // neither `&str`, `String`, nor `Box<dyn Error + Send>` exercises the fallback.
+    fn panic_any_error<T: Any + Send + 'static>(val: T) -> Box<dyn Any + Send> {
+        panic::catch_unwind(panic::AssertUnwindSafe(|| panic::panic_any(val))).unwrap_err()
     }
 }


### PR DESCRIPTION
Adds `--all-features` Rust checking at the base of the maintenance stack, so it merges forward into
`maint/v2.6.x`, `main`, and `feature/ironwood-slipstream` rather than being reinvented per branch.

    45e659dc  CI: check and test the Rust backend with --all-features
    d1fae767  backend-lib: drop needless borrows in the eip681 JNI bindings
    d49c20e2  backend-lib: fix unreachable assertion in unknown_any test

## Why `--all-features`

Code behind a cargo feature is invisible to a default-feature `cargo check`, so a merge can break it
while the check stays green. That is not hypothetical. Merging this branch into `maint/v2.6.x` broke
the shielded-voting fixtures in two places — a missing `ironwood_tree` field on the NU6.3 `TreeState`
proto, and `Pczt::serialize` becoming fallible in pczt 0.8. Both sit behind `android-test-fixtures`,
a feature `backend-lib/build.gradle.kts` enables for the Android build but which no CI check
compiled. Both were textually conflict-free, so git flagged nothing and the failure only surfaced
much later, in the Android build.

## The jobs

- **`static_analysis_clippy`** — `cargo clippy --tests --all-features -- -W clippy::all -D warnings`.
  Byte-identical to the job already on `main`, so the forward merge deduplicates it rather than
  conflicting. `--tests` extends coverage to test-only code, which is where both breaks above lived.
- **`test_rust_unit`** — `cargo test --all-features`. Clippy compiles the tests but never runs them,
  so without this a failing test sits unnoticed.

Both use the `actions/checkout` 6.0.3 pin rather than this branch's 6.0.2, matching `main` and
`maint/v2.6.x`. It is the newer pin, and it is what keeps the clippy job textually identical to
main's.

This branch defines no cargo features of its own, so `--all-features` is currently equivalent to a
default build here. The guard earns its keep once it reaches the branches that do define them.

## What had to be fixed to make them pass

Both pre-existing on this branch, and both exactly what the new jobs exist to catch:

- **`utils::exception::tests::unknown_any` was failing.** Its helper panics via `panic!("{}", val)`,
  which always produces a `String` payload, so `any_to_string`'s fallback branch — the thing the test
  asserts on — was unreachable. Nothing caught it because no job ran `cargo test`. Cherry-picked from
  `dw/run-rust-tests-in-ci`.
- **Three `needless_borrows_for_generic_args` in `eip681.rs`.** `JNIEnv::new_object` takes its class
  argument by `Into<JClass>`, which `String` already satisfies, so the `&format!(...)` borrows were
  redundant. Applied by `cargo clippy --fix`; no behaviour change.

## Verification

| Check | Result |
| --- | --- |
| `cargo clippy --tests --all-features -- -W clippy::all -D warnings` | pass |
| `cargo test --all-features` | pass — 4 tests, 0 failures (was 3 passed / 1 failed) |
| `cargo fmt --all --check` | pass |
| `cargo check --all-targets --all-features` | pass |
| `./gradlew ktlint detektAll` | pass |
| `./gradlew :sdk-lib:test :sdk-incubator-lib:test :backend-lib:test` | pass — 153 tests, 0 failures |

## Note for the forward merge

`feature/ironwood-slipstream` already carries its own `test_rust_unit`, which additionally passes the
`SLIPSTREAM_APP_ID` / `SLIPSTREAM_APP_PRIVATE_KEY` setup inputs and uses the checkout 7.0.0 pin with
`persist-credentials: false`. Expect a one-hunk conflict there; the feature branch's version is the
superset and should win. `static_analysis_clippy` should merge with no conflict anywhere.

---
Filed with Claude Code assistance.