### PR TITLE
Backport AGENTS.md from feature/ironwood-slipstream

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,11 +13,12 @@ jobs that are runnable on a dev machine:
 
 ```bash
 ./scripts/ci-local.sh fast     # detekt + ktlint (~30s) -- run this first
-./scripts/ci-local.sh quick    # fast + unit tests (~5m)
+./scripts/ci-local.sh quick    # fast + rust + unit tests (~5m)
 ./scripts/ci-local.sh full     # everything, including androidTest (~15-30m)
 
 # Or a single stage when iterating:
 ./scripts/ci-local.sh detekt
+./scripts/ci-local.sh rust
 ./scripts/ci-local.sh lint
 ./scripts/ci-local.sh demoapp
 ```
@@ -25,6 +26,9 @@ jobs that are runnable on a dev machine:
 `quick` is what actually compiles the Kotlin: `fast` only runs static
 analysis, so it will pass on code that does not compile. Run at least `quick`
 after any change to a Kotlin source file.
+
+The `rust` stage runs `cargo test` against `backend-lib`. The first invocation
+builds around 640 crates and is slow; later runs are incremental.
 
 ### Environment requirements
 
@@ -64,6 +68,7 @@ after any change to a Kotlin source file.
 |---|---|
 | Style / rename / doc | `fast` |
 | Logic or refactor | `quick` |
+| Rust-only change under `backend-lib/src/main/rust` | `fast` then `rust` |
 | New public API, new module, JNI/Rust boundary | `full` |
 | Demo-app only | `fast` then `demoapp` |
 
@@ -97,12 +102,129 @@ git pull origin main
 git worktree add ../fix-something -b fix/something main
 ```
 
+## Security-critical API rules
+
+These rules exist because violations have shipped before. They are not
+stylistic.
+
+### Semantic types for public APIs (MUST)
+
+Every public API parameter that carries a domain value — key material,
+seeds, addresses, memos, account identifiers — MUST use its semantic
+wrapper type. Never accept or pass bare `String` or `ByteArray` for these
+values in the public surface. A primitive-typed parameter lets a typo or
+autocomplete slip a key into a memo field, and lets invalid input travel
+all the way to the Rust backend before failing.
+
+- Gold-standard pattern to copy: `UnifiedSpendingKey`
+  (`sdk-lib/.../sdk/model/UnifiedSpendingKey.kt`) — private constructor,
+  rust-backed validation on construction (`validateUnifiedSpendingKey`),
+  bytes held in `FirstClassByteArray`, and `toString()` redacted so the key
+  can never leak through logs. New key-material types MUST follow it.
+- Known weak spot: `UnifiedFullViewingKey` is currently a bare
+  `data class(val encoding: String)` with no construction-time validation.
+  Do not treat it as a pattern to copy; new or changed types must validate
+  on construction through the backend so invalid values are rejected before
+  reaching deeper API calls.
+- **All parsing and validation is librustzcash's job, surfaced through the
+  JNI layer.** NEVER implement your own inline parser, regex, prefix check,
+  or encoding check for key material or addresses in Kotlin. If the
+  validation entry point you need does not exist, expose the librustzcash
+  function through `backend-lib` (`Backend.kt`) and `TypesafeBackend`, and
+  call that.
+- Known gaps — do not extend them: seeds as raw `ByteArray`
+  (`DerivationTool`), addresses and memos as `String` on `Synchronizer`
+  (`proposeTransfer`, `validateAddress`, ...), and the UFVK as `String` in
+  `DerivationTool.deriveUnifiedAddress` / `derivePrivateUseMetadataKey`.
+  Any new API takes the semantic type; conversion from raw input happens at
+  the app-facing edge.
+- Reduction to raw `String`/`ByteArray` happens only in
+  `TypesafeBackendImpl` at the JNI boundary (e.g. `setup.ufvk.encoding`).
+  That is the existing pattern — keep it there and nowhere else.
+- This does not conflict with the "soft validation for `Jni*` classes" note
+  below: that note covers data flowing *out of* Rust into `Jni*` holders;
+  this section covers caller input flowing *toward* Rust.
+
+### Key material in errors and logs (MUST)
+
+- Rust side: NEVER interpolate caller-supplied input into `anyhow!` /
+  exception messages. Counterexample not to repeat: `parse_ufvk`
+  (`backend-lib/src/main/rust/lib.rs`) embeds the full input in
+  `Value "{ufvk_string}" did not decode as a valid UFVK`. The correct
+  pattern, used elsewhere in `lib.rs`, embeds only the error (`{:?}` on
+  `e`), never the input.
+- Kotlin side: exception messages must not splice `cause?.message` from JNI
+  `RuntimeException`s — those messages originate in Rust and may echo key
+  material. Counterexample: `InitializeException.ImportAccountException`
+  (`sdk-lib/.../exception/Exceptions.kt`) builds
+  `"... due to: ${cause?.message}"`. Keep the cause as the chained
+  throwable; keep the message fixed and generic.
+- Do not pass backend throwables to `Twig` whole (e.g.
+  `Twig.error(it) { ... }` on a JNI failure) — log a fixed message instead.
+  Users copy logs and error dialogs into support emails without knowing
+  what is embedded in them.
+- Changes to error paths that cross the JNI boundary must be checked on
+  both the Rust and Kotlin sides in lockstep, same as any other JNI change.
+
+## CHANGELOG discipline
+
+`CHANGELOG.md` exists for consumers of the published library, and nothing else.
+
+- Update it for any **public API change, bug fix, or semantic change**. The entry
+  **must** be part of the same commit that makes the change, not a follow-up.
+- Entries carry **only** what a consumer needs in order to adapt: the public symbol
+  by name, the precise shape of the change, what breaks at their call site, and the
+  edit to make (or that none is needed).
+- **Never** describe implementation details, or contracts that are not visible
+  through the public API. In particular, do not narrate branch or release topology
+  -- which line merged into which, which version numbers were skipped, why the
+  ordering in the file looks the way it does. None of that is actionable for a
+  consumer.
+- Record **only completed changes since the last release**, never the interstitial
+  states of an API that was changed several times since then. If a symbol was added
+  and then renamed before release, the entry describes the final name only.
+- **Never modify an entry under an already-published version heading** (a dated
+  `## [x.y.z] - DATE` section). Those are the historical record of what that release
+  shipped, and must not be altered even to clarify or correct. New information goes
+  under `## [Unreleased]`.
+- Do **not** add a separate "Breaking changes" section. `### Changed` already is the
+  breaking-change section -- everything under it is breaking, whether semver,
+  dependency, or otherwise. Non-breaking additions go under `### Added`, fixes under
+  `### Fixed`. Each `### Changed` entry should read as the consumer meets the break:
+  "positional construction will not compile", "exhaustive `when` stops compiling until
+  the new case is handled", "any implementer or test fake must now provide this".
+- Privacy, security, and cost properties are user-facing even when they are documented
+  only in KDoc or rustdoc. Wallet teams design confirmation UI from the changelog, so
+  a feature that reveals data on-chain, costs a fee, or fails at runtime belongs here
+  too.
+
+When preparing a release, audit the public surface by diffing the release range rather
+than trusting the file to be complete. Behavior-only changes with no signature change
+-- altered equality semantics, stricter validation, a previously fixed value becoming
+settable -- are the ones most often missed.
+
 ## Commit message conventions
 
-The project uses ticket-prefixed commit messages for tracked work, e.g.
-`MOB-1100: Fixed runtime crashes`. For untracked fixes, a short imperative
-prefix is acceptable (`fix: ...`, `chore: ...`). Keep the first line under
-72 characters; include context in the body.
+Tracked work uses ticket-prefixed commit messages. Two ticket systems are
+in use, and they are equivalent in format — reference whichever ticket the
+work was assigned from:
+
+- `MOB-1100: Fixed runtime crashes` — Linear tickets, internal to the
+  wallet team. A MOB- ticket may or may not have a correlated GitHub issue.
+- `[#258] Fixed runtime crashes` — GitHub issues (the format described in
+  `CONTRIBUTING.md`); use this when the work references a GitHub issue.
+
+For untracked fixes, a short imperative prefix is acceptable (`fix: ...`,
+`chore: ...`). Keep the first line under 72 characters; include context in
+the body.
+
+## PRs and changelog
+
+- PRs that reference a GitHub issue should link it (`[#issue]` in the
+  title/commits per `CONTRIBUTING.md`); PRs for Linear-tracked work
+  reference the MOB- ticket instead.
+- All enhancements and bug fixes need an entry in `CHANGELOG.md`
+  (see `CONTRIBUTING.md` and `docs/CODE_REVIEW_GUIDELINES.md`).
 
 ## Other notes
 
@@ -121,7 +243,10 @@ prefix is acceptable (`fix: ...`, `chore: ...`). Keep the first line under
   `env.new_object` type signature still needs `./scripts/ci-local.sh quick`.
 - Detekt and ktlint are strict; treat their output as blocking. `detektAll`
   catches `MaxLineLength`, `ReturnCount`, `LongParameterList`, and similar
-  issues that won't be apparent from a plain `./gradlew build`.
+  issues that won't be apparent from a plain `./gradlew build`. Configs live
+  in `tools/detekt.yml` and `tools/.editorconfig`; the authoritative style
+  references are the Kotlin Coding Conventions and AOSP Java conventions
+  (see `docs/CODE_REVIEW_GUIDELINES.md`).
 - When touching `Jni*` data classes that are constructed from Rust via
   `env.new_object`, keep the JVM signature (`(JJJ)V` etc.) in sync and
   avoid adding `require` blocks that crash on edge-case inputs -- the


### PR DESCRIPTION
The agent guidance on `feature/ironwood-slipstream` had moved ahead of this
maintenance branch, so work started here inherits stale instructions. This
takes the feature branch's `AGENTS.md` verbatim so both branches agree before
anything is layered on top.

Copied as-is from `origin/feature/ironwood-slipstream`; nothing is invented
here. 129 lines -> 254.

What it brings in: the **Security-critical API rules** section (semantic types
for public APIs, key material in errors and logs) and the **CHANGELOG
discipline** and **PRs and changelog** sections, plus rewording of the pre-push
and commit-convention guidance.

Six lines from the old file have no byte-identical counterpart, but all are
rewordings rather than removals: the `ci-local.sh quick` comment now reads
`fast + rust + unit tests`, and the commit-convention paragraph is replaced by
a fuller section that still documents the `MOB-` ticket prefix. I checked each
rather than assuming the newer file is a superset.

#2095 is stacked on this and adds the database-access rule on top.

Generated with [Claude Code](https://claude.com/claude-code)