### PR TITLE
CONTRIBUTING: document the maintenance branch and release process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,12 @@ main          ───●───────────────●──
 
 ### Cutting a release
 
+`./scripts/start-release.sh <remote> <version>` performs steps 1 through 4:
+it works out which release this one follows, creates and pushes the release
+branch, creates the review branch, bumps the version and promotes the
+CHANGELOG. Pass `--dry-run` first to see what it will do. The steps below are
+what it automates, and what to do by hand if a release needs to deviate.
+
 1. Create `release/vX.Y.Z` **from the previous release tag** and push it to
    upstream. It starts out identical to the last release.
 2. Create `review/vX.Y.Z` from the maintenance branch that contains all of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Please read it before you start participating.
 * [Asking Questions](#asking-questions)
 * [Reporting Security Issues](#reporting-security-issues)
 * [Reporting Non Security Issues](#reporting-other-issues)
+* [Release and Maintenance Branches](#release-and-maintenance-branches)
 * [Commit Messages](#commit-messages)
 * [Developers Certificate of Origin](#developers-certificate-of-origin)
 
@@ -68,6 +69,116 @@ prioritized.
   logic are either obvious to a reasonably skilled professional, or add a
   comment that explains it.
   
+## Release and Maintenance Branches
+
+`main` is the development trunk. Released versions are maintained on long-lived
+`maint/` branches, one per minor release line, so that a fix can reach users
+already running an older version without shipping them unrelated trunk work.
+
+| Branch | Lifetime | Purpose |
+| --- | --- | --- |
+| `main` | permanent | Development trunk. New feature work lands here. |
+| `maint/vX.Y.x` | permanent | One per supported release line. Fixes to released versions land here. |
+| `release/vX.Y.Z` | one release | Cut from the previous release tag. The base of the release PR, and what gets tagged. |
+| `review/vX.Y.Z` | one release | Release preparation: version bumps, CHANGELOG promotion, final review. |
+
+### Basing a bug fix
+
+**The rule is: merge forward, cherry-pick back.**
+
+Branch bug fixes from the oldest currently-supported maintenance branch — at the
+time of writing that is `maint/v2.7.x`. From there the fix travels to every newer
+line by merging forward, keeping one commit identity and leaving later merges
+between those branches clean. This is the normal path and the one the diagram
+below shows; expect nearly every fix to take it.
+
+Cherry-picking back is the exception, for a fix that has already landed on a
+newer line and turns out to be needed on an older one too. Never merge backward:
+that would drag everything else on the newer line into the older release.
+
+```
+                    fix/1234
+                   ●────●
+                  /       \
+maint/v2.7.x  ───●─────────●─────────────────────────────▶   base bug fixes here
+                            \
+                             \  merge forward
+                              ▼
+maint/v2.8.x  ───●────────────●──────────────────────────▶
+                               \
+                                \  merge forward
+                                 ▼
+main          ───●───────────────●───────────────────────▶
+```
+
+### Cutting a release
+
+1. Create `release/vX.Y.Z` **from the previous release tag** and push it to
+   upstream. It starts out identical to the last release.
+2. Create `review/vX.Y.Z` from the maintenance branch that contains all of the
+   changes to be released.
+3. Open a pull request **on the public repository** from `review/vX.Y.Z` into
+   `release/vX.Y.Z`.
+4. Make the release preparation commits on `review/vX.Y.Z` — version bumps,
+   CHANGELOG promotion, and anything else the release needs. The review branch,
+   not the release branch, is where this work happens.
+5. Merge the pull request, then tag the result `vX.Y.Z`.
+
+Basing the release branch on the previous release tag is what makes the pull
+request worth reviewing: its diff is exactly what users receive relative to the
+last release, rather than the intervening development history.
+
+```
+tag vX.Y.W  (previous release)
+      │
+      └──▶  release/vX.Y.Z  ●──────────────────────────────●  tag vX.Y.Z
+                                                           ▲
+                                                           │  PR: review ──▶ release
+                                                           │
+        review/vX.Y.Z   ●────●────●────────────────────────┘
+                        ▲     version bumps, CHANGELOG promotion
+                        │
+                        │  branch from maint
+maint/vX.Y.x ──●────●───┴────────────────────────▶
+               └─ changes to be released ─┘
+```
+
+### After the release
+
+Three merges, in order:
+
+1. Merge `release/vX.Y.Z` back into `maint/vX.Y.x`, so the maintenance branch
+   carries the tagged release and its preparation commits.
+2. Merge each maintenance branch forward into the next newer one. With
+   `maint/v2.7.x` and `maint/v2.8.x` both active, a release on the 2.7 line goes
+   `maint/v2.7.x` → `maint/v2.8.x`. Repeat along the chain for every newer line.
+3. Merge the newest maintenance branch into `main`.
+
+```
+release/vX.Y.Z  ●  tag vX.Y.Z
+                 \
+                  \  1. merge back
+                   ▼
+maint/vX.Y.x  ──────●────────────────────────────────────▶
+                     \
+                      \  2. merge forward
+                       ▼
+maint/vX.Y+1.x  ────────●────────────────────────────────▶
+                         \
+                          \  3. merge back to trunk
+                           ▼
+main          ──────────────●────────────────────────────▶
+```
+
+Do not treat step 3 as release-time-only work: merge `maint/` branches back to
+`main` regularly. Trunk then never drifts far from what is shipping, and each
+merge stays small enough to resolve confidently.
+
+Skipping a forward merge is how a fix silently regresses — a user upgrading from
+2.7.1 to 2.8.0 would lose it. If a forward merge conflicts, resolve it in favour
+of keeping both changes rather than dropping either, and verify the result builds
+before pushing.
+
 ## Commit Messages
 
 Commit history is an important part of the project's documentation.

--- a/scripts/start-release.sh
+++ b/scripts/start-release.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+#
+# start-release.sh: open a release for review.
+#
+# Creates the two branches described in CONTRIBUTING.md and makes the version
+# bump commit:
+#
+#   release/vX.Y.Z   cut from the PREVIOUS release tag. It is the base of the
+#                    release PR and what eventually gets tagged.
+#   review/vX.Y.Z    cut from the revision being released. It carries the
+#                    version bumps and the CHANGELOG promotion.
+#
+# The PR from review/vX.Y.Z into release/vX.Y.Z then shows exactly what this
+# release adds over the previous one, with none of the intervening history.
+#
+# Usage:
+#   ./scripts/start-release.sh [options] <remote> <version> [<revision>]
+#
+#   <remote>    git remote for zcash/zcash-android-wallet-sdk, e.g. upstream
+#   <version>   version being released, without the leading v, e.g. 2.7.1
+#   <revision>  commit or branch holding the changes to release
+#               (default: current HEAD, which should be a maint/ branch)
+#
+# Options:
+#   --previous <tag>  base the release branch on this tag rather than the
+#                     detected one. Use when the newest tag reachable from
+#                     <revision> is not the release you are following.
+#   --push-review     also push review/vX.Y.Z, so the PR can be opened at once.
+#   --dry-run         print what would happen and change nothing.
+#
+# It deliberately does not tag, publish, or open the PR: those are the steps
+# worth a human looking at the diff first.
+
+set -euo pipefail
+
+readonly TAG_PREFIX="v"
+
+usage() { sed -n '2,33p' "$0" | sed 's|^# \{0,1\}||'; exit "${1:-1}"; }
+
+PREVIOUS=""
+PUSH_REVIEW=false
+DRY_RUN=false
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --previous)     PREVIOUS="${2:?--previous needs a tag}"; shift 2 ;;
+        --push-review)  PUSH_REVIEW=true; shift ;;
+        --dry-run)      DRY_RUN=true; shift ;;
+        -h|--help)      usage 0 ;;
+        --*)            echo "error: unknown option '$1'" >&2; usage ;;
+        *)              break ;;
+    esac
+done
+
+[ $# -ge 2 ] || usage
+readonly REMOTE="$1"
+readonly VERSION="${2#v}"
+readonly REVISION="${3:-HEAD}"
+
+cd "$(git rev-parse --show-toplevel)"
+
+run() {
+    if $DRY_RUN; then echo "  would run: $*"; else "$@"; fi
+}
+
+step() { echo; echo "==> $*"; }
+
+# Semver ordering. GNU `sort -V` ranks 2.7.0-rc.1 *above* 2.7.0, which is
+# backwards: a pre-release precedes its release. Mapping '-' to '~' fixes it,
+# because sort -V treats '~' as lower than the empty string.
+version_sort() { sed 's/-/~/' | sort -V | sed 's/~/-/'; }
+
+version_le() {
+    [ "$(printf '%s\n%s\n' "$1" "$2" | version_sort | head -1)" = "$1" ]
+}
+
+# ---------------------------------------------------------------- preflight
+
+step "Checking preconditions"
+
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+    echo "error: working tree has uncommitted changes." >&2
+    exit 1
+fi
+
+git remote get-url "$REMOTE" >/dev/null 2>&1 || {
+    echo "error: no such remote '$REMOTE'." >&2; exit 1; }
+
+echo "  fetching $REMOTE ..."
+git fetch --tags "$REMOTE" >/dev/null 2>&1
+
+REV_SHA="$(git rev-parse --verify "${REVISION}^{commit}")"
+echo "  releasing the content of $REVISION ($(git rev-parse --short "$REV_SHA"))"
+
+readonly NEW_TAG="${TAG_PREFIX}${VERSION}"
+if git rev-parse -q --verify "refs/tags/${NEW_TAG}" >/dev/null; then
+    echo "error: ${NEW_TAG} is already tagged; pick a new version." >&2
+    exit 1
+fi
+
+# ------------------------------------------------------- previous release
+
+step "Determining the release base"
+
+if [ -n "$PREVIOUS" ]; then
+    PREV_TAG="${PREVIOUS}"
+    git rev-parse -q --verify "refs/tags/${PREV_TAG}" >/dev/null || {
+        echo "error: no such tag '${PREV_TAG}'." >&2; exit 1; }
+    echo "  using --previous ${PREV_TAG}"
+else
+    # Only tags reachable from the revision are candidates: a tag on a newer
+    # line is not something this release can be a successor to.
+    PREV_TAG="$(git tag --list --merged "$REV_SHA" "${TAG_PREFIX}[0-9]*" \
+                | sed "s/^${TAG_PREFIX}//" | version_sort | tail -1 \
+                | sed "s/^/${TAG_PREFIX}/")"
+    [ -n "$PREV_TAG" ] || {
+        echo "error: no release tags are reachable from ${REVISION}." >&2
+        echo "       pass --previous <tag> to say which release this follows." >&2
+        exit 1; }
+    echo "  newest release reachable from ${REVISION}: ${PREV_TAG}"
+fi
+
+PREV_VERSION="${PREV_TAG#"$TAG_PREFIX"}"
+if version_le "$VERSION" "$PREV_VERSION"; then
+    echo "error: ${VERSION} does not come after ${PREV_VERSION}." >&2
+    exit 1
+fi
+
+readonly RELEASE_BRANCH="release/${TAG_PREFIX}${VERSION}"
+readonly REVIEW_BRANCH="review/${TAG_PREFIX}${VERSION}"
+
+for b in "$RELEASE_BRANCH" "$REVIEW_BRANCH"; do
+    git rev-parse -q --verify "refs/heads/${b}" >/dev/null && {
+        echo "error: branch ${b} already exists locally." >&2; exit 1; }
+done
+
+echo
+echo "  ${RELEASE_BRANCH}  <- ${PREV_TAG}        (PR base, pushed to ${REMOTE})"
+echo "  ${REVIEW_BRANCH}   <- ${REVISION}   (version bumps go here)"
+
+# --------------------------------------------------------------- branches
+
+step "Creating ${RELEASE_BRANCH} from ${PREV_TAG}"
+run git branch "$RELEASE_BRANCH" "refs/tags/${PREV_TAG}"
+run git push "$REMOTE" "${RELEASE_BRANCH}:${RELEASE_BRANCH}"
+
+step "Creating ${REVIEW_BRANCH} from ${REVISION}"
+run git switch -c "$REVIEW_BRANCH" "$REV_SHA"
+
+# ------------------------------------------------------------ version bump
+
+step "Bumping the version to ${VERSION}"
+
+bump_versions() {
+    # gradle.properties carries the version the Gradle publishing conventions
+    # read. IS_SNAPSHOT is deliberately left alone: release publishing passes
+    # -PIS_SNAPSHOT=false rather than committing the change.
+    sed -i "s/^LIBRARY_VERSION=.*/LIBRARY_VERSION=${VERSION}/" gradle.properties
+
+    # Only the [package] version, which is the first `version =` in the file;
+    # the dependency versions below it must not be touched.
+    sed -i "0,/^version = \".*\"$/s//version = \"${VERSION}\"/" backend-lib/Cargo.toml
+
+    # Let cargo rewrite the lock's package entry rather than editing it by
+    # hand, so the lock stays internally consistent.
+    cargo update --manifest-path backend-lib/Cargo.toml --workspace --offline >/dev/null
+}
+
+if $DRY_RUN; then
+    echo "  would set LIBRARY_VERSION, backend-lib/Cargo.toml and Cargo.lock to ${VERSION}"
+else
+    bump_versions
+    for f in gradle.properties backend-lib/Cargo.toml; do
+        grep -q "${VERSION}" "$f" || { echo "error: ${f} not updated." >&2; exit 1; }
+    done
+    grep -A1 '^name = "zcash-android-wallet-sdk"' backend-lib/Cargo.lock \
+        | grep -q "version = \"${VERSION}\"" \
+        || { echo "error: Cargo.lock package entry not updated." >&2; exit 1; }
+    echo "  gradle.properties, backend-lib/Cargo.toml, backend-lib/Cargo.lock"
+fi
+
+# ------------------------------------------------------------- CHANGELOG
+
+step "Promoting the CHANGELOG"
+
+# Entries are written as part of the commit that makes each change, so this
+# only ever promotes what is already there -- it never generates text. An
+# empty Unreleased section means the entries were not written, which is much
+# more likely to be an oversight than a genuinely invisible release.
+if ! awk '/^## \[Unreleased\]/{f=1;next} f && /^## \[/{exit} f && NF{found=1} END{exit !found}' CHANGELOG.md; then
+    echo "error: the [Unreleased] section is empty." >&2
+    echo "       Every user-visible change needs an entry before release; see" >&2
+    echo "       the CHANGELOG discipline in AGENTS.md." >&2
+    exit 1
+fi
+
+if $DRY_RUN; then
+    echo "  would insert '## [${VERSION}] - $(date +%Y-%m-%d)' below [Unreleased]"
+else
+    awk -v ver="$VERSION" -v date="$(date +%Y-%m-%d)" '
+        !done && /^## \[Unreleased\]/ { print; print ""; print "## [" ver "] - " date; done=1; next }
+        { print }
+    ' CHANGELOG.md > CHANGELOG.md.tmp && mv CHANGELOG.md.tmp CHANGELOG.md
+    grep -q "^## \[${VERSION}\] - " CHANGELOG.md \
+        || { echo "error: CHANGELOG not promoted." >&2; exit 1; }
+    echo "  ## [${VERSION}] - $(date +%Y-%m-%d)"
+fi
+
+# ----------------------------------------------------------------- commit
+
+step "Committing"
+run git add gradle.properties backend-lib/Cargo.toml backend-lib/Cargo.lock CHANGELOG.md
+run git commit -m "Prepare SDK release ${VERSION}"
+
+if $PUSH_REVIEW; then
+    step "Pushing ${REVIEW_BRANCH}"
+    run git push -u "$REMOTE" "$REVIEW_BRANCH"
+fi
+
+# ------------------------------------------------------------- next steps
+
+cat <<EOF
+
+Done. ${RELEASE_BRANCH} is on ${REMOTE}; ${REVIEW_BRANCH} is checked out here.
+
+Next:
+EOF
+$PUSH_REVIEW || echo "  git push -u ${REMOTE} ${REVIEW_BRANCH}"
+cat <<EOF
+  gh pr create --repo zcash/zcash-android-wallet-sdk \\
+      --base ${RELEASE_BRANCH} --head ${REVIEW_BRANCH} \\
+      --title "Release zcash-android-wallet-sdk ${VERSION}"
+
+Review the PR diff: it is exactly what users get over ${PREV_TAG}. Then merge
+it, tag ${NEW_TAG} on ${RELEASE_BRANCH}, and afterwards merge the release
+branch back into its maint/ branch and forward along the chain, as described
+in CONTRIBUTING.md.
+EOF


### PR DESCRIPTION
Documents the maintenance-branch and release process in `CONTRIBUTING.md`, and adds `scripts/start-release.sh` to automate the branch setup it describes.

Targets `maint/v2.7.x`, the oldest currently-supported line, so it merges forward to `maint/v2.8.x` and `main` — per the rule the document itself states.

Opened without a closing keyword: this is documentation and tooling with no tracking issue.

## `CONTRIBUTING.md`

A new **Release and Maintenance Branches** section covering the three things that are easy to get wrong and fail quietly:

- **Base bug fixes on the oldest supported maintenance branch.** The rule is *merge forward, cherry-pick back*. A fix based on a newer line can't travel to an older one by merging at all.
- **Cut `release/vX.Y.Z` from the previous release tag**, not from the maintenance branch. That is what makes the release PR's diff exactly what users receive, rather than the intervening development history.
- **Do version bumps on `review/vX.Y.Z`**, not on the release branch.

Plus the post-release merges — release → `maint/vX.Y.x` → forward along the chain → `main` — with the note that merging maint back to `main` is regular practice, not release-time-only. Skipping a forward merge is how a fix silently regresses: a user upgrading 2.7.1 → 2.8.0 loses it.

Three ASCII diagrams: the fix path, the release PR shape, and the post-release merges. The release one in particular is hard to describe without showing which branch starts where.

## `scripts/start-release.sh`

Takes the release through steps 1–4: works out which release this one follows, cuts and pushes `release/vX.Y.Z`, cuts `review/vX.Y.Z`, bumps the version, promotes the CHANGELOG, commits. It stops before tagging, publishing, and opening the PR — the points where someone should read the diff. `--dry-run` shows the plan.

Two details worth review attention:

**Base-tag selection.** The previous release is the newest version tag *reachable from the revision being released*, not the newest tag in the repository. And `sort -V` can't be used directly — it ranks `2.7.0-rc.1` **above** `2.7.0`, while semver puts a pre-release before its release. Mapping `-` → `~` before sorting fixes it, since `sort -V` treats `~` as lower than the empty string. Verified against this repo's ~80 tags: it selects `v2.7.0-rc.1` correctly.

**Version bumping.** Only the `[package]` version in `backend-lib/Cargo.toml` may change — it's the first `version =` line, so the substitution is anchored to the first match rather than applied over the dependency versions below it. `Cargo.lock` is rewritten by cargo rather than by hand. `IS_SNAPSHOT` is deliberately untouched, since release publishing passes `-PIS_SNAPSHOT=false`.

**CHANGELOG handling** is the main departure from zcashd's `make-release.py`, which generates release notes from git history at release time. We can't: entries are written as part of the commit that makes each change. So the script only *promotes* `[Unreleased]` to a dated heading and never generates text — and it refuses to run when `[Unreleased]` is empty, since that almost always means the entries were never written.

## Verification

Dry-run exercised against the real repository. The `sed`/`awk` transformations were tested on file copies rather than assumed: the `[package]` bump leaves every dependency version intact, `IS_SNAPSHOT` is unchanged, and the empty-`[Unreleased]` guard was confirmed to fire in both directions.

A sibling PR adds the same document and script to `zcash-swift-wallet-sdk`, written in that repository's own naming (unprefixed tags, `release/X.Y.Z`).

---

_Opened with the assistance of Claude Code._
