### PR TITLE
Match BlockTableDefinition to the blocks schema

### DIFF
--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/BlockTable.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/BlockTable.kt
@@ -69,5 +69,9 @@ internal object BlockTableDefinition {
 
     const val COLUMN_INTEGER_SAPLING_OUTPUT_COUNT = "sapling_output_count" // $NON-NLS
 
-    const val COLUMN_INTEGER_ORCHARD_OUTPUT_COUNT = "orchard_output_count" // $NON-NLS
+    const val COLUMN_INTEGER_ORCHARD_ACTION_COUNT = "orchard_action_count" // $NON-NLS
+
+    const val COLUMN_INTEGER_IRONWOOD_COMMITMENT_TREE_SIZE = "ironwood_commitment_tree_size" // $NON-NLS
+
+    const val COLUMN_INTEGER_IRONWOOD_ACTION_COUNT = "ironwood_action_count" // $NON-NLS
 }


### PR DESCRIPTION
**Stacked on #2095.** It targets that branch, not `maint/v2.7.x`, so the diff
here is only this change.

You asked whether the missing Ironwood columns in `BlockTable.kt` are correct.
They are not, and checking turned up a second, worse problem.

## What the schema actually is

From `zcash_client_sqlite/src/wallet/db.rs` at the pinned
`zcash_client_backend 0.24.0-rc.6`:

```sql
CREATE TABLE blocks (
    height INTEGER PRIMARY KEY,  hash BLOB NOT NULL,  time INTEGER NOT NULL,
    sapling_tree BLOB NOT NULL,
    sapling_commitment_tree_size INTEGER,  orchard_commitment_tree_size INTEGER,
    sapling_output_count INTEGER,          orchard_action_count INTEGER,
    ironwood_commitment_tree_size INTEGER, ironwood_action_count INTEGER)
```

## Two defects

1. **Ironwood was missing.** `ironwood_commitment_tree_size` and
   `ironwood_action_count` have been in the table since NU6.3 support landed
   and were never declared. Added.
2. **`orchard_output_count` does not exist and never did.** The column is
   `orchard_action_count` — an Orchard bundle is counted in *actions*, not
   outputs, which is also why the Ironwood column is named the same way. A
   query built from the old constant would have failed at runtime with
   `no such column`. Renamed.

The second one is the reason this was worth checking rather than just adding
two lines.

## Why this is currently harmless, and the honest caveat

Every one of these constants is **unused**. Only `height`, `hash` and `time`
are ever projected, by `findBlockByExpiryHeight` via `PROJECTION_BLOCK_SIMPLE`.
I confirmed `COLUMN_INTEGER_ORCHARD_OUTPUT_COUNT` had no references anywhere,
so the rename cannot break a build.

So this PR fixes a description, not behaviour. I kept the constants rather than
deleting them because the object exists to describe the schema, and a
description that is *wrong* is worse than one that is incomplete.

**The better end state is deleting the six unused constants entirely**, which
becomes natural when this file moves behind the FFI (`blocks` is one of the
table-reader exceptions recorded in #2095). Say the word and I will swap this
PR for that instead.

## Swift: nothing to change

`BlockDao.swift` models only `height` and `time` (`Block.TableStructure`). It
never mirrored the tree-size or count columns, so there is no Ironwood gap
there and nothing to add. Adding them would be inventing unused declarations.

## Verification

- Declared column set now equals the upstream schema exactly: no missing, no
  bogus.
- `ktlint` and `detektAll` pass.

Based on `maint/v2.7.x` via #2095, so it can be forward-merged.

Generated with [Claude Code](https://claude.com/claude-code)