### PR TITLE
Sync the vendored proposal.proto with zcash_client_backend 0.24.0-rc.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   note exists.
 
 ### Fixed
+- The vendored `proposal.proto` is back in sync with the definition in
+  `zcash_client_backend 0.24.0-rc.6`. It was missing the `Ironwood` value pool,
+  so a proposal with an Ironwood output or change value decoded that pool as
+  `UNRECOGNIZED`, and it was missing the `Proposal.confirmationsPolicy`,
+  `Proposal.proposedVersion`, `TransactionBalance.dummyOutputs`, and
+  `ChangeValue.isEphemeral` fields, which decoded into unknown fields and so
+  could not be read. Round-tripping a proposal through Kotlin preserved all of
+  these, so no proposal was mis-built; they were simply unreadable.
+
 All of the following were picked up from the librustzcash update:
 
 - A wallet whose database was upgraded by a build using

--- a/backend-lib/src/main/proto/proposal.proto
+++ b/backend-lib/src/main/proto/proposal.proto
@@ -19,6 +19,25 @@ message Proposal {
     uint32 minTargetHeight = 3;
     // The series of transactions to be created.
     repeated ProposalStep steps = 4;
+    // The confirmations policy under which the proposal was constructed. It is used to resolve the
+    // anchor for any step that spends no shielded notes (such a step defers the choice of anchor).
+    // Proposals serialized by older versions omit this field; they are interpreted using the
+    // default confirmations policy.
+    ConfirmationsPolicy confirmationsPolicy = 5;
+    // The transaction version header explicitly requested when the proposal was constructed.
+    // Proposals serialized by older versions, or constructed without an explicit version request,
+    // omit this field; they are built at the version implied by the target height.
+    optional uint32 proposedVersion = 6;
+}
+
+// The number of confirmations required before notes may be spent, per ZIP 315.
+message ConfirmationsPolicy {
+    // The number of confirmations required before trusted notes may be spent.
+    uint32 trusted = 1;
+    // The number of confirmations required before untrusted notes may be spent.
+    uint32 untrusted = 2;
+    // Whether transparent inputs may be spent with zero confirmations in shielding transactions.
+    bool allowZeroConfShielding = 3;
 }
 
 // A data structure that describes the inputs to be consumed and outputs to
@@ -55,6 +74,10 @@ enum ValuePool {
     Sapling = 2;
     // The Orchard value pool
     Orchard = 3;
+    // The Ironwood value pool (ZIP 2005). Ironwood notes are Orchard-shaped but
+    // belong to a distinct pool; older decoders that do not recognize this value
+    // will reject the proposal rather than misattribute it to Orchard.
+    Ironwood = 4;
 }
 
 // A mapping from ZIP 321 payment index to the output pool that has been chosen
@@ -74,14 +97,14 @@ message ReceivedOutput {
     uint64 value = 4;
 }
 
-// A reference a payment in a prior step of the proposal. This payment must
+// A reference to a payment in a prior step of the proposal. This payment must
 // belong to the wallet.
 message PriorStepOutput {
     uint32 stepIndex = 1;
     uint32 paymentIndex = 2;
 }
 
-// A reference a change output from a prior step of the proposal.
+// A reference to a change or ephemeral output from a prior step of the proposal.
 message PriorStepChange {
     uint32 stepIndex = 1;
     uint32 changeIndex = 2;
@@ -113,22 +136,43 @@ enum FeeRule {
 
 // The proposed change outputs and fee value.
 message TransactionBalance {
-    // A list of change output values.
+    // A list of change or ephemeral output values.
     repeated ChangeValue proposedChange = 1;
     // The fee to be paid by the proposed transaction, in zatoshis.
     uint64 feeRequired = 2;
+    // The exact number of dummy outputs in each shielded bundle. Omitted by
+    // proposals created before transaction shape was modelled explicitly.
+    DummyOutputs dummyOutputs = 3;
 }
 
-// A proposed change output. If the transparent value pool is selected,
-// the `memo` field must be null.
+// Exact per-pool dummy-output counts for the proposed transaction.
+message DummyOutputs {
+    uint32 sapling = 1;
+    uint32 orchard = 2;
+    uint32 ironwood = 3;
+}
+
+// A proposed change or ephemeral output. If the transparent value pool is
+// selected, the `memo` field must be null.
+//
+// When the `isEphemeral` field of a `ChangeValue` is set, it represents
+// an ephemeral output, which must be spent by a subsequent step. This is
+// only supported for transparent outputs. Each ephemeral output will be
+// given a unique t-address.
+//
+// When the transparent value pool is selected and the `isEphemeral` field
+// is not set, the value represents transparent change, which will be sent
+// to an internal-scope (change) transparent address of the wallet.
 message ChangeValue {
-    // The value of a change output to be created, in zatoshis.
+    // The value of a change or ephemeral output to be created, in zatoshis.
     uint64 value = 1;
-    // The value pool in which the change output should be created.
+    // The value pool in which the change or ephemeral output should be created.
     ValuePool valuePool = 2;
-    // The optional memo that should be associated with the newly created change output.
-    // Memos must not be present for transparent change outputs.
+    // The optional memo that should be associated with the newly created output.
+    // Memos must not be present for transparent outputs.
     MemoBytes memo = 3;
+    // Whether this is to be an ephemeral output.
+    bool isEphemeral = 4;
 }
 
 // An object wrapper for memo bytes, to facilitate representing the


### PR DESCRIPTION
The Kotlin copy of `proposal.proto` had drifted from the definition the pinned
`zcash_client_backend` encodes against. Rust builds the proposal with the
upstream schema, so every field the vendored copy lacked was unreadable on the
Kotlin side.

## What was missing

- `ValuePool.Ironwood = 4`. A proposal carrying an Ironwood output or change
  value decoded that pool as `UNRECOGNIZED`, which is exactly the
  misattribution the upstream comment on the variant warns about.
- `Proposal.confirmationsPolicy = 5`, plus the `ConfirmationsPolicy` message.
- `Proposal.proposedVersion = 6`.
- `TransactionBalance.dummyOutputs = 3`, plus the `DummyOutputs` message. This
  one is Ironwood-relevant: it carries the per-pool dummy-output counts that
  determine Ironwood bundle padding.
- `ChangeValue.isEphemeral = 4`.
- Two comment typos and the change/ephemeral wording upstream has since fixed.

All are additive, so previously serialized proposals keep decoding unchanged.
Round-tripping a proposal through Kotlin already preserved these values as
unknown fields, so no proposal was ever mis-built; they were simply unreadable.

## Verification

- `protoc --descriptor_set_out` compiles the file (protoc 35.1 locally;
  `PROTOC_VERSION=4.34.0` in `gradle.properties`, both well above the 3.15
  needed for proto3 `optional`).
- Decoding the descriptor set confirms `name: "Ironwood" number: 4`, matching
  the upstream discriminant.
- `diff` against `zcash_client_backend/proto/proposal.proto` at librustzcash
  `6c07e5f329` (the `zcash_client_sqlite-0.22.0-rc.6` release commit this
  branch pins) is empty apart from the `option java_package` line. That is the
  same single local deviation `scripts/update-lightwallet-protocol.sh:11`
  documents for the other vendored protos.
- No Kotlin or Rust source references `ValuePool`, and the generated Java and
  Kotlin is not committed, so the next build picks this up with no other edits.

## Follow-up worth doing separately

Unlike `compact_formats.proto` and `service.proto`, this file has no provenance
header and no sync tooling. Nothing in `scripts/`, `.github/`, or the Gradle
build references `proposal.proto` at all, so there is nothing to tell a reader
where it comes from or to catch it drifting again. Its upstream is a different
repository from the lightwallet protos, so it needs its own equivalent of
`scripts/update-lightwallet-protocol.sh` plus a CI check that diffs it against
the pinned `zcash_client_backend`. This PR only repairs the current drift.

Based on `maint/v2.7.x` so it can be forward-merged, per the branching policy.

Generated with [Claude Code](https://claude.com/claude-code)