### PR TITLE
Bump slipstream-core and record the migration-signing fix in the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Hardware-wallet signing of Orchard-to-Ironwood migration transactions: the Orchard spends a
+  migration transaction still needs a signature for now carry ZIP 32 derivation metadata, so an
+  external signer can recognize them as the account's and authorize them. Previously the SDK
+  attached no derivation to these spends, and a Keystone-signed migration could not be completed.
+- In builds that ship the Slipstream sync engine, a transaction whose Ironwood spend was not yet
+  linked to the note it spends was treated as reconciled during a recent-first restore. A
+  self-send's change could therefore surface as a phantom receive and the restore balance could
+  over-report, correcting itself only once the origin block was scanned. Since NU6.3 every
+  shielded output a wallet receives lands in Ironwood, so this affected essentially every
+  post-activation restore.
+
 ## [2.8.0-rc.1] - 2026-07-26
 
 ### Added

--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -4606,7 +4606,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slipstream-core"
 version = "0.6.4"
-source = "git+https://github.com/zodl-inc/slipstream.git?rev=f134aa625a92c5085f1e42d5f75d7178a1ea9999#f134aa625a92c5085f1e42d5f75d7178a1ea9999"
+source = "git+https://github.com/zodl-inc/slipstream.git?rev=c9cf12c50793b008885ba98e50cfbe372192b54f#c9cf12c50793b008885ba98e50cfbe372192b54f"
 dependencies = [
  "ff",
  "futures-util",

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -186,7 +186,7 @@ ur-registry = { git = "https://github.com/KeystoneHQ/keystone-sdk-rust", package
 tracing-android = { version = "0.2", optional = true }
 
 [patch.crates-io]
-slipstream-core = { git = "https://github.com/zodl-inc/slipstream.git", rev = "f134aa625a92c5085f1e42d5f75d7178a1ea9999" }
+slipstream-core = { git = "https://github.com/zodl-inc/slipstream.git", rev = "c9cf12c50793b008885ba98e50cfbe372192b54f" }
 # Commented out with the `zcash_voting` dependency itself: cargo warns about a patch
 # entry for a crate that is not in the graph. Uncomment together with it.
 # zcash_voting = { git = "https://github.com/valargroup/zcash_voting.git", rev = "7d39d02b297f0ce23751f2638bf403285e34e675" }


### PR DESCRIPTION
Follow-up to #2049, targeting its branch.

Two user-facing behaviour changes landed on `feature/ironwood-slipstream` without a
CHANGELOG entry. This adds them, and moves `slipstream-core` to the tip of
`api-review-fixes` so the second one is actually in the build.

### `slipstream-core` rev bump

`f134aa62` → `c9cf12c5` (zodl-inc/slipstream#5), which adds the missing Ironwood arm to
`ext_slipstream_v_tx_reconciled`. Without it a transaction whose Ironwood spend was not
yet linked to the note it spends read as reconciled, so during a recent-first restore a
self-send's change could surface as a phantom receive and the restore balance could
over-report until the origin block was scanned.

### CHANGELOG

- **Migration signing.** The adapter's `MigrationCrypto::account_derivation` implementation
  (added when adapting to librustzcash `a00f4a7a`) makes the builders stamp the account's
  ZIP 32 derivation onto every Orchard spend a migration transaction still awaits a
  signature for. That is what lets an external signer recognize those spends as the
  account's; previously a Keystone-signed migration could not be completed. This is the
  sibling of the padding-spend fix already recorded in 2.7.0-rc.2.
- **Restore reconciliation.** The engine fix above, scoped in the entry to builds that ship
  the Slipstream sync engine.

The second entry is a judgement call worth a look: it describes a fix that lives in the
engine dependency rather than in this repo's own code, but it is observable through the
SDK, so it seemed wrong to let the rev bump carry it silently.

### Verification

`cargo check --all-targets` and `cargo clippy` clean, with default features and with
`slipstream,android-test-fixtures`. No test suites were run and nothing was built for an
Android target.

---
Filed with Claude Code assistance.
