### PR TITLE
Expose mismatch details on server-compatibility exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Synchronizer.proposeOrchardToIronwoodMigration`, which builds a proposal that
   moves the account's entire Orchard balance across the NU6.3 turnstile into the
   Ironwood pool.
+- `CompactBlockProcessorException.MismatchedConsensusBranch`, `MismatchedNetwork`
+  and `MismatchedSaplingActivationHeight` now expose their constructor arguments
+  as public `val`s (`clientBranchId`/`serverBranchId`,
+  `clientNetwork`/`serverNetwork`, `clientHeight`/`serverHeight`). Previously the
+  mismatched values were reachable only by parsing the exception's `message`, so
+  consumers had to either scrape English prose or surface it verbatim. Wallets
+  can now render a localized, structured explanation of why a server is
+  incompatible. Note that consensus branch IDs are opaque unordered constants:
+  neither the SDK nor a consumer can infer from them alone which side is stale.
 
 ### Changed
 - Migrated to the `zcash_client_backend 0.24` / `zcash_client_sqlite 0.22` API

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/exception/Exceptions.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/exception/Exceptions.kt
@@ -166,26 +166,48 @@ sealed class CompactBlockProcessorException(
             )
     }
 
+    /**
+     * The client and the server disagree about which network they are on.
+     *
+     * [clientNetwork] and [serverNetwork] are exposed so that callers can present the mismatch
+     * without parsing [message], whose wording is not part of the API contract.
+     */
     class MismatchedNetwork(
-        clientNetwork: String?,
-        serverNetwork: String?
+        val clientNetwork: String?,
+        val serverNetwork: String?
     ) : CompactBlockProcessorException(
             "Incompatible server: this client expects a server using $clientNetwork but it was $serverNetwork! Try " +
                 "updating the client or switching servers."
         )
 
+    /**
+     * The client and the server disagree about the active consensus branch, so sync cannot make
+     * progress. Either side may be the stale one: the client may predate a network upgrade the
+     * server has already activated, or the server may be running an older release than the client.
+     *
+     * [clientBranchId] and [serverBranchId] are lowercase hex branch IDs (for example `5437f330`),
+     * exposed so that callers can present the mismatch without parsing [message], whose wording is
+     * not part of the API contract. They are opaque unordered constants and cannot be compared to
+     * decide which side is behind.
+     */
     class MismatchedConsensusBranch(
-        clientBranchId: String,
-        serverBranchId: String
+        val clientBranchId: String,
+        val serverBranchId: String
     ) : CompactBlockProcessorException(
             message =
                 "Incompatible server: this client expects a consensus branch $clientBranchId but it " +
                     "was $serverBranchId! Try updating the client or switching servers."
         )
 
+    /**
+     * The client and the server disagree about the Sapling activation height.
+     *
+     * [clientHeight] and [serverHeight] are exposed so that callers can present the mismatch
+     * without parsing [message], whose wording is not part of the API contract.
+     */
     class MismatchedSaplingActivationHeight(
-        clientHeight: Long,
-        serverHeight: Long
+        val clientHeight: Long,
+        val serverHeight: Long
     ) : CompactBlockProcessorException(
             message =
                 "Incompatible server: this client expects a sapling activation height $clientHeight but it " +


### PR DESCRIPTION
## What

`MismatchedConsensusBranch`, `MismatchedNetwork` and `MismatchedSaplingActivationHeight` take their mismatched values as plain constructor params, so the values exist only inside the exception's message string. Promote them to public `val`s.

```kotlin
class MismatchedConsensusBranch(
    val clientBranchId: String,
    val serverBranchId: String
) : CompactBlockProcessorException(...)
```

## Why

A wallet that wants to tell the user *why* a server is incompatible currently has two bad options: regex the IDs out of the message (the wording is not an API contract, so it would silently stop matching), or show the raw English sentence verbatim in every locale.

This came from a real report: a server on NU6.3/Ironwood (`0x37a5165b`) against a client expecting NU6.2 (`0x5437f330`). Sync can never progress, and the remedy is a decision the user has to make — update, or switch servers — so the specifics are worth showing them.

The KDoc is explicit that branch IDs are opaque unordered constants: neither the SDK nor a consumer can tell from them which side is stale. In the observed case the *client* was behind, not the server.

## Compatibility

Source and binary compatible. Constructor signatures are unchanged; the classes gain getters. All existing call sites (`CompactBlockProcessor.kt`, `SdkSynchronizer.kt`) are untouched.

## Scope

Deliberately does **not** touch `Synchronizer.validateConsensusBranch()` (#1405) or the `ConsensusBranchId` enum (#679, hardcoded and stopping at CANOPY, so `fromHex("37a5165b")` returns null). Those are separate decisions.

## Target branch

Targeting `maint/v2.5.x` per the merge-forward convention — oldest maintenance branch that should carry the fix, then merged forward. Verified that `Exceptions.kt` cherry-picks onto `main` with no conflict (only `CHANGELOG.md` conflicts, as expected).

## Verification

`./scripts/ci-local.sh quick` — **passing**, exit code 0, "all requested stages passed":

```
==> [1/6] detekt (static_analysis_detekt)      BUILD SUCCESSFUL
==> [2/6] ktlint (static_analysis_ktlint)      BUILD SUCCESSFUL
> Task :sdk-lib:testDebugUnitTest
> Task :sdk-lib:testReleaseUnitTest
> Task :sdk-lib:test
BUILD SUCCESSFUL in 9m 34s
483 actionable tasks: 160 executed, 38 from cache, 285 up-to-date
```

Not run: `full` (androidTest on a managed device) and the `emulator.wtf` / Firebase Test Lab cloud stages. Per AGENTS.md's table this change is "logic or refactor" tier, for which `quick` is the stated minimum.

### Note for other macOS contributors

The Rust link step fails on a clean macOS machine with `linker-wrapper.sh: line 4: python: command not found`, because macOS ships only `python3`. `docs/Setup.md:34` covers it — set `rust.pythonCommand` in `local.properties`. Unrelated to this change, but it's the first thing you'll hit.