### PR TITLE
AGENTS.md: only v_transactions and v_tx_outputs may be read directly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,19 @@ tables. The definitions live in `zcash_client_sqlite/src/wallet/db.rs` in
 
 [lrz]: https://github.com/zcash/librustzcash
 
+### Why those two, and when to ask for another
+
+Everything the FFI returns is serialized and copied across the boundary, so a
+query yielding many rows can cost more that way than reading it directly.
+That is why `v_transactions` and `v_tx_outputs`, which back the transaction
+history, are exempt at all.
+
+Another query with the same bulk property may deserve the same treatment, but
+that is not a call to make on your own. Do not add a direct read silently:
+flag it to the user, say what the query returns and roughly how much data it
+moves, and let them decide. If they agree, record it in the table below so the
+next reader sees a sanctioned exception rather than a violation.
+
 ### Where direct access lives
 
 All of it is under

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,6 +226,48 @@ the body.
 - All enhancements and bug fixes need an entry in `CHANGELOG.md`
   (see `CONTRIBUTING.md` and `docs/CODE_REVIEW_GUIDELINES.md`).
 
+## Database access: views only, everything else through the FFI
+
+`data.db` is owned by Rust. `zcash_client_sqlite` defines both its tables and
+a set of `v_*` views, and only the views are a supported interface. The tables
+are an implementation detail that upstream reshapes freely, and a schema
+migration that leaves a view's columns intact can still rename, split or drop
+the tables underneath it.
+
+**Kotlin may read `v_transactions` and `v_tx_outputs` directly. Every other
+query goes through the FFI.** Never read a table from Kotlin, and never write
+anything at all: writes belong to Rust, which owns invariants across tables
+that no single statement can preserve.
+
+Those two views are the client-facing read surface. `zcash_client_sqlite`
+defines other `v_*` views, but they serve the scanning and note-commitment
+machinery inside Rust and are not an interface for this SDK; treat them like
+tables. The definitions live in `zcash_client_sqlite/src/wallet/db.rs` in
+[librustzcash][lrz].
+
+[lrz]: https://github.com/zcash/librustzcash
+
+### Where direct access lives
+
+All of it is under
+`sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/`. Adding a
+query anywhere else is a mistake; adding one that names a table is a mistake
+wherever it is.
+
+| File | Reads | Status |
+|---|---|---|
+| `AllTransactionView.kt` | `v_transactions` | view, fine |
+| `TxOutputsView.kt` | `v_tx_outputs` | view, fine |
+| `BlockTable.kt` | `blocks` | **table, pre-existing exception** |
+| `TransactionTable.kt` | `transactions` | **table, pre-existing exception** |
+
+`DerivedDataDb.kt` and `DbDerivedDataRepository.kt` are wiring and open no
+entities of their own.
+
+The two exceptions predate this rule and are being migrated to the FFI. Do not
+copy them, and do not add to them: if you need something they expose, add an
+FFI call rather than a third table reader.
+
 ## Other notes
 
 - The SDK and related libraries are Kotlin + Rust. Changes that cross the


### PR DESCRIPTION
`data.db` is owned by Rust. `zcash_client_sqlite` treats its `v_*` views as the
interface and its tables as an implementation detail, so a migration that keeps
a view's columns stable is still free to rename, split or drop the tables
beneath it. A Kotlin query naming a table therefore breaks on a dependency bump
with **no compile error and no test failure** until it runs against an upgraded
wallet. Worth writing down.

## The rule

Kotlin may read `v_transactions` and `v_tx_outputs` directly. Every other query
goes through the FFI, and nothing in Kotlin writes to the database at all.

The other `v_*` views upstream defines (`v_received_outputs`,
`v_received_output_spends`, `v_address_uses`, `v_address_first_use`, and the
per-pool shard scan-state views) serve Rust's own scanning machinery rather than
this SDK, so they are treated like tables.

## Where direct access lives

All of it is under `sdk-lib/.../internal/db/derived/`:

| File | Reads | Status |
|---|---|---|
| `AllTransactionView.kt` | `v_transactions` | view, fine |
| `TxOutputsView.kt` | `v_tx_outputs` | view, fine |
| `BlockTable.kt` | `blocks` | table, pre-existing exception |
| `TransactionTable.kt` | `transactions` | table, pre-existing exception |

I surveyed rather than assumed: those four are the only files naming an entity.
`DerivedDataDb.kt` and `DbDerivedDataRepository.kt` are wiring.

The two exceptions are documented as exceptions, not endorsed. Each needs an
FFI accessor that does not exist yet (block lookup by expiry height,
transaction counts, raw bytes by txid, mined height by txid), so removing them
is upstream librustzcash work first. That overlaps API gaps already identified
during the PR #2021 SQL review.

Docs only, so no CHANGELOG entry and no behaviour change.

The companion rule for the Swift SDK is
zcash/zcash-swift-wallet-sdk#(see linked PR).

Based on `maint/v2.7.x` so it can be forward-merged, per the branching policy.

Generated with [Claude Code](https://claude.com/claude-code)