### PR TITLE
Release zcash-android-wallet-sdk 2.7.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.0-rc.4] - 2026-07-29
+
 ### Changed
 - Updated the librustzcash crates to `zcash_client_backend 0.24.0-rc.6` and
   `zcash_client_sqlite 0.22.0-rc.6`, adopting the revised ZIP 318 migration timing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Updated the librustzcash crates to `zcash_client_backend 0.24.0-rc.6` and
+  `zcash_client_sqlite 0.22.0-rc.6`, adopting the revised ZIP 318 migration timing
+  (shorter transfer and preparation delays, and an anchor-age cap of 4 bucket
+  boundaries rather than 16).
+- A canonical ZIP 318 crossing is now funded from the single oldest Orchard note
+  that covers the payment and its fee, falling back to ordinary multi-note funding
+  when no such note exists. Canonical-denomination payments that previously lost
+  the canonical shape to multi-note funding now take it whenever a single covering
+  note exists.
+
+### Fixed
+All of the following were picked up from the librustzcash update:
+
+- A wallet whose database was upgraded by a build using
+  `zcash_client_sqlite 0.22.0-rc.1` (the 2.6.6 internal build) no longer fails
+  every scan. Such a wallet's `orchard_ironwood_migrations` table never acquired
+  the `anchor_bucket_interval` column, added to the table-creation migration in
+  place afterwards, and the column reference then failed on every scan — no block
+  could be written and no transaction ever acquired a mined height, whether or not
+  a pool migration was in progress. A new database migration adds the missing
+  column. The backfilled value is exact on the production network; on a test
+  network, a pool migration planned under a custom anchor grid is reported as
+  `AnchorIntervalMismatch` and must be re-planned.
+- A ZIP 318 crossing anchored to a bucket boundary whose block contains no note
+  commitments in any pool no longer fails with `ProposalError::AnchorNotFound`:
+  scanning now creates a checkpoint at every anchor-retention grid height, and
+  proposal creation additionally falls back to an ordinary crossing when no anchor
+  is computable at the boundary rather than proposing a build that would fail.
+- Note selection now draws the oldest eligible notes first, in note commitment
+  tree (chain) order. Notes were previously drawn in scan-discovery order, which
+  for a restored wallet prefers its most recently discovered — typically newest —
+  notes.
+- A payment to one of the wallet's own transparent addresses is now reported with
+  the transparent receiver address itself as the output's recipient, rather than
+  the receiving account's unified address; for outputs the wallet created, the
+  recipient address recorded at transaction construction time takes precedence
+  over the receiving address.
+
 ## [2.7.0-rc.3] - 2026-07-29
 
 ### Changed

--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -6794,9 +6794,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.5"
+version = "0.24.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956f2438ea82fbbcf2407fb7c96e14ea6420963fbb0483a522e3e20fab2ae93f"
+checksum = "832ace878c125814bb9e82228d3661499124c6f2936e60fc1df3c6876eb54624"
 dependencies = [
  "arti-client",
  "base64",
@@ -6862,9 +6862,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.5"
+version = "0.22.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70415a7cc23b9850d984231b989813684166adab55c22d92185abd0601288c2e"
+checksum = "c4a789c0038359968f93bfe3952d2b942e3bae5582f79c2f31137c6fd736a225"
 dependencies = [
  "bip32",
  "bitflags",
@@ -6964,9 +6964,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_pool_migration"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5099c9398bc00929cfc6b72842cbd9af60b0acc45f64ce830c4ed42026d2fe"
+checksum = "9010904169a92805128b3a8eab0dd4ff79fd164dd416af68aaeac5c7ebbd2522"
 dependencies = [
  "corez",
  "getset",
@@ -7038,9 +7038,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d23144aed9cc370a746896a1b0cb5ebe40d7ce0599aa8522ac6b189c1d61a22"
+checksum = "9f074493fff337207e28bcfa5bbdf0e2a125c4203a4bdd07e72067eea81e9e7b"
 dependencies = [
  "corez",
  "document-features",

--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -6734,7 +6734,7 @@ dependencies = [
 
 [[package]]
 name = "zcash-android-wallet-sdk"
-version = "2.7.0-rc.3"
+version = "2.7.0-rc.4"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zcash-android-wallet-sdk"
-version = "2.7.0-rc.3"
+version = "2.7.0-rc.4"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kevin Gorham <kevin.gorham@z.cash>",

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -17,7 +17,7 @@ pczt = { version = "0.9.0", features = ["prover", "orchard", "sapling"] }
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
 transparent = { package = "zcash_transparent", version = "0.10", default-features = false }
 zcash_address = "0.13"
-zcash_client_backend = { version = "0.24.0-rc.5", features = [
+zcash_client_backend = { version = "0.24.0-rc.6", features = [
     "orchard",
     "lightwalletd-tonic-tls-webpki-roots",
     "tor",
@@ -25,7 +25,7 @@ zcash_client_backend = { version = "0.24.0-rc.5", features = [
     "unstable",
     "pczt",
 ] }
-zcash_client_sqlite = { version = "0.22.0-rc.5", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
+zcash_client_sqlite = { version = "0.22.0-rc.6", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
 zcash_note_encryption = "0.4.1"
 zcash_primitives = "0.30"
 zcash_proofs = "0.30"

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ ZCASH_ASCII_GPG_KEY=
 # Configures whether release is an unstable snapshot, therefore published to the snapshot repository.
 IS_SNAPSHOT=true
 
-LIBRARY_VERSION=2.7.0-rc.3
+LIBRARY_VERSION=2.7.0-rc.4
 
 # Kotlin compiler warnings can be considered errors, failing the build.
 ZCASH_IS_TREAT_WARNINGS_AS_ERRORS=true


### PR DESCRIPTION
Release zcash_android_wallet_sdk version 2.7.0-rc.4

- **Update to the zcash_client_backend 0.24.0-rc.6 release candidates**
- **Prepare SDK release 2.7.0-rc.4**

🤖 Generated with [Claude Code](https://claude.com/claude-code)