### PR TITLE
[#2069] Request the full PCZT signer view for hardware signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `addProofsToPczt` now creates Ironwood proofs. It previously only handled Orchard and Sapling,
   so any PCZT with Ironwood Actions (e.g. a Keystone-signed spend from the Ironwood pool) failed
   at extraction with `Pczt(Extraction(Ironwood(Extract(MissingProof))))`.
+- Hardware-wallet (Keystone) PCZT signing now sends the full (non-compacted) signer view in the
+  minimal PCZT encoding (v1 for v5 transactions). The compact view/v2-encoding wire contract is
+  not supported by deployed firmware's ordinary signing flow, and caused finalization failures
+  with `MissingSpendAuthSig`.
 
 ## [2.7.0-rc.1] - 2026-07-25
 

--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -1456,8 +1456,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2cbb55ec58887c52b96ff697b081861cb6467b45#2cbb55ec58887c52b96ff697b081861cb6467b45"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1493,8 +1492,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2cbb55ec58887c52b96ff697b081861cb6467b45#2cbb55ec58887c52b96ff697b081861cb6467b45"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2981,8 +2979,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "pczt"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3935cce17fdfba4d70187a2075302e0d576192629e93579c8ac5086948bb15"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2cbb55ec58887c52b96ff697b081861cb6467b45#2cbb55ec58887c52b96ff697b081861cb6467b45"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -6781,8 +6778,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2cbb55ec58887c52b96ff697b081861cb6467b45#2cbb55ec58887c52b96ff697b081861cb6467b45"
 dependencies = [
  "bech32",
  "bs58",
@@ -6795,8 +6791,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f489078672c0f4399b731cb5d4cd934c7820c51de2b4a1e7d2594857916250f0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2cbb55ec58887c52b96ff697b081861cb6467b45#2cbb55ec58887c52b96ff697b081861cb6467b45"
 dependencies = [
  "arti-client",
  "base64",
@@ -6863,8 +6858,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a2d018a15b2e4374a08f2472f8d4309079cbbfa2f697fbfb864ef6bacd4792"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2cbb55ec58887c52b96ff697b081861cb6467b45#2cbb55ec58887c52b96ff697b081861cb6467b45"
 dependencies = [
  "bip32",
  "bitflags",
@@ -6922,8 +6916,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc842e024fe37e52cfd3920826c4a28cc2a023fc9d77351d9c0f310becae3eb7"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2cbb55ec58887c52b96ff697b081861cb6467b45#2cbb55ec58887c52b96ff697b081861cb6467b45"
 dependencies = [
  "bech32",
  "bip32",
@@ -6965,8 +6958,7 @@ dependencies = [
 [[package]]
 name = "zcash_pool_migration"
 version = "0.1.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852d7e66febd7ec83aa7fbd254a33872bf1c4cd072bdc74f65f253ec3a2ef8f4"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2cbb55ec58887c52b96ff697b081861cb6467b45#2cbb55ec58887c52b96ff697b081861cb6467b45"
 dependencies = [
  "corez",
  "getset",
@@ -6979,8 +6971,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ca4de11896f704ffe6319c2cd7bc8fc6ab31a55cec80d26def15c009d83678"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2cbb55ec58887c52b96ff697b081861cb6467b45#2cbb55ec58887c52b96ff697b081861cb6467b45"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7010,8 +7001,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea125021aaa749e966989c7f7aaa18afe2f89474573f5f0dfac8b98083a6d095"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2cbb55ec58887c52b96ff697b081861cb6467b45#2cbb55ec58887c52b96ff697b081861cb6467b45"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7032,8 +7022,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4034db33a1ce58416430e065b01474b958e4649caa3e06e20654683a95149710"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2cbb55ec58887c52b96ff697b081861cb6467b45#2cbb55ec58887c52b96ff697b081861cb6467b45"
 dependencies = [
  "corez",
  "document-features",
@@ -7071,8 +7060,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "547c012778bae17f58007731af074d638aa146ab0ecfc120adebf23d049aff6c"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2cbb55ec58887c52b96ff697b081861cb6467b45#2cbb55ec58887c52b96ff697b081861cb6467b45"
 dependencies = [
  "bip32",
  "bs58",
@@ -7165,8 +7153,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb464491970d9b61889e4f2b7b00fb9f471a33692e5c0de3122fdc575d8067ab"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2cbb55ec58887c52b96ff697b081861cb6467b45#2cbb55ec58887c52b96ff697b081861cb6467b45"
 dependencies = [
  "base64",
  "nom",

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -78,15 +78,19 @@ component = "0.1.1"
 rust-analyzer = "0.0.1"
 
 ## Uncomment this to test librustzcash changes locally
-#[patch.crates-io]
-#pczt = { package = "pczt", path = '../../clones/librustzcash/pczt' }
-#transparent = { package = "zcash_transparent", path = '../../clones/librustzcash/zcash_protocol' }
-#zcash_address = { path = '../../clones/librustzcash/components/zcash_address' }
-#zcash_client_backend = { path = '../../clones/librustzcash/zcash_client_backend' }
-#zcash_client_sqlite = { path = '../../clones/librustzcash/zcash_client_sqlite' }
-#zcash_primitives = { path = '../../clones/librustzcash/zcash_primitives' }
-#zcash_proofs = { path = '../../clones/librustzcash/zcash_proofs' }
-#zcash_protocol = { path = '../../clones/librustzcash/zcash_protocol' }
+# TODO: [#2069] Remove these patches once pczt 0.9.0 and zcash_client_backend 0.24.0-rc.3 are
+# published (zcash/librustzcash#2769); sibling crates are pinned to the same revision to keep the
+# dependency graph on a single source.
+[patch.crates-io]
+pczt = { package = "pczt", git = "https://github.com/zcash/librustzcash.git", rev = "2cbb55ec58887c52b96ff697b081861cb6467b45" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "2cbb55ec58887c52b96ff697b081861cb6467b45" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "2cbb55ec58887c52b96ff697b081861cb6467b45" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "2cbb55ec58887c52b96ff697b081861cb6467b45" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "2cbb55ec58887c52b96ff697b081861cb6467b45" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "2cbb55ec58887c52b96ff697b081861cb6467b45" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "2cbb55ec58887c52b96ff697b081861cb6467b45" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "2cbb55ec58887c52b96ff697b081861cb6467b45" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "2cbb55ec58887c52b96ff697b081861cb6467b45" }
 
 ## Uncomment this to test someone else's librustzcash changes in a branch
 #[patch.crates-io]

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -28,7 +28,7 @@ use uuid::Uuid;
 
 use pczt::{
     Pczt,
-    roles::{combiner::Combiner, prover::Prover, redactor::Redactor},
+    roles::{combiner::Combiner, prover::Prover},
 };
 use transparent::{
     address::{Script, TransparentAddress},
@@ -49,10 +49,10 @@ use zcash_client_backend::{
         chain::{CommitmentTreeRoot, ScanSummary, scan_cached_blocks},
         scanning::{ScanPriority, ScanRange},
         wallet::{
-            self, create_pczt_from_proposal, create_proposed_transactions,
+            self, SignerView, create_pczt_from_proposal, create_proposed_transactions,
             decrypt_and_store_transaction, extract_and_store_transaction_from_pczt,
             input_selection::{GreedyInputSelector, LockFilter, LockedInputPolicy, SpendPolicy},
-            propose_shielding, propose_transfer,
+            propose_shielding, propose_transfer, redact_pczt_for_signer,
         },
     },
     encoding::AddressCodec,
@@ -2520,32 +2520,14 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_redactPcz
 
         let pczt = parse_pczt(env, pczt)?;
 
-        let pczt_with_proofs = Redactor::new(pczt)
-            .redact_global_with(|mut r| r.redact_proprietary("zcash_client_backend:proposal_info"))
-            .redact_orchard_with(|mut r| {
-                r.redact_actions(|mut ar| {
-                    ar.clear_spend_witness();
-                    ar.redact_output_proprietary("zcash_client_backend:output_info");
-                })
-            })
-            .redact_ironwood_with(|mut r| {
-                r.redact_actions(|mut ar| {
-                    ar.clear_spend_witness();
-                    ar.redact_output_proprietary("zcash_client_backend:output_info");
-                })
-            })
-            .redact_sapling_with(|mut r| {
-                r.redact_spends(|mut sr| sr.clear_witness());
-                r.redact_outputs(|mut or| {
-                    or.redact_proprietary("zcash_client_backend:output_info")
-                });
-            })
-            .redact_transparent_with(|mut r| {
-                r.redact_outputs(|mut or| {
-                    or.redact_proprietary("zcash_client_backend:output_info")
-                });
-            })
-            .finish();
+        // Keystone's ordinary send flow signs the full (non-compacted) signer
+        // view: deployed firmware predates the compact view and, for v5
+        // transactions, the v2 PCZT encoding (which `Pczt::serialize` only
+        // selects when the content requires it). Do not switch this to
+        // `SignerView::Compact` without confirming the target signer supports
+        // it — the compact view caused missing-signature failures at
+        // extraction in zcash-swift-wallet-sdk#1863, which this mirrors.
+        let pczt_with_proofs = redact_pczt_for_signer(&pczt, SignerView::Full);
 
         Ok(utils::rust_bytes_to_java(
             env,


### PR DESCRIPTION
Closes #2069.

**The fix:** `redactPcztForSignerRole` now requests `SignerView::Full` via
`zcash_client_backend`'s explicit `SignerView` API (added in
zcash/librustzcash#2769) instead of running its own hand-rolled `Redactor`
chain. The full view retains proofs, binding-signature keys, and anchors,
clears Orchard/Ironwood/Sapling spend witnesses and dummy signing keys, and
performs no field compaction, so for v5 transactions it remains
representable in the v1 PCZT encoding — which the new minimal-encoding
`Pczt::serialize()` then selects. This is the wire contract deployed
Keystone firmware is validated against.

**Android-specific finding:** unlike zcash-swift-wallet-sdk, this SDK never
adopted the compact signer view (zcash-swift-wallet-sdk#1863) that caused
Keystone sends to fail at finalization with
`Pczt(Extraction(Orchard(Extract(MissingSpendAuthSig))))` there
(zcash-swift-wallet-sdk#1869, fixed in zcash-swift-wallet-sdk#1870).
Android's `redactPcztForSignerRole` was still running the original
hand-rolled chain that predates even that #1863 change — so this PR isn't
fixing an observed regression here, it's aligning Android onto the explicit
`SignerView` API before it could regress the same way, and it also closes
Android's exposure to the pczt 0.7→0.8 `Pczt::serialize()` encoding change
(unconditional v2), since the old chain never pinned itself to the v1
encoding explicitly.

**Dependency pinning:** `[patch.crates-io]` pins the librustzcash PR
revision (`2cbb55ec58`) for `pczt`/`zcash_client_backend` plus the
transitively-shared sibling crates (same-version-different-source
unification would otherwise cause duplicate-crate-version errors). A
`TODO: [#2069]` marks the patches for removal once `pczt 0.9.0` and
`zcash_client_backend 0.24.0-rc.3` are published — **these patches must be
dropped before this PR merges.**

**Testing:** `cargo check`, `cargo tree -d` (no zcash/orchard/sapling/pczt
duplicates), and `cargo fmt --all -- --check` pass against the pinned
revision. The librustzcash-side redaction policy itself is covered by new
pool tests in zcash/librustzcash#2769. Per current testing conventions,
device acceptance testing runs against this PR branch directly rather than
a local build.

Filed with Claude Code assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
