### PR TITLE
Carry the Ironwood tree state through checkpoints

### DIFF
--- a/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/model/TreeStateUnsafe.kt
+++ b/lightwallet-client-lib/src/main/java/co/electriccoin/lightwallet/client/model/TreeStateUnsafe.kt
@@ -8,12 +8,14 @@ class TreeStateUnsafe(
     companion object {
         fun new(treeState: TreeState): TreeStateUnsafe = TreeStateUnsafe(treeState.toByteArray())
 
+        @Suppress("LongParameterList")
         fun fromParts(
             height: Long,
             hash: String,
             time: Int,
             saplingTree: String,
-            orchardTree: String
+            orchardTree: String,
+            ironwoodTree: String?
         ): TreeStateUnsafe {
             val treeState =
                 TreeState
@@ -23,6 +25,7 @@ class TreeStateUnsafe(
                     .setTime(time)
                     .setSaplingTree(saplingTree)
                     .setOrchardTree(orchardTree)
+                    .apply { ironwoodTree?.let { setIronwoodTree(it) } }
                     .build()
             return new(treeState)
         }

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/fixture/CheckpointFixture.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/fixture/CheckpointFixture.kt
@@ -4,6 +4,7 @@ import cash.z.ecc.android.sdk.internal.model.Checkpoint
 import cash.z.ecc.android.sdk.internal.model.ext.KEY_EPOCH_SECONDS
 import cash.z.ecc.android.sdk.internal.model.ext.KEY_HASH
 import cash.z.ecc.android.sdk.internal.model.ext.KEY_HEIGHT
+import cash.z.ecc.android.sdk.internal.model.ext.KEY_IRONWOOD_TREE
 import cash.z.ecc.android.sdk.internal.model.ext.KEY_ORCHARD_TREE
 import cash.z.ecc.android.sdk.internal.model.ext.KEY_SAPLING_TREE
 import cash.z.ecc.android.sdk.internal.model.ext.KEY_VERSION
@@ -26,18 +27,21 @@ object CheckpointFixture {
     @Suppress("MaxLineLength", "ktlint:standard:max-line-length")
     const val ORCHARD_TREE = "01ffe841309dd0d9fd5073282a966b5daaf3a36834b62ac25e350dd581cfce6e2f01f6be2fb34b7ead63fcf256751c7839f138121c5237b745f6bd1bf17b4b16da1e1f0102c2cc2ee89c7561d05e34d642efa5eb991141579cca7b0ff2c7faf7a253501d013490d36beed18879794594a1b9bf0def458e30cd99ddc5ae716c2eb121ccce37000001941b26a7f09a7a3887aec0879dfc1275225b83efbcef54674930c3c2dfe3322200000123f80f8c4446da4a147c92340b492788dca810ce0a997860f151a86927e86f390000000000000000000000000000000000000000000000"
 
+    @Suppress("LongParameterList")
     internal fun new(
         height: BlockHeight = HEIGHT,
         hash: String = HASH,
         time: Long = EPOCH_SECONDS,
         saplingTree: String = SAPLING_TREE,
-        orchardTree: String = ORCHARD_TREE
+        orchardTree: String = ORCHARD_TREE,
+        ironwoodTree: String? = null
     ) = Checkpoint(
         height = height,
         hash = hash,
         epochSeconds = time,
         saplingTree = saplingTree,
-        orchardTree = orchardTree
+        orchardTree = orchardTree,
+        ironwoodTree = ironwoodTree
     )
 }
 
@@ -50,4 +54,5 @@ internal fun Checkpoint.toJson() =
             put(Checkpoint.KEY_EPOCH_SECONDS, epochSeconds)
             put(Checkpoint.KEY_SAPLING_TREE, saplingTree)
             put(Checkpoint.KEY_ORCHARD_TREE, orchardTree)
+            ironwoodTree?.let { put(Checkpoint.KEY_IRONWOOD_TREE, it) }
         }.toString()

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/Checkpoint.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/Checkpoint.kt
@@ -9,7 +9,12 @@ import cash.z.ecc.android.sdk.model.BlockHeight
  * @param height the height of the checkpoint.
  * @param hash the hash of the block at [height].
  * @param epochSeconds the time of the block at [height].
- * @param tree the sapling tree corresponding to [height].
+ * @param saplingTree the sapling tree corresponding to [height].
+ * @param orchardTree the orchard tree corresponding to [height].
+ * @param ironwoodTree the ironwood tree corresponding to [height], or null for a
+ * checkpoint generated before Ironwood tree states were published. Mainnet
+ * checkpoints do not carry it yet, so this cannot be required the way
+ * [orchardTree] is.
  */
 internal data class Checkpoint(
     val height: BlockHeight,
@@ -17,13 +22,21 @@ internal data class Checkpoint(
     // Note: this field does NOT match the name of the JSON, so will break with field-based JSON parsing
     val epochSeconds: Long,
     val saplingTree: String,
-    val orchardTree: String
+    val orchardTree: String,
+    val ironwoodTree: String?
 ) {
     fun treeState(): TreeState {
         require(epochSeconds.isInUIntRange()) {
             "epochSeconds $epochSeconds is outside of allowed UInt range"
         }
-        return TreeState.fromParts(height.value, hash, epochSeconds.toInt(), saplingTree, orchardTree)
+        return TreeState.fromParts(
+            height.value,
+            hash,
+            epochSeconds.toInt(),
+            saplingTree,
+            orchardTree,
+            ironwoodTree
+        )
     }
 
     @Suppress("MagicNumber")

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/TreeState.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/TreeState.kt
@@ -13,14 +13,17 @@ class TreeState(
             )
         }
 
+        @Suppress("LongParameterList")
         fun fromParts(
             height: Long,
             hash: String,
             time: Int,
             saplingTree: String,
-            orchardTree: String
+            orchardTree: String,
+            ironwoodTree: String?
         ): TreeState {
-            val unsafeTreeState = TreeStateUnsafe.fromParts(height, hash, time, saplingTree, orchardTree)
+            val unsafeTreeState =
+                TreeStateUnsafe.fromParts(height, hash, time, saplingTree, orchardTree, ironwoodTree)
             return TreeState.new(unsafeTreeState)
         }
     }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/ext/CheckpointExt.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/ext/CheckpointExt.kt
@@ -24,6 +24,9 @@ internal val Checkpoint.Companion.KEY_SAPLING_TREE
 internal val Checkpoint.Companion.KEY_ORCHARD_TREE
     get() = "orchardTree"
 
+internal val Checkpoint.Companion.KEY_IRONWOOD_TREE
+    get() = "ironwoodTree"
+
 internal fun Checkpoint.Companion.from(
     zcashNetwork: ZcashNetwork,
     jsonString: String
@@ -56,7 +59,18 @@ private fun Checkpoint.Companion.from(
                     "000000" // NON-NLS
                 }
 
-            return Checkpoint(height, hash, epochSeconds, saplingTree, orchardTree)
+            // Optional, unlike orchardTree: mainnet checkpoints do not carry an
+            // Ironwood tree state yet, so requiring it post-NU6.3 would reject
+            // every mainnet checkpoint currently shipped.
+            val ironwoodTree =
+                try {
+                    jsonObject.getString(Checkpoint.KEY_IRONWOOD_TREE)
+                } catch (e: JSONException) {
+                    Twig.verbose(e) { "This checkpoint does not contain an Ironwood tree state" }
+                    null
+                }
+
+            return Checkpoint(height, hash, epochSeconds, saplingTree, orchardTree, ironwoodTree)
         }
 
         else -> {


### PR DESCRIPTION
Found by an audit of where Ironwood should appear but does not. Independent of
the other open PRs; based directly on `maint/v2.7.x`.

## The bug

The lightwalletd `TreeState` message has **`string ironwoodTree = 7`**
(`service.proto:193`). The SDK never read it:

- `Checkpoint.kt` held only `saplingTree` and `orchardTree`
- `TreeState.fromParts` and `TreeStateUnsafe.fromParts` took only those two, so
  the protobuf builder never called `setIronwoodTree`
- `CheckpointExt.kt` parsed only those two

This feeds wallet initialisation (`SdkSynchronizer.kt:902`,
`DerivedDataDb.kt:157`), so a wallet seeded from a checkpoint got **no Ironwood
commitment tree state**.

**Not hypothetical:** testnet checkpoints already ship the field and it was
being read off disk and discarded. Counted in-tree: 7 of 394 on `maint/v2.7.x`,
16 of 394 on `maint/v2.8.x`. The Swift SDK already handles it
(`Checkpoint.swift:34,70,103`), so Android was simply behind.

## Optional, deliberately

`orchardTree` is *required* post-NU5, and the obvious symmetry would be to
require `ironwoodTree` post-NU6.3. **That would break every mainnet wallet.** I
counted: `0` mainnet checkpoints carry an `ironwoodTree` on `maint/v2.7.x`,
`maint/v2.8.x`, or `feature/ironwood-slipstream` (newest checkpoint 3427310).
Requiring it would reject all 807 shipped mainnet checkpoints.

So it is optional, matching Swift's `decodeIfPresent`. Tightening to a
requirement is a follow-up once the mainnet checkpoints are regenerated with
the field, and at that point the `orchardTree` block is the template.

## Verification

- `:sdk-lib:compileDebugKotlin` and `:sdk-lib:compileDebugAndroidTestKotlin`
  both compile.
- `ktlint` and `detektAll` pass (the three signatures now hit the
  6-parameter `LongParameterList` threshold and carry a scoped `@Suppress`,
  matching how the codebase handles it elsewhere).
- `CheckpointFixture.toJson` writes the field when present, so the
  parse-and-serialise round trip cannot silently drop it again.

Generated with [Claude Code](https://claude.com/claude-code)