### PR TITLE
Enforce voting hotkey lengths on the type that carries them

### DIFF
--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModels.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModels.kt
@@ -1,6 +1,8 @@
 package cash.z.ecc.android.sdk.internal.model.voting
 
 import androidx.annotation.Keep
+import cash.z.ecc.android.sdk.internal.jni.JNI_HOTKEY_STORED_SECRET_BYTES_SIZE
+import cash.z.ecc.android.sdk.internal.jni.JNI_ORCHARD_RAW_ADDRESS_BYTES_SIZE
 
 /**
  * Typed JNI carrier for a spendable note the voting backend may draw voting weight from.
@@ -458,14 +460,14 @@ data class JniShareDelegationRecord(
  * `data class` rendering would print the secret's bytes into any log that
  * interpolates it.
  *
- * The constructor and `copy()` are public, unlike the `@ConsistentCopyVisibility`
- * predecessor of this type. A hotkey is now only ever produced by
- * `generateHotkey`, whose typesafe wrapper in `sdk-lib` length-checks both byte
- * arrays; that wrapper's own tests live in a different Gradle module and so need
- * to fabricate a malformed hotkey to exercise the check. Constructing one here
- * grants no capability: every native entry point takes the raw
- * [storedSecret] bytes, not this carrier, so a fabricated instance cannot make
- * `zcash_voting` accept a hotkey it would otherwise reject.
+ * Both byte arrays are length-checked on construction, so a malformed hotkey
+ * cannot exist regardless of where it came from. That includes the native layer:
+ * JNI's `NewObject` runs the constructor, and therefore this `init` block, so a
+ * bug in `make_jni_voting_hotkey` surfaces here rather than travelling onward as
+ * a short secret. The constructor stays public because the invariant is enforced
+ * by the type rather than by visibility, and constructing one grants no
+ * capability in any case: every native entry point takes the raw [storedSecret]
+ * bytes, not this carrier.
  */
 @Keep
 data class JniVotingHotkey(
@@ -473,6 +475,16 @@ data class JniVotingHotkey(
     val rawOrchardAddress: ByteArray,
     val addressIndex: Int
 ) {
+    init {
+        require(storedSecret.size == JNI_HOTKEY_STORED_SECRET_BYTES_SIZE) {
+            "storedSecret must be $JNI_HOTKEY_STORED_SECRET_BYTES_SIZE bytes"
+        }
+
+        require(rawOrchardAddress.size == JNI_ORCHARD_RAW_ADDRESS_BYTES_SIZE) {
+            "rawOrchardAddress must be $JNI_ORCHARD_RAW_ADDRESS_BYTES_SIZE bytes"
+        }
+    }
+
     override fun toString(): String = "JniVotingHotkey(redacted)"
 
     override fun equals(other: Any?): Boolean {

--- a/backend-lib/src/main/rust/voting/helpers.rs
+++ b/backend-lib/src/main/rust/voting/helpers.rs
@@ -277,6 +277,21 @@ pub(super) fn java_secret_bytes_at_least(
     require_min_len(java_bytes(env, array, field)?, field, minimum).map(SecretVec::new)
 }
 
+/// Reads a secret whose length is fixed by the protocol.
+///
+/// Distinct from `java_secret_bytes_at_least`, which exists for inputs like a
+/// wallet seed whose length genuinely varies. Where the width is fixed, checking
+/// it exactly keeps the JNI boundary and `zcash_voting` agreeing on the contract
+/// rather than accepting an over-long value here and having it rejected deeper in.
+pub(super) fn java_secret_bytes_exact(
+    env: &mut JNIEnv<'_>,
+    array: &JByteArray<'_>,
+    field: &str,
+    expected: usize,
+) -> anyhow::Result<SecretVec<u8>> {
+    require_len(java_bytes(env, array, field)?, field, expected).map(SecretVec::new)
+}
+
 pub(super) fn java_bytes32(
     env: &mut JNIEnv<'_>,
     array: &JByteArray<'_>,
@@ -1111,14 +1126,17 @@ pub(super) fn make_jni_voting_hotkey<'local>(
 
 /// Reconstructs a voting hotkey from the stored secret a caller persisted.
 ///
-/// The secret is opaque app-owned material; `zcash_voting` owns its length and
-/// key-derivation checks, so this does not pre-validate the bytes.
+/// The secret is opaque app-owned material, so its content is `zcash_voting`'s
+/// business, but its width is fixed and is checked here against the same
+/// constant the crate uses. Checking it at the boundary means a caller that
+/// passes the wrong material gets an error naming the parameter, rather than one
+/// phrased in terms of the crate's internals.
 pub(super) fn java_voting_hotkey(
     env: &mut JNIEnv<'_>,
     stored_secret: &JByteArray<'_>,
     network: VotingNetwork,
 ) -> anyhow::Result<VotingHotkey> {
-    let stored_secret = java_secret_bytes_at_least(
+    let stored_secret = java_secret_bytes_exact(
         env,
         stored_secret,
         "hotkeyStoredSecret",

--- a/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModelsTest.kt
+++ b/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModelsTest.kt
@@ -2,7 +2,9 @@ package cash.z.ecc.android.sdk.internal.model.voting
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class JniVotingModelsTest {
     @Test
@@ -68,6 +70,37 @@ class JniVotingModelsTest {
         assertFalse(text.contains("storedSecret"))
         assertFalse(text.contains("123"))
         assertFalse(text.contains("7b"))
+    }
+
+    // Both widths are fixed by zcash_voting, so a malformed hotkey should not be
+    // representable rather than merely rejected downstream. JNI's NewObject runs this
+    // init block too, so the check also covers a hotkey built by the native layer.
+    @Test
+    fun voting_hotkey_rejects_a_stored_secret_of_the_wrong_length() {
+        val error =
+            assertFailsWith<IllegalArgumentException> {
+                JniVotingHotkey(
+                    storedSecret = byteArrayOf(1, 2, 3),
+                    rawOrchardAddress = ByteArray(43) { 0x2C },
+                    addressIndex = 0
+                )
+            }
+
+        assertTrue(error.message.orEmpty().contains("storedSecret"))
+    }
+
+    @Test
+    fun voting_hotkey_rejects_a_raw_orchard_address_of_the_wrong_length() {
+        val error =
+            assertFailsWith<IllegalArgumentException> {
+                JniVotingHotkey(
+                    storedSecret = ByteArray(64) { 0x7B },
+                    rawOrchardAddress = byteArrayOf(1, 2, 3),
+                    addressIndex = 0
+                )
+            }
+
+        assertTrue(error.message.orEmpty().contains("rawOrchardAddress"))
     }
 
     // A note carries the randomness that reconstructs its spend and the account's full viewing

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImplTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImplTest.kt
@@ -705,29 +705,12 @@ class TypesafeVotingBackendImplTest {
             assertTrue(error.message.orEmpty().contains("encShares"))
         }
 
-    @Test
-    fun generate_hotkey_wrapper_rejects_malformed_hotkey_material() =
-        runTest {
-            val backend =
-                RecordingVotingDbBackend(
-                    proofResult = jniDelegationProofResult(),
-                    submissionResult = jniDelegationSubmissionResult(),
-                    hotkeyResult =
-                        JniVotingHotkey(
-                            storedSecret = byteArrayOf(1, 2, 3),
-                            rawOrchardAddress = ByteArray(JNI_ORCHARD_RAW_ADDRESS_BYTES_SIZE),
-                            addressIndex = 0
-                        )
-                )
-            val db = TypesafeVotingDbImpl(backend)
-
-            val error =
-                assertFailsWith<IllegalArgumentException> {
-                    db.generateHotkey("round-vote", 0)
-                }
-
-            assertTrue(error.message.orEmpty().contains("storedSecret"))
-        }
+    // generate_hotkey_wrapper_rejects_malformed_hotkey_material used to live here. It
+    // fabricated a hotkey carrying a three-byte secret and asserted that the typesafe
+    // wrapper rejected it. JniVotingHotkey now length-checks both of its byte arrays in
+    // its own init block, so that value cannot be constructed at all and the wrapper
+    // check it exercised has been removed as unreachable. The invariant is tested where
+    // it is now enforced, in backend-lib's JniVotingModelsTest.
 
     private fun jniDelegationProofResult(
         proof: ByteArray = ByteArray(PROOF_BYTES) { 3 },

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackendImpl.kt
@@ -4,8 +4,6 @@ package cash.z.ecc.android.sdk.internal
 
 import cash.z.ecc.android.sdk.internal.jni.JNI_DELEGATION_PUBLIC_INPUT_COUNT
 import cash.z.ecc.android.sdk.internal.jni.JNI_GOVERNANCE_NULLIFIER_COUNT
-import cash.z.ecc.android.sdk.internal.jni.JNI_HOTKEY_STORED_SECRET_BYTES_SIZE
-import cash.z.ecc.android.sdk.internal.jni.JNI_ORCHARD_RAW_ADDRESS_BYTES_SIZE
 import cash.z.ecc.android.sdk.internal.jni.JNI_PROTOCOL_FIELD_BYTES_SIZE
 import cash.z.ecc.android.sdk.internal.jni.JNI_SPEND_AUTH_SIG_BYTES_SIZE
 import cash.z.ecc.android.sdk.internal.jni.JNI_VAN_WITNESS_PATH_DEPTH
@@ -766,16 +764,11 @@ internal class TypesafeVotingDbImpl(
         roundId: String,
         networkId: Int
     ): JniVotingHotkey =
-        votingDb.generateHotkey(roundId, networkId).also { hotkey ->
-            hotkey.storedSecret.requireByteArraySize(
-                "storedSecret",
-                JNI_HOTKEY_STORED_SECRET_BYTES_SIZE
-            )
-            hotkey.rawOrchardAddress.requireByteArraySize(
-                "rawOrchardAddress",
-                JNI_ORCHARD_RAW_ADDRESS_BYTES_SIZE
-            )
-        }
+        // JniVotingHotkey length-checks both byte arrays on construction, and JNI's
+        // NewObject runs that init block too, so there is no route by which a
+        // malformed hotkey reaches this point. Re-checking here would be a defence
+        // that can never fire.
+        votingDb.generateHotkey(roundId, networkId)
 
     override suspend fun buildGovernancePczt(
         roundId: String,


### PR DESCRIPTION
Closes #2079.
Resolves MOB-1562

Stacked on #2075 — based on `merge/maint-2.8.x` rather than `main`, because the code this touches only exists in its current form on that branch. Please merge #2075 first.

## The problem

Validation of the voting hotkey's stored secret was split across two modules, looser than the contract it was checking, and documented as not happening.

- `java_voting_hotkey` applied a **floor** check while `zcash_voting` requires exactly `VOTING_HOTKEY_STORED_SECRET_LEN`, so a 65-byte secret was accepted at the JNI boundary and rejected a layer deeper — in the crate's terms rather than the caller's.
- The doc comment directly above that check said the bytes were **not pre-validated at all**.
- `JniVotingHotkey`'s constructor and `copy()` were public where the predecessor type had `@ConsistentCopyVisibility` and an `internal constructor`, so app code could fabricate one bypassing the length check in the typesafe wrapper.

## The fix

The issue suggested moving the length check into `backend-lib` so the wrapper's test would not need a public constructor. Investigating turned up a better answer already established in this repo: `JniAccount`, `JniBlockMeta` and `JniMetadataKey` all enforce their invariants in `init { require(...) }` blocks. `JniVotingHotkey` was the outlier.

So the invariant moves onto the type. **This covers the native layer as well** — JNI's `NewObject` runs the constructor, so a bug in `make_jni_voting_hotkey` now surfaces at the boundary instead of travelling onward as a short secret. That is more than either the visibility restriction or the wrapper check gave.

With the malformed state unrepresentable, the visibility question dissolves: the constructor was public *only* so a test in another Gradle module could fabricate malformed material. The KDoc paragraph that had been arguing the bypass was "nominal" is replaced by a description of the invariant.

On the Rust side, `java_voting_hotkey` now uses a new `java_secret_bytes_exact` and its doc comment says what it does. The existing `java_secret_bytes_at_least` stays, because `walletSeed` genuinely varies in length.

## One consequence worth reviewing

The typesafe wrapper re-checked the same two lengths. It can no longer fire, so it is removed — validation that cannot fire reads as a defence while providing none.

Its test, `generate_hotkey_wrapper_rejects_malformed_hotkey_material`, moves to `backend-lib`'s `JniVotingModelsTest` with a stronger assertion: that the value cannot be constructed at all, rather than that one particular layer happens to reject it. A comment is left at the old site explaining where it went and why, so the removal does not read as lost coverage.

## Test plan

```
cd backend-lib && cargo check --lib --all-targets && cargo clippy --all-targets \
  && cargo clippy --all-targets --features android-test-fixtures \
  && cargo fmt --check && cargo test --lib
./scripts/ci-local.sh quick
./scripts/ci-local.sh fast
./gradlew :backend-lib:compileDebugAndroidTestKotlin :sdk-lib:compileDebugAndroidTestKotlin
```

All clean. `JniVotingModelsTest` goes from 15 to 17 tests — the two new ones assert that a wrong-length `storedSecret` and a wrong-length `rawOrchardAddress` are each rejected at construction, and both were confirmed to run rather than merely compile.

The instrumented suites are unaffected by this change and are exercised by `test_android_modules_emulator` on this PR as usual.

---
Prepared with Claude Code assistance.
