### PR TITLE
fix: create and redact Ironwood proofs in the PCZT prover/signer glue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `addProofsToPczt` now reuses a cached Orchard proving key (via `zcash_primitives`'
+  `cached_orchard_proving_key`) instead of rebuilding it for every proof, so proving a PCZT with
+  both Orchard and Ironwood bundles no longer constructs the key twice.
+
 ### Fixed
 - `addProofsToPczt` now creates Ironwood proofs. It previously only handled Orchard and Sapling,
   so any PCZT with Ironwood Actions (e.g. a Keystone-signed spend from the Ironwood pool) failed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `addProofsToPczt` now creates Ironwood proofs. It previously only handled Orchard and Sapling,
+  so any PCZT with Ironwood Actions (e.g. a Keystone-signed spend from the Ironwood pool) failed
+  at extraction with `Pczt(Extraction(Ironwood(Extract(MissingProof))))`.
+
 ## [2.7.0-rc.1] - 2026-07-25
 
 ### Added

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -79,7 +79,10 @@ use zcash_client_sqlite::{
 use zcash_primitives::{
     block::BlockHash,
     merkle_tree::HashSer,
-    transaction::{Transaction, TxId, components::orchard::bundle_version_for_branch},
+    transaction::{
+        Transaction, TxId, builder::cached_orchard_proving_key,
+        components::orchard::bundle_version_for_branch,
+    },
 };
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::{
@@ -2621,7 +2624,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_addProofs
                 anyhow!("PCZT requires an Orchard proof but its consensus branch does not support Orchard")
             })?;
             prover = prover
-                .create_orchard_proof(&orchard::circuit::ProvingKey::build(circuit_version))
+                .create_orchard_proof(cached_orchard_proving_key(circuit_version))
                 .map_err(|e| anyhow!("Failed to create Orchard proof for PCZT: {:?}", e))?;
         }
         assert!(!prover.requires_orchard_proof());
@@ -2631,7 +2634,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_addProofs
                 anyhow!("PCZT requires an Ironwood proof but its consensus branch does not support Ironwood")
             })?;
             prover = prover
-                .create_ironwood_proof(&orchard::circuit::ProvingKey::build(circuit_version))
+                .create_ironwood_proof(cached_orchard_proving_key(circuit_version))
                 .map_err(|e| anyhow!("Failed to create Ironwood proof for PCZT: {:?}", e))?;
         }
         assert!(!prover.requires_ironwood_proof());

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -2591,27 +2591,27 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_addProofs
 
         let pczt = parse_pczt(env, pczt)?;
 
-        // The Orchard circuit version is fixed by the consensus branch under which the
-        // transaction will be mined; derive it from the branch id carried by the PCZT.
+        // The Orchard-family circuit versions are fixed by the consensus branch under
+        // which the transaction will be mined; derive them from the branch id carried by
+        // the PCZT, per value pool.
         //
-        // The pool argument does not select the circuit: `BundleVersion::circuit_version`
-        // is documented as many-to-one, deriving only from the `ProtocolVersion`, so the
-        // Orchard and Ironwood pools under NU6.3 share the post-NU6.3 circuit. Passing
-        // `ValuePool::Orchard` is therefore correct for an Ironwood bundle as well, and
-        // it is the only choice that is total over the branches Orchard supports:
-        // `bundle_version_for_branch(_, ValuePool::Ironwood)` is `None` before NU6.3,
-        // which would fail proving for every pre-NU6.3 Orchard PCZT. If a future protocol
-        // revision ever gave the two pools distinct circuits, that would break this
-        // documented contract, and the pool would have to be derived from the bundle.
-        let orchard_circuit_version = BranchId::try_from(*pczt.global().consensus_branch_id())
-            .ok()
-            .and_then(|branch_id| bundle_version_for_branch(branch_id, orchard::ValuePool::Orchard))
-            .map(|bundle_version| bundle_version.circuit_version());
+        // `BundleVersion::circuit_version` is documented as many-to-one, deriving only
+        // from the `ProtocolVersion`, so under NU6.3 the Orchard and Ironwood pools share
+        // the post-NU6.3 circuit. Each proof still derives its circuit from its own pool:
+        // `bundle_version_for_branch(_, ValuePool::Ironwood)` is `None` before NU6.3, but
+        // an Ironwood proof is only required post-NU6.3, so the per-pool lookup is total
+        // on the branches that can actually require that proof.
+        let consensus_branch_id = BranchId::try_from(*pczt.global().consensus_branch_id()).ok();
+        let circuit_version_for = |pool: orchard::ValuePool| {
+            consensus_branch_id
+                .and_then(|branch_id| bundle_version_for_branch(branch_id, pool))
+                .map(|bundle_version| bundle_version.circuit_version())
+        };
 
         let mut prover = Prover::new(pczt);
 
         if prover.requires_orchard_proof() {
-            let circuit_version = orchard_circuit_version.ok_or_else(|| {
+            let circuit_version = circuit_version_for(orchard::ValuePool::Orchard).ok_or_else(|| {
                 anyhow!("PCZT requires an Orchard proof but its consensus branch does not support Orchard")
             })?;
             prover = prover
@@ -2619,6 +2619,16 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_addProofs
                 .map_err(|e| anyhow!("Failed to create Orchard proof for PCZT: {:?}", e))?;
         }
         assert!(!prover.requires_orchard_proof());
+
+        if prover.requires_ironwood_proof() {
+            let circuit_version = circuit_version_for(orchard::ValuePool::Ironwood).ok_or_else(|| {
+                anyhow!("PCZT requires an Ironwood proof but its consensus branch does not support Ironwood")
+            })?;
+            prover = prover
+                .create_ironwood_proof(&orchard::circuit::ProvingKey::build(circuit_version))
+                .map_err(|e| anyhow!("Failed to create Ironwood proof for PCZT: {:?}", e))?;
+        }
+        assert!(!prover.requires_ironwood_proof());
 
         if prover.requires_sapling_proofs() {
             let spend_params = path_from_jni(env, spend_params)?;

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -2525,6 +2525,12 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_redactPcz
                     ar.redact_output_proprietary("zcash_client_backend:output_info");
                 })
             })
+            .redact_ironwood_with(|mut r| {
+                r.redact_actions(|mut ar| {
+                    ar.clear_spend_witness();
+                    ar.redact_output_proprietary("zcash_client_backend:output_info");
+                })
+            })
             .redact_sapling_with(|mut r| {
                 r.redact_spends(|mut sr| sr.clear_witness());
                 r.redact_outputs(|mut or| {


### PR DESCRIPTION
## Development

Two Ironwood parity fixes in the PCZT JNI glue, each in its own commit (plus a dedicated CHANGELOG commit).

### 1. `addProofsToPczt` now creates Ironwood proofs

The prover glue only handled Orchard and Sapling, so any PCZT with Ironwood Actions (e.g. a Keystone-signed spend from the Ironwood pool) sailed through proving without an Ironwood proof and failed at extraction with `Pczt(Extraction(Ironwood(Extract(MissingProof))))`.

Mirrors the Orchard branch: derives the Ironwood circuit version from the PCZT's consensus branch id (`bundle_version_for_branch` with `ValuePool::Ironwood`) and calls `Prover::create_ironwood_proof` with a proving key built for that circuit. The stale comment claiming `ValuePool::Orchard` is correct for Ironwood bundles is updated to reflect the per-pool derivation.

### 2. `redactPcztForSignerRole` now redacts the Ironwood bundle

While auditing pool parity, the Signer-role redaction was found to clear the spend witness and the internal `zcash_client_backend:output_info` metadata for Orchard and Sapling but leave the Ironwood bundle untouched. A Keystone-signed Ironwood spend therefore shipped its Merkle witnesses and wallet output metadata to the external signer, which does not need them. Fixed by mirroring the Orchard redaction for Ironwood.

## Verification

- `cargo check` on `backend-lib` is clean; the crate is formatted with the repo toolchain.
- Confirmed against the pinned `pczt 0.8.0` that `requires_ironwood_proof`/`create_ironwood_proof`/`redact_ironwood_with` exist and share the Orchard shape, and that the extractor and Signer role authorize Ironwood identically to Orchard.

Other Orchard sites (subtree roots, balance, sync index, pool mapping, migration proposal) already handle Ironwood.