### PR TITLE
[#2072] Adopt the v6 wallet-controlled-spend derivation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Hardware-wallet signing of post-NU6.3 (v6) transactions: the wallet-controlled zero-value
+  Orchard spends that pad such transactions now carry ZIP 32 derivation metadata (via
+  `zcash_client_backend 0.24.0-rc.4`), so signers can identify and sign them. Previously these
+  actions were unsignable and v6 sends failed at finalization with
+  `Pczt(Extraction(Orchard(Extract(MissingSpendAuthSig))))` even though the device approved the
+  transaction.
+
 ## [2.7.0-rc.2] - 2026-07-26
 
 ### Changed

--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -1456,8 +1456,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
+source = "git+https://github.com/zcash/librustzcash.git?rev=536a10fd61af2d554bbe92764b0912a5d78e7d49#536a10fd61af2d554bbe92764b0912a5d78e7d49"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1493,8 +1492,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+source = "git+https://github.com/zcash/librustzcash.git?rev=536a10fd61af2d554bbe92764b0912a5d78e7d49#536a10fd61af2d554bbe92764b0912a5d78e7d49"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2981,8 +2979,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "pczt"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508e40a1767b8054533db0fdfe9ddce29e708fa4f8bcfe68056995d46f5ee711"
+source = "git+https://github.com/zcash/librustzcash.git?rev=536a10fd61af2d554bbe92764b0912a5d78e7d49#536a10fd61af2d554bbe92764b0912a5d78e7d49"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -6781,8 +6778,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
+source = "git+https://github.com/zcash/librustzcash.git?rev=536a10fd61af2d554bbe92764b0912a5d78e7d49#536a10fd61af2d554bbe92764b0912a5d78e7d49"
 dependencies = [
  "bech32",
  "bs58",
@@ -6794,9 +6790,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "103eca02554239be80ffaa6fef0b617d60a527f8e3b288cee0de533b9b00a571"
+version = "0.24.0-rc.4"
+source = "git+https://github.com/zcash/librustzcash.git?rev=536a10fd61af2d554bbe92764b0912a5d78e7d49#536a10fd61af2d554bbe92764b0912a5d78e7d49"
 dependencies = [
  "arti-client",
  "base64",
@@ -6863,8 +6858,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0953496bf58df03c4c240d3a55196c62385997c67cbde78eb02960fe7a003c1a"
+source = "git+https://github.com/zcash/librustzcash.git?rev=536a10fd61af2d554bbe92764b0912a5d78e7d49#536a10fd61af2d554bbe92764b0912a5d78e7d49"
 dependencies = [
  "bip32",
  "bitflags",
@@ -6922,8 +6916,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc842e024fe37e52cfd3920826c4a28cc2a023fc9d77351d9c0f310becae3eb7"
+source = "git+https://github.com/zcash/librustzcash.git?rev=536a10fd61af2d554bbe92764b0912a5d78e7d49#536a10fd61af2d554bbe92764b0912a5d78e7d49"
 dependencies = [
  "bech32",
  "bip32",
@@ -6965,8 +6958,7 @@ dependencies = [
 [[package]]
 name = "zcash_pool_migration"
 version = "0.1.0-rc.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520816e0e6b35ff936a7247fd5c7203800274a7328ed76f644614fc0747aa5a6"
+source = "git+https://github.com/zcash/librustzcash.git?rev=536a10fd61af2d554bbe92764b0912a5d78e7d49#536a10fd61af2d554bbe92764b0912a5d78e7d49"
 dependencies = [
  "corez",
  "getset",
@@ -6979,8 +6971,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ca4de11896f704ffe6319c2cd7bc8fc6ab31a55cec80d26def15c009d83678"
+source = "git+https://github.com/zcash/librustzcash.git?rev=536a10fd61af2d554bbe92764b0912a5d78e7d49#536a10fd61af2d554bbe92764b0912a5d78e7d49"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7010,8 +7001,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea125021aaa749e966989c7f7aaa18afe2f89474573f5f0dfac8b98083a6d095"
+source = "git+https://github.com/zcash/librustzcash.git?rev=536a10fd61af2d554bbe92764b0912a5d78e7d49#536a10fd61af2d554bbe92764b0912a5d78e7d49"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7032,8 +7022,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4034db33a1ce58416430e065b01474b958e4649caa3e06e20654683a95149710"
+source = "git+https://github.com/zcash/librustzcash.git?rev=536a10fd61af2d554bbe92764b0912a5d78e7d49#536a10fd61af2d554bbe92764b0912a5d78e7d49"
 dependencies = [
  "corez",
  "document-features",
@@ -7071,8 +7060,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "547c012778bae17f58007731af074d638aa146ab0ecfc120adebf23d049aff6c"
+source = "git+https://github.com/zcash/librustzcash.git?rev=536a10fd61af2d554bbe92764b0912a5d78e7d49#536a10fd61af2d554bbe92764b0912a5d78e7d49"
 dependencies = [
  "bip32",
  "bs58",
@@ -7165,8 +7153,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb464491970d9b61889e4f2b7b00fb9f471a33692e5c0de3122fdc575d8067ab"
+source = "git+https://github.com/zcash/librustzcash.git?rev=536a10fd61af2d554bbe92764b0912a5d78e7d49#536a10fd61af2d554bbe92764b0912a5d78e7d49"
 dependencies = [
  "base64",
  "nom",

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -17,7 +17,7 @@ pczt = { version = "0.9.0", features = ["prover", "orchard", "sapling"] }
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
 transparent = { package = "zcash_transparent", version = "0.10", default-features = false }
 zcash_address = "0.13"
-zcash_client_backend = { version = "0.24.0-rc.3", features = [
+zcash_client_backend = { version = "0.24.0-rc.4", features = [
     "orchard",
     "lightwalletd-tonic-tls-webpki-roots",
     "tor",
@@ -82,15 +82,20 @@ rust-analyzer = "0.0.1"
 # published (zcash/librustzcash#2769); sibling crates are pinned to the same revision to keep the
 # dependency graph on a single source.
 [patch.crates-io]
-# pczt = { package = "pczt", git = "https://github.com/zcash/librustzcash.git", rev = "REPLACE_ME_WITH_GIT_HASH" }
-# transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "REPLACE_ME_WITH_GIT_HASH" }
-# zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "REPLACE_ME_WITH_GIT_HASH" }
-# zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "REPLACE_ME_WITH_GIT_HASH" }
-# zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "REPLACE_ME_WITH_GIT_HASH" }
-# zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "REPLACE_ME_WITH_GIT_HASH" }
-# zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "REPLACE_ME_WITH_GIT_HASH" }
-# zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "REPLACE_ME_WITH_GIT_HASH" }
-# zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "REPLACE_ME_WITH_GIT_HASH" }
+# TODO: [#2072] Remove these patches once zcash_client_backend 0.24.0-rc.4 is
+# published (zcash/librustzcash#2779); they pin the release-prep revision so
+# device verification exercises exactly the bits to be published, with the
+# sibling crates pinned to the same revision to keep the dependency graph on a
+# single source.
+pczt = { package = "pczt", git = "https://github.com/zcash/librustzcash.git", rev = "536a10fd61af2d554bbe92764b0912a5d78e7d49" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "536a10fd61af2d554bbe92764b0912a5d78e7d49" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "536a10fd61af2d554bbe92764b0912a5d78e7d49" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "536a10fd61af2d554bbe92764b0912a5d78e7d49" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "536a10fd61af2d554bbe92764b0912a5d78e7d49" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "536a10fd61af2d554bbe92764b0912a5d78e7d49" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "536a10fd61af2d554bbe92764b0912a5d78e7d49" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "536a10fd61af2d554bbe92764b0912a5d78e7d49" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "536a10fd61af2d554bbe92764b0912a5d78e7d49" }
 
 ## Uncomment this to test someone else's librustzcash changes in a branch
 #[patch.crates-io]


### PR DESCRIPTION
Closes #2072.
Resolves MOB-1554

Fixes post-NU6.3 (v6) Keystone sends failing at finalization with `Pczt(Extraction(Orchard(Extract(MissingSpendAuthSig))))`: the wallet-controlled zero-value Orchard spends that pad v6 transactions carried no ZIP 32 derivation metadata, so derivation-matching signers correctly skipped them as "not ours" and nothing could ever sign them (their `dummy_sk` is absent by design under the post-NU6.3 cross-address rule). Root cause and fix are upstream: zcash/librustzcash#2777, fixed in zcash/librustzcash#2778. Mirrors zcash/zcash-swift-wallet-sdk#1874.

**This PR is the device-verification vehicle:** it bumps `zcash_client_backend` to `0.24.0-rc.4` and pins the release-prep revision (zcash/librustzcash#2779) via `[patch.crates-io]` git pins, so the tester exercises exactly the bits that will be published. On tester confirmation, the crate is published and a follow-up commit drops the pins (`TODO: [#2072]` marks them).

**Testing:** `cargo check` passes against the pinned revision; upstream adds a general signability invariant to the PCZT pool tests (every shielded spend must be pre-signed, dummy-key-carrying, or ZIP 32-derivable) that reproduces this bug class and guards the fix. Device acceptance test: a post-NU6.3 testnet Keystone send run against this branch.

Filed with Claude Code assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
