### PR TITLE
Carry migration transfer ids as Long, not decimal strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   line, adapting the backend to the send-max and builder API changes.
 - Updated the librustzcash crates to their published releases,
   `zcash_client_backend 0.24.0-rc.2` and `zcash_client_sqlite 0.22.0-rc.2`.
+- Migration transfer ids are `Long` (the engine's `u32`, widened as this JNI boundary widens every
+  unsigned 32-bit value) rather than decimal strings, across `JniTransferProposal`,
+  `JniPreparedTransfer`, `JniMigrationTransferState`, `JniUnsignedTransferPczt`,
+  `JniAttentionReason.InvalidTransfer`, their `MigrationSdk` counterparts
+  (`TransferProposal`, `MigrationTransferState`, `AttentionReason.InvalidTransfer`),
+  `recordTransferResult(transferId:)`, and the `ids` array of `storeSignedSchedulePczts`
+  (now a `LongArray`). The id identifies the TRANSFER, not one broadcast attempt: a rebuilt
+  expired transfer keeps its id while getting a new transaction id, so it stays the key to
+  correlate on.
 - The native backend no longer runs any DDL or direct DML against wallet-database
   internals: the pre-release schema self-heal shim for
   `orchard_ironwood_migration_transactions` is removed (wallets created against

--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -3286,9 +3286,9 @@ dependencies = [
 
 [[package]]
 name = "pczt"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3935cce17fdfba4d70187a2075302e0d576192629e93579c8ac5086948bb15"
+checksum = "508e40a1767b8054533db0fdfe9ddce29e708fa4f8bcfe68056995d46f5ee711"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -6638,7 +6638,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vote-commitment-tree"
 version = "0.3.2"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=7d39d02b297f0ce23751f2638bf403285e34e675#7d39d02b297f0ce23751f2638bf403285e34e675"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=e53e74487d31ad0f5713580fb2f0222b53ae9db8#e53e74487d31ad0f5713580fb2f0222b53ae9db8"
 dependencies = [
  "anyhow",
  "ff",
@@ -6654,7 +6654,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.5.2"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=7d39d02b297f0ce23751f2638bf403285e34e675#7d39d02b297f0ce23751f2638bf403285e34e675"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=e53e74487d31ad0f5713580fb2f0222b53ae9db8#e53e74487d31ad0f5713580fb2f0222b53ae9db8"
 dependencies = [
  "base64",
  "ff",
@@ -7367,9 +7367,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.2"
+version = "0.24.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f489078672c0f4399b731cb5d4cd934c7820c51de2b4a1e7d2594857916250f0"
+checksum = "103eca02554239be80ffaa6fef0b617d60a527f8e3b288cee0de533b9b00a571"
 dependencies = [
  "arti-client",
  "base64",
@@ -7435,9 +7435,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.2"
+version = "0.22.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a2d018a15b2e4374a08f2472f8d4309079cbbfa2f697fbfb864ef6bacd4792"
+checksum = "0953496bf58df03c4c240d3a55196c62385997c67cbde78eb02960fe7a003c1a"
 dependencies = [
  "bip32",
  "bitflags",
@@ -7537,9 +7537,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_pool_migration"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852d7e66febd7ec83aa7fbd254a33872bf1c4cd072bdc74f65f253ec3a2ef8f4"
+checksum = "520816e0e6b35ff936a7247fd5c7203800274a7328ed76f644614fc0747aa5a6"
 dependencies = [
  "corez",
  "getset",
@@ -7674,8 +7674,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "1.0.0"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=7d39d02b297f0ce23751f2638bf403285e34e675#7d39d02b297f0ce23751f2638bf403285e34e675"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/valargroup/zcash_voting.git?rev=e53e74487d31ad0f5713580fb2f0222b53ae9db8#e53e74487d31ad0f5713580fb2f0222b53ae9db8"
 dependencies = [
  "anyhow",
  "base64",

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -35,12 +35,12 @@ slipstream = ["dep:slipstream-core", "dep:tokio", "dep:tracing-android", "tracin
 # voting-circuits support the old git pin provided, matching the zcash-swift-wallet-sdk pin.
 # No orchard [patch] entry is needed (and slipstream-core requires ^0.15.4, which it satisfies).
 orchard = { version = "0.15", features = ["unstable-voting-circuits"] }
-zcash_pool_migration = { version = "0.1.0-rc.1", features = ["wallet"] }
-pczt = { version = "0.8", features = ["prover", "orchard", "sapling", "signer"] }
+zcash_pool_migration = { version = "0.1.0-rc.2", features = ["wallet"] }
+pczt = { version = "0.9", features = ["prover", "orchard", "sapling", "signer"] }
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
 transparent = { package = "zcash_transparent", version = "0.10", default-features = false }
 zcash_address = "0.13"
-zcash_client_backend = { version = "0.24.0-rc.2", features = [
+zcash_client_backend = { version = "0.24.0-rc.3", features = [
     "orchard",
     "lightwalletd-tonic-tls-webpki-roots",
     "tor",
@@ -48,7 +48,7 @@ zcash_client_backend = { version = "0.24.0-rc.2", features = [
     "unstable",
     "pczt",
 ] }
-zcash_client_sqlite = { version = "0.22.0-rc.2", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
+zcash_client_sqlite = { version = "0.22.0-rc.3", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
 zcash_note_encryption = "0.4.1"
 zcash_primitives = "0.30"
 zcash_proofs = "0.30"
@@ -120,7 +120,7 @@ xz2 = { version = "0.1", features = ["static"] }
 # The transitive `voting-circuits` dependency contains the share-reveal circuit
 # and the Poseidon-based `share_nullifier_hash` implementation:
 # https://github.com/valargroup/voting-circuits/blob/v0.8.0/voting-circuits/src/share_reveal/circuit.rs
-zcash_voting = { version = "1.0.0", optional = true }
+zcash_voting = { version = "2.0.0-rc.1", optional = true }
 # The delegation-submission signing recipe (voting/delegation.rs) derives the account
 # SpendAuth key locally and needs the same Pallas scalar/field types zcash_voting and
 # orchard already carry transitively; pin to the versions already resolved for them
@@ -166,7 +166,7 @@ tracing-android = { version = "0.2", optional = true }
 
 [patch.crates-io]
 slipstream-core = { git = "https://github.com/zodl-inc/slipstream.git", rev = "35faa0c2f2095704c53d79849d2ef547c4ce2cad" }
-zcash_voting = { git = "https://github.com/valargroup/zcash_voting.git", rev = "7d39d02b297f0ce23751f2638bf403285e34e675" }
+zcash_voting = { git = "https://github.com/valargroup/zcash_voting.git", rev = "e53e74487d31ad0f5713580fb2f0222b53ae9db8" }
 
 ## Uncomment and modify the following block to use librustzcash crates at a pinned revision.
 #[patch.crates-io]

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/MigrationRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/MigrationRustBackend.kt
@@ -192,7 +192,7 @@ class MigrationRustBackend private constructor() {
         dbDataPath: String,
         networkId: Int,
         accountUuidBytes: ByteArray,
-        transferId: String,
+        transferId: Long,
         resultTag: Int,
         retryable: Boolean,
         txId: ByteArray
@@ -434,7 +434,7 @@ class MigrationRustBackend private constructor() {
         dbDataPath: String,
         networkId: Int,
         accountUuidBytes: ByteArray,
-        ids: Array<String>,
+        ids: LongArray,
         pcztBytesList: Array<ByteArray>
     ) = withContext(SdkDispatchers.DATABASE_IO) {
         storeSignedSchedulePcztsNative(dbDataPath, networkId, accountUuidBytes, ids, pcztBytesList)
@@ -621,7 +621,7 @@ class MigrationRustBackend private constructor() {
             dbDataPath: String,
             networkId: Int,
             accountUuidBytes: ByteArray,
-            transferId: String,
+            transferId: Long,
             resultTag: Int,
             retryable: Boolean,
             txId: ByteArray
@@ -748,7 +748,7 @@ class MigrationRustBackend private constructor() {
             dbDataPath: String,
             networkId: Int,
             accountUuidBytes: ByteArray,
-            ids: Array<String>,
+            ids: LongArray,
             pcztBytesList: Array<ByteArray>
         )
 

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/migration/JniMigrationModels.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/migration/JniMigrationModels.kt
@@ -41,22 +41,34 @@ class JniNoteSplitProposal(
  */
 @Keep
 class JniPreparedTransfer(
-    val id: String,
+    val id: Long,
     val txid: ByteArray,
     val pcztBytes: ByteArray
-)
+) {
+    init {
+        require(id.isInUIntRange()) {
+            "Transfer id $id is outside of allowed UInt range"
+        }
+    }
+}
 
 /**
  * Serves as cross layer (Kotlin, Rust) communication class.
  */
 @Keep
 class JniTransferProposal(
-    val id: String,
+    val id: Long,
     val amountZatoshi: Long,
     val anchorHeight: Long,
     val nextExecutableAfterHeight: Long,
     val expiryHeight: Long
-)
+) {
+    init {
+        require(id.isInUIntRange()) {
+            "Transfer id $id is outside of allowed UInt range"
+        }
+    }
+}
 
 /**
  * Serves as cross layer (Kotlin, Rust) communication class.
@@ -81,10 +93,16 @@ class JniMigrationSchedule(
  */
 @Keep
 class JniMigrationTransferState(
-    val id: String,
+    val id: Long,
     val isSent: Boolean,
     val scheduledHeight: Long
-)
+) {
+    init {
+        require(id.isInUIntRange()) {
+            "Transfer id $id is outside of allowed UInt range"
+        }
+    }
+}
 
 /**
  * Serves as cross layer (Kotlin, Rust) communication class. The live schedule/status of every
@@ -105,9 +123,15 @@ class JniMigrationTransferStates(
  */
 @Keep
 class JniUnsignedTransferPczt(
-    val id: String,
+    val id: Long,
     val pcztBytes: ByteArray
-)
+) {
+    init {
+        require(id.isInUIntRange()) {
+            "Transfer id $id is outside of allowed UInt range"
+        }
+    }
+}
 
 /**
  * Serves as cross layer (Kotlin, Rust) communication class. The result of feeding one scanned QR
@@ -145,8 +169,14 @@ class JniKeystoneBatchSignedPczts(
 sealed class JniAttentionReason {
     @Keep
     class InvalidTransfer(
-        val transferId: String
-    ) : JniAttentionReason()
+        val transferId: Long
+    ) : JniAttentionReason() {
+        init {
+            require(transferId.isInUIntRange()) {
+                "Transfer id $transferId is outside of allowed UInt range"
+            }
+        }
+    }
 
     @Keep
     class TransferExpired : JniAttentionReason()

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -58,8 +58,9 @@ use zcash_protocol::{PoolType, ShieldedPool};
 use zcash_pool_migration::wallet::{WalletMigrationProver, WalletProveError};
 use zcash_pool_migration::{
     engine::{
-        self, MigrationCrypto, MigrationPlan, MigrationState, MigrationTransaction, MigrationTxId,
-        MigrationTxKind, MigrationTxState, PoolMigrationRead, PoolMigrationWrite, ProveError,
+        self, MigrationCrypto, MigrationPlan, MigrationState, MigrationTransaction,
+        MigrationTransferId, MigrationTxKind, MigrationTxState, PoolMigrationRead,
+        PoolMigrationWrite, ProveError,
     },
     scheduling::AnchorBucketInterval,
 };
@@ -345,7 +346,7 @@ fn plan(
 /// A migration state paired with the transactions it left awaiting signature, each as its
 /// id and PCZT bytes. Named because both the commit entry point and every `sign` closure it
 /// dispatches to return this same shape.
-type MigrationCommitOutcome = (MigrationState, Vec<(MigrationTxId, Vec<u8>)>);
+type MigrationCommitOutcome = (MigrationState, Vec<(MigrationTransferId, Vec<u8>)>);
 
 /// The wallet-side context a commit runs against: which network and account, the store
 /// connection it writes through, and the target height the cached plan was built for. Grouped
@@ -490,7 +491,7 @@ fn encode_note_split_proposal<'a>(
     plan: &MigrationPlan,
     plan_handle: crate::migration_plan_cache::PlanHandle,
 ) -> jni::errors::Result<JObject<'a>> {
-    let split = plan.note_split();
+    let split = plan.denominations();
     let values: Vec<i64> = split
         .crossing_values()
         .iter()
@@ -514,15 +515,16 @@ fn encode_note_split_proposal<'a>(
 /// A transaction id as Kotlin receives it: the engine's `u32` widened to the `Long` this JNI
 /// boundary uses for every unsigned 32-bit value (heights included), so the value survives without
 /// a sign flip and Kotlin can range-check it.
-fn encode_transfer_id(id: MigrationTxId) -> jlong {
+fn encode_transfer_id(id: MigrationTransferId) -> jlong {
     jlong::from(u32::from(id))
 }
 
 /// The inverse of [`encode_transfer_id`]: a `Long` from Kotlin back to the engine's id. Rejects
 /// values outside the `u32` range rather than truncating them into a different transaction.
-fn decode_transfer_id(id: jlong) -> anyhow::Result<MigrationTxId> {
-    let idx = u32::try_from(id).map_err(|_| anyhow!("Transfer id {} is outside the u32 range", id))?;
-    Ok(MigrationTxId::new(idx))
+fn decode_transfer_id(id: jlong) -> anyhow::Result<MigrationTransferId> {
+    let idx =
+        u32::try_from(id).map_err(|_| anyhow!("Transfer id {} is outside the u32 range", id))?;
+    Ok(MigrationTransferId::new(idx))
 }
 
 /// `anchor_height` here is NOT a real commitment-tree anchor (ZIP 374 defers that to proving time
@@ -535,7 +537,7 @@ fn decode_transfer_id(id: jlong) -> anyhow::Result<MigrationTxId> {
 /// correctly spread out (see the `MIGRATION_DIAG plan:` log in `plan()` above).
 fn encode_transfer_proposal<'a>(
     env: &mut JNIEnv<'a>,
-    id: MigrationTxId,
+    id: MigrationTransferId,
     amount: Zatoshis,
     anchor_height: BlockHeight,
     schedule_broadcast_height: BlockHeight,
@@ -575,7 +577,7 @@ fn encode_migration_schedule<'a>(
     // displaying the received amount, fee visible only in the transaction detail), so subtract the
     // constant fee buffer back out to recover the round `{1,2,5}×10ⁿ` crossing value per note.
     let funding_notes = plan.funding_notes();
-    let note_fee_buffer = plan.note_split().note_fee_buffer();
+    let note_fee_buffer = plan.denominations().note_fee_buffer();
     let schedule = plan.schedule();
     if funding_notes.len() != schedule.len() {
         return Err(anyhow!(
@@ -592,7 +594,7 @@ fn encode_migration_schedule<'a>(
         })
         .collect();
 
-    // The real `MigrationTxId` the engine will assign at commit time numbers every preparation
+    // The real `MigrationTransferId` the engine will assign at commit time numbers every preparation
     // transaction (across all layers) first, THEN transfers in `schedule()` order (confirmed
     // directly against `commit_preparation_inner` in `zcash_pool_migration::engine`) — so
     // transfer `i`'s id is `prep_tx_count + i`, not `i`. Getting this wrong doesn't affect Kotlin
@@ -610,7 +612,7 @@ fn encode_migration_schedule<'a>(
     let mut proposals = Vec::with_capacity(schedule.len());
     for (i, (amount, entry)) in crossings.iter().zip(schedule.iter()).enumerate() {
         proposals.push((
-            MigrationTxId::new(prep_tx_count + i as u32),
+            MigrationTransferId::new(prep_tx_count + i as u32),
             *amount,
             entry.broadcast_height(),
             entry.expiry_height(),
@@ -695,7 +697,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
 }
 
 /// The new engine plans the note split and the transfer schedule together in one
-/// `plan_migration()` call (the split's realized output values ARE `plan.note_split()
+/// `plan_migration()` call (the split's realized output values ARE `plan.denominations()
 /// .crossing_values()`, which is exactly what `encode_migration_schedule` already derives the
 /// schedule from) — so unlike `proposeMigrationTransfersNative` above, this does NOT plan afresh:
 /// it encodes the schedule of the exact cached plan `proposal_handle` identifies (the one whose
@@ -808,7 +810,7 @@ fn try_prove(
     account: AccountUuid,
     fvk: orchard::keys::FullViewingKey,
     state: &mut MigrationState,
-    id: MigrationTxId,
+    id: MigrationTransferId,
     kind: MigrationTxKind,
 ) -> anyhow::Result<bool> {
     let anchor = match kind {
@@ -851,7 +853,7 @@ fn finalize_note_split(
     account: AccountUuid,
     store_conn: &mut Connection,
     state: &mut MigrationState,
-    id: MigrationTxId,
+    id: MigrationTransferId,
 ) -> anyhow::Result<(Vec<u8>, [u8; 32])> {
     let fvk = {
         let backend = Backend::new(wallet, account, None, store_conn)?;
@@ -1346,7 +1348,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         // Collect ready ids/kinds up front (not while iterating `state.transactions()`) since
         // `try_prove` needs `&mut state` — see `is_prove_ready`'s doc comment for why this doesn't
         // just loop `MigrationState::next_provable`.
-        let ready: Vec<(MigrationTxId, MigrationTxKind)> = state
+        let ready: Vec<(MigrationTransferId, MigrationTxKind)> = state
             .transactions()
             .iter()
             .filter(|t| {
@@ -1495,14 +1497,14 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
             return Ok(ptr::null_mut());
         };
 
-        // Keyed by the transfer's real, stable MigrationTxId — NOT `transfer_crossing()` (the
+        // Keyed by the transfer's real, stable MigrationTransferId — NOT `transfer_crossing()` (the
         // funding-note/crossing index). The app's displayed "Transfer N" position comes from
         // sorting the ORIGINAL proposal by broadcast_height (see `encode_migration_schedule`),
         // while the engine assigns real tx ids in crossing/schedule() order at commit time —
         // ZIP 318 deliberately shuffles those two orderings apart, so they permanently disagree.
         // The app now carries this same id on its cached `MigrationTransfer.id` (see
         // `MigrationSchedule.toMigrationPlan`), which is the only stable key the two sides share.
-        let transfers: Vec<(MigrationTxId, bool, BlockHeight)> = state
+        let transfers: Vec<(MigrationTransferId, bool, BlockHeight)> = state
             .transactions()
             .iter()
             .filter(|t| matches!(t.kind(), MigrationTxKind::Transfer { .. }))
@@ -1705,7 +1707,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         // transfer anchors lie on.
         let cancelled = MigrationState::from_parts(
             engine::MigrationStatus::Failed,
-            state.note_split().clone(),
+            state.denominations().clone(),
             state.preparation().clone(),
             state.transactions().clone(),
             state.anchor_bucket_interval(),
@@ -1832,7 +1834,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
 
         // The new (scheduled_height, anchor_boundary) for each pending transfer, keyed by its
         // stable id so the full transactions vec can be rebuilt in its original order below.
-        let mut reschedule: HashMap<MigrationTxId, (BlockHeight, Option<BlockHeight>)> =
+        let mut reschedule: HashMap<MigrationTransferId, (BlockHeight, Option<BlockHeight>)> =
             HashMap::with_capacity(pending.len());
         for (i, tx) in pending.iter().enumerate() {
             let new_height = BlockHeight::from(
@@ -1881,7 +1883,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
 
         let new_state = MigrationState::from_parts(
             state.status(),
-            state.note_split().clone(),
+            state.denominations().clone(),
             state.preparation().clone(),
             new_transactions,
             match network {
@@ -2164,7 +2166,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                 ))
             },
         )?;
-        let transfer_ids: std::collections::HashSet<MigrationTxId> = state
+        let transfer_ids: std::collections::HashSet<MigrationTransferId> = state
             .transactions()
             .iter()
             .filter(|t| matches!(t.kind(), MigrationTxKind::Transfer { .. }))
@@ -2559,7 +2561,7 @@ mod live_wallet_signing_tests {
             backend.orchard_fvk().expect("fvk")
         };
 
-        let ids_and_kinds: Vec<(MigrationTxId, MigrationTxKind)> = state
+        let ids_and_kinds: Vec<(MigrationTransferId, MigrationTxKind)> = state
             .transactions()
             .iter()
             .map(|t| (t.id(), t.kind()))
@@ -3170,7 +3172,7 @@ mod live_wallet_edge_case_tests {
         let db_path = fresh_test_db_copy(&fixture_db_path());
         let network = Network::TestNetwork;
 
-        let committed_ids: Vec<MigrationTxId> = {
+        let committed_ids: Vec<MigrationTransferId> = {
             let (wallet, mut store_conn) = open_at(&db_path, network).expect("open wallet");
             let account = first_account(&wallet);
             let (plan, tip, _handle) =
@@ -3194,7 +3196,7 @@ mod live_wallet_edge_case_tests {
             .get_migration()
             .expect("read migration state")
             .expect("migration state must persist across a fresh connection to the same DB file");
-        let reloaded_ids: Vec<MigrationTxId> =
+        let reloaded_ids: Vec<MigrationTransferId> =
             reloaded.transactions().iter().map(|t| t.id()).collect();
         assert_eq!(
             committed_ids, reloaded_ids,

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -34,7 +34,7 @@
 use anyhow::anyhow;
 use jni::{
     JNIEnv,
-    objects::{JByteArray, JClass, JObject, JObjectArray, JString, JValue},
+    objects::{JByteArray, JClass, JLongArray, JObject, JObjectArray, JString, JValue},
     sys::{JNI_FALSE, JNI_TRUE, jboolean, jbyteArray, jint, jlong, jobject, jobjectArray},
 };
 use prost::Message;
@@ -511,18 +511,17 @@ fn encode_note_split_proposal<'a>(
     )
 }
 
-fn encode_transfer_id<'a>(
-    env: &mut JNIEnv<'a>,
-    id: MigrationTxId,
-) -> jni::errors::Result<JString<'a>> {
-    env.new_string(u32::from(id).to_string())
+/// A transaction id as Kotlin receives it: the engine's `u32` widened to the `Long` this JNI
+/// boundary uses for every unsigned 32-bit value (heights included), so the value survives without
+/// a sign flip and Kotlin can range-check it.
+fn encode_transfer_id(id: MigrationTxId) -> jlong {
+    jlong::from(u32::from(id))
 }
 
-fn decode_transfer_id(env: &mut JNIEnv, id: &JString) -> anyhow::Result<MigrationTxId> {
-    let raw = crate::utils::java_string_to_rust(env, id)?;
-    let idx: u32 = raw
-        .parse()
-        .map_err(|e| anyhow!("Invalid transfer id {}: {}", raw, e))?;
+/// The inverse of [`encode_transfer_id`]: a `Long` from Kotlin back to the engine's id. Rejects
+/// values outside the `u32` range rather than truncating them into a different transaction.
+fn decode_transfer_id(id: jlong) -> anyhow::Result<MigrationTxId> {
+    let idx = u32::try_from(id).map_err(|_| anyhow!("Transfer id {} is outside the u32 range", id))?;
     Ok(MigrationTxId::new(idx))
 }
 
@@ -542,12 +541,11 @@ fn encode_transfer_proposal<'a>(
     schedule_broadcast_height: BlockHeight,
     schedule_expiry_height: BlockHeight,
 ) -> jni::errors::Result<JObject<'a>> {
-    let id = encode_transfer_id(env, id)?;
     env.new_object(
         JNI_TRANSFER_PROPOSAL,
-        "(Ljava/lang/String;JJJJ)V",
+        "(JJJJJ)V",
         &[
-            JValue::Object(&id),
+            JValue::Long(encode_transfer_id(id)),
             JValue::Long(u64::from(amount) as i64),
             JValue::Long(i64::from(u32::from(anchor_height))),
             JValue::Long(i64::from(u32::from(schedule_broadcast_height))),
@@ -956,15 +954,15 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let (proven_pczt, txid) =
             finalize_note_split(&mut wallet, account, &mut store_conn, &mut state, split_id)?;
 
-        let id = encode_transfer_id(env, split_id)?;
+        let id = encode_transfer_id(split_id);
         let txid_obj = crate::utils::rust_bytes_to_java(env, &txid)?;
         let pczt_obj = crate::utils::rust_bytes_to_java(env, &proven_pczt)?;
         Ok(env
             .new_object(
                 JNI_PREPARED_TRANSFER,
-                "(Ljava/lang/String;[B[B)V",
+                "(J[B[B)V",
                 &[
-                    JValue::Object(&id),
+                    JValue::Long(id),
                     JValue::Object(&txid_obj),
                     JValue::Object(&pczt_obj),
                 ],
@@ -1009,7 +1007,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     db_data: JString<'local>,
     network_id: jint,
     account_uuid: JByteArray<'local>,
-    transfer_id: JString<'local>,
+    transfer_id: jlong,
     result_tag: jint,
     _retryable: jboolean,
     tx_id: JByteArray<'local>,
@@ -1017,7 +1015,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     let res = catch_unwind(&mut env, |env| {
         let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
-        let id = decode_transfer_id(env, &transfer_id)?;
+        let id = decode_transfer_id(transfer_id)?;
         let mut backend = Backend::new(&wallet, account, None, &mut store_conn)?;
         match result_tag {
             // Success: record the broadcast txid. `mark_mined` has no old-crate equivalent call
@@ -1451,15 +1449,15 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         .map_err(|e| anyhow!("extract proven transfer tx: {:?}", e))?;
         let txid: [u8; 32] = *extracted.txid().as_ref();
 
-        let id = encode_transfer_id(env, tx.id())?;
+        let id = encode_transfer_id(tx.id());
         let txid_obj = crate::utils::rust_bytes_to_java(env, &txid)?;
         let pczt_obj = crate::utils::rust_bytes_to_java(env, bytes)?;
         Ok(env
             .new_object(
                 JNI_PREPARED_TRANSFER,
-                "(Ljava/lang/String;[B[B)V",
+                "(J[B[B)V",
                 &[
-                    JValue::Object(&id),
+                    JValue::Long(id),
                     JValue::Object(&txid_obj),
                     JValue::Object(&pczt_obj),
                 ],
@@ -1522,12 +1520,11 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
             transfers,
             JNI_MIGRATION_TRANSFER_STATE,
             |env, (id, is_sent, scheduled_height)| {
-                let id = encode_transfer_id(env, id)?;
                 env.new_object(
                     JNI_MIGRATION_TRANSFER_STATE,
-                    "(Ljava/lang/String;ZJ)V",
+                    "(JZJ)V",
                     &[
-                        JValue::Object(&id),
+                        JValue::Long(encode_transfer_id(id)),
                         JValue::Bool(is_sent as jboolean),
                         JValue::Long(i64::from(u32::from(scheduled_height))),
                     ],
@@ -2103,15 +2100,15 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let (proven_pczt, txid) =
             finalize_note_split(&mut wallet, account, &mut store_conn, &mut state, split_id)?;
 
-        let id = encode_transfer_id(env, split_id)?;
+        let id = encode_transfer_id(split_id);
         let txid_obj = crate::utils::rust_bytes_to_java(env, &txid)?;
         let pczt_bytes = crate::utils::rust_bytes_to_java(env, &proven_pczt)?;
         Ok(env
             .new_object(
                 JNI_PREPARED_TRANSFER,
-                "(Ljava/lang/String;[B[B)V",
+                "(J[B[B)V",
                 &[
-                    JValue::Object(&id),
+                    JValue::Long(id),
                     JValue::Object(&txid_obj),
                     JValue::Object(&pczt_bytes),
                 ],
@@ -2193,12 +2190,14 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
             transfers,
             JNI_UNSIGNED_TRANSFER_PCZT,
             |env, (id, pczt_bytes)| {
-                let id = encode_transfer_id(env, id)?;
                 let pczt_bytes = crate::utils::rust_bytes_to_java(env, &pczt_bytes)?;
                 env.new_object(
                     JNI_UNSIGNED_TRANSFER_PCZT,
-                    "(Ljava/lang/String;[B)V",
-                    &[JValue::Object(&id), JValue::Object(&pczt_bytes)],
+                    "(J[B)V",
+                    &[
+                        JValue::Long(encode_transfer_id(id)),
+                        JValue::Object(&pczt_bytes),
+                    ],
                 )
             },
         )?
@@ -2216,13 +2215,17 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     db_data: JString<'local>,
     network_id: jint,
     account_uuid: JByteArray<'local>,
-    ids: JObjectArray<'local>,
+    ids: JLongArray<'local>,
     pczt_bytes_list: JObjectArray<'local>,
 ) {
     let res = catch_unwind(&mut env, |env| {
         let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let count = env.get_array_length(&ids)?;
+        // A `long[]` is read as a region rather than element-by-element: the ids are primitives,
+        // not objects.
+        let mut raw_ids = vec![0i64; count as usize];
+        env.get_long_array_region(&ids, 0, &mut raw_ids)?;
         let mut backend = Backend::new(&wallet, account, None, &mut store_conn)?;
         let mut state = backend
             .get_migration()
@@ -2231,8 +2234,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         // Absorbs the new engine's per-transaction `apply_signature` into the old batch-shaped
         // call Kotlin still makes — see module doc point about the signed-PCZT return path.
         for i in 0..count {
-            let id_obj = env.get_object_array_element(&ids, i)?;
-            let id = decode_transfer_id(env, &JString::from(id_obj))?;
+            let id = decode_transfer_id(raw_ids[i as usize])?;
             let bytes_obj = env.get_object_array_element(&pczt_bytes_list, i)?;
             let pczt_bytes = crate::utils::java_bytes_to_rust(env, &JByteArray::from(bytes_obj))?;
             if !state.apply_signature(id, pczt_bytes) {

--- a/backend-lib/src/main/rust/migration_engine.rs
+++ b/backend-lib/src/main/rust/migration_engine.rs
@@ -35,7 +35,7 @@ use zcash_protocol::value::Zatoshis;
 
 use zcash_client_sqlite::pool_migration::orchard_ironwood::PoolMigrations;
 use zcash_pool_migration::engine::{
-    MigrationBackend, MigrationCrypto, MigrationState, MigrationTxId, MigrationTxState,
+    MigrationBackend, MigrationCrypto, MigrationState, MigrationTransferId, MigrationTxState,
     PoolMigrationRead, PoolMigrationWrite,
 };
 use zcash_pool_migration::scheduling::SchedulingParams;
@@ -234,7 +234,7 @@ where
 
     fn update_transaction(
         &mut self,
-        id: MigrationTxId,
+        id: MigrationTransferId,
         state: MigrationTxState,
     ) -> Result<(), Self::Error> {
         self.store

--- a/backend-lib/src/main/rust/migration_plan_cache.rs
+++ b/backend-lib/src/main/rust/migration_plan_cache.rs
@@ -14,7 +14,7 @@
 //! hazard).
 //!
 //! Unlike this file's neighbors, this is NOT backed by the wallet SQLite database: the new
-//! engine's `MigrationPlan` (and its `NoteSplitPlan`/`PreparationPlan` fields) has no `serde`
+//! engine's `MigrationPlan` (and its `DenominationPlan`/`PreparationPlan` fields) has no `serde`
 //! support and no public constructor — the only way to obtain one is calling `plan_migration()`
 //! itself (verified directly against `zcash_pool_migration`'s source, not assumed), so it
 //! can't be round-tripped through our own persistence the way `migration_finalize`'s proven-pczt

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
@@ -115,7 +115,7 @@ data class NoteSplitProposal(
  * invalid and [OrchardMigrationSdk.restartCurrentMigrationStep] must be called.
  */
 data class TransferProposal(
-    val id: String,
+    val id: Long,
     val amountZatoshi: Long,
     val anchorHeight: Long,
     val nextExecutableAfterHeight: Long,
@@ -182,7 +182,7 @@ data class KeystoneBatchSignedPczts(
  * shuffles those two orderings apart, so a caller must correlate by [id], never by array index.
  */
 data class MigrationTransferState(
-    val id: String,
+    val id: Long,
     val isSent: Boolean,
     val scheduledHeight: Long
 )
@@ -249,7 +249,7 @@ sealed class MigrationState {
 sealed class AttentionReason {
     /** Input note was spent externally before the migration transfer was broadcast. */
     data class InvalidTransfer(
-        val transferId: String
+        val transferId: Long
     ) : AttentionReason()
 
     /** Transaction anchor expired before broadcast (e.g. extended offline period). */
@@ -404,7 +404,7 @@ interface OrchardMigrationSdk {
      * placeholder-witness scheme [signAndStoreMigrationSchedule] does — callers do not need to
      * wait for the note-split to confirm on-chain before calling this either.
      */
-    suspend fun createUnsignedTransferPczts(schedule: MigrationSchedule): List<Pair<String, ByteArray>>
+    suspend fun createUnsignedTransferPczts(schedule: MigrationSchedule): List<Pair<Long, ByteArray>>
 
     /**
      * Accepts the full set of externally-signed transfer PCZTs — **all-or-nothing**, matched back
@@ -413,7 +413,7 @@ interface OrchardMigrationSdk {
      * role): [finalizeReadyTransfers] later completes any transfer that was staged awaiting proof,
      * exactly as it already does for the software-signing path.
      */
-    suspend fun storeSignedSchedulePczts(signed: List<Pair<String, ByteArray>>)
+    suspend fun storeSignedSchedulePczts(signed: List<Pair<Long, ByteArray>>)
 
     /**
      * Builds the animated multi-part QR frames for one combined Keystone batch-signing request

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
@@ -290,7 +290,7 @@ internal class OrchardMigrationSdkImpl(
             mapped.transferResult
         }
 
-    override suspend fun createUnsignedTransferPczts(schedule: MigrationSchedule): List<Pair<String, ByteArray>> =
+    override suspend fun createUnsignedTransferPczts(schedule: MigrationSchedule): List<Pair<Long, ByteArray>> =
         logged("createUnsignedTransferPczts") {
             val dbDataPath = dbDataPath()
             val account = account ?: noAccountAvailable()
@@ -299,7 +299,7 @@ internal class OrchardMigrationSdkImpl(
                 .map { it.id to it.pcztBytes }
         }
 
-    override suspend fun storeSignedSchedulePczts(signed: List<Pair<String, ByteArray>>) =
+    override suspend fun storeSignedSchedulePczts(signed: List<Pair<Long, ByteArray>>) =
         logged("storeSignedSchedulePczts") {
             val dbDataPath = dbDataPath()
             val account = account ?: noAccountAvailable()
@@ -307,7 +307,7 @@ internal class OrchardMigrationSdkImpl(
                 dbDataPath,
                 network,
                 account,
-                Array(signed.size) { signed[it].first },
+                LongArray(signed.size) { signed[it].first },
                 Array(signed.size) { signed[it].second },
             )
         }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackend.kt
@@ -106,7 +106,7 @@ internal interface TypesafeMigrationBackend {
         dbDataPath: String,
         network: ZcashNetwork,
         account: AccountUuid,
-        transferId: String,
+        transferId: Long,
         resultTag: Int,
         retryable: Boolean,
         txId: ByteArray
@@ -243,7 +243,7 @@ internal interface TypesafeMigrationBackend {
         dbDataPath: String,
         network: ZcashNetwork,
         account: AccountUuid,
-        ids: Array<String>,
+        ids: LongArray,
         pcztBytesList: Array<ByteArray>
     )
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackendImpl.kt
@@ -103,7 +103,7 @@ internal class TypesafeMigrationBackendImpl(
         dbDataPath: String,
         network: ZcashNetwork,
         account: AccountUuid,
-        transferId: String,
+        transferId: Long,
         resultTag: Int,
         retryable: Boolean,
         txId: ByteArray
@@ -219,7 +219,7 @@ internal class TypesafeMigrationBackendImpl(
         dbDataPath: String,
         network: ZcashNetwork,
         account: AccountUuid,
-        ids: Array<String>,
+        ids: LongArray,
         pcztBytesList: Array<ByteArray>
     ) = rustBackend().storeSignedSchedulePczts(dbDataPath, network.id, account.value, ids, pcztBytesList)
 

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImplTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImplTest.kt
@@ -254,7 +254,7 @@ class OrchardMigrationSdkImplTest {
             dbDataPath: String,
             network: ZcashNetwork,
             account: AccountUuid,
-            transferId: String,
+            transferId: Long,
             resultTag: Int,
             retryable: Boolean,
             txId: ByteArray
@@ -353,7 +353,7 @@ class OrchardMigrationSdkImplTest {
             dbDataPath: String,
             network: ZcashNetwork,
             account: AccountUuid,
-            ids: Array<String>,
+            ids: LongArray,
             pcztBytesList: Array<ByteArray>
         ) = error("Unused")
 


### PR DESCRIPTION
The Swift SDK counterpart is zcash/zcash-swift-wallet-sdk#1868; this is the same defect on the JNI boundary.

## The change

The engine's transfer id is a `u32`. The boundary rendered it as a Java `String` outbound and parsed it back inbound, which buys nothing — every id is engine-issued, round-tripped verbatim by the app, and never displayed — while costing a string allocation per schedule row, a parse-failure lane on every inbound call, and a Kotlin API where an opaque-looking `String` invites callers to construct one.

Ids now cross as **`Long`**: the width this boundary already uses for every unsigned 32-bit value (heights included), with the same `isInUIntRange()` guard, so an out-of-range id fails loudly at the boundary rather than silently becoming a different transaction.

- **Outbound:** `JniTransferProposal`, `JniPreparedTransfer`, `JniMigrationTransferState`, `JniUnsignedTransferPczt`, `JniAttentionReason.InvalidTransfer` (constructor signatures `(Ljava/lang/String;…)V` → `(J…)V`), and their `MigrationSdk` counterparts.
- **Inbound:** `recordTransferResult(transferId:)`, and `storeSignedSchedulePczts`' `ids` array — now a `LongArray`, read as a primitive region rather than element-by-element.

## Which identifier this is

It names the **transfer**, not one broadcast attempt. `rebuild_expired_transfer` keeps the transfer id while producing a new transaction with a new `TxId`, so this id — not the `TxId` — is what an app correlates its own records on across an expiry rebuild. zcash/librustzcash#2767 renames the engine type `MigrationTxId` → `MigrationTransferId` for the same reason; when the pin moves to that rc, the Rust references here rename with it.

## Testing

`:sdk-lib:compileDebugKotlin` and `:sdk-lib:testDebugUnitTest` both pass, and the JNI crate cross-compiles (`cargo ndk -t arm64-v8a check`, plus the full `cargoBuildArm` that the Kotlin build drives). The JNI signature changes are compile-checked on the Kotlin side and hand-matched on the Rust side — #2017's JNI ABI check would be the mechanical guard for exactly this class of change, if it lands.

Not run: instrumented tests (no emulator in this environment).

---

This PR was prepared with Claude Code assistance.
