### PR TITLE
backend-lib: handle non_exhaustive BirthdayError match

### DIFF
--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -481,6 +481,10 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_createAcc
                 BirthdayError::Decode(e) => {
                     anyhow!("Invalid TreeState: Invalid frontier encoding: {}", e)
                 }
+                // `BirthdayError` is `#[non_exhaustive]`; this arm is unreachable
+                // against enum versions that expose only the variants above.
+                #[allow(unreachable_patterns)]
+                _ => anyhow!("Invalid TreeState: unrecognized birthday error"),
             })?;
 
         let account_name = java_string_to_rust(env, &account_name)?;
@@ -567,6 +571,10 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_importAcc
                 BirthdayError::Decode(e) => {
                     anyhow!("Invalid TreeState: Invalid frontier encoding: {}", e)
                 }
+                // `BirthdayError` is `#[non_exhaustive]`; this arm is unreachable
+                // against enum versions that expose only the variants above.
+                #[allow(unreachable_patterns)]
+                _ => anyhow!("Invalid TreeState: unrecognized birthday error"),
             })?;
 
         let account_name = java_string_to_rust(env, &account_name)?;


### PR DESCRIPTION
`zcash_client_backend` now marks its public error enums `#[non_exhaustive]`
(unreleased on `main`), including `data_api::BirthdayError`. Matching a
`#[non_exhaustive]` enum from another crate requires a wildcard arm, so the two
`AccountBirthday::from_treestate(...).map_err(|e| match e { ... })` sites in the
JNI backend fail to compile against those releases.

This adds an `#[allow(unreachable_patterns)] _ =>` arm to both sites. The
`#[allow]` keeps the arm warning-free against the currently pinned release
(`zcash_client_backend 0.24.0-rc.4`), where `BirthdayError` still exposes only
`HeightInvalid` and `Decode` and the arm is unreachable, so this is safe to
merge now and unblocks building against `main`.

Independent forward-compat fix; no behavior change on current releases.

Verified with `cargo check` on `backend-lib` both against `0.24.0-rc.4` (no
warnings, arm unreachable) and against `librustzcash` `main` via a temporary
`[patch.crates-io]` (compiles; the two `BirthdayError` errors are the only
non-exhaustive breakage in this crate).