### PR TITLE
Show the Ironwood balance in the demo app

### DIFF
--- a/demo-app/src/main/java/cash/z/ecc/android/sdk/demoapp/demos/getbalance/GetBalanceFragment.kt
+++ b/demo-app/src/main/java/cash/z/ecc/android/sdk/demoapp/demos/getbalance/GetBalanceFragment.kt
@@ -153,6 +153,21 @@ class GetBalanceFragment : BaseDemoFragment<FragmentGetBalanceBinding>() {
                             val account = it.getAccounts()[CURRENT_ZIP_32_ACCOUNT_INDEX.toInt()]
                             it.walletBalances.combine(it.exchangeRateUsd) { balances, rate ->
                                 balances?.let {
+                                    val walletBalance = balances[account.accountUuid]!!.ironwood
+                                    walletBalance to
+                                        rate.currencyConversion
+                                            ?.priceOfZec
+                                            ?.toBigDecimal()
+                                }
+                            }
+                        }.collect { onIronwoodBalance(it) }
+
+                    sharedViewModel.synchronizerFlow
+                        .filterNotNull()
+                        .flatMapLatest {
+                            val account = it.getAccounts()[CURRENT_ZIP_32_ACCOUNT_INDEX.toInt()]
+                            it.walletBalances.combine(it.exchangeRateUsd) { balances, rate ->
+                                balances?.let {
                                     val walletBalance = balances[account.accountUuid]!!.unshielded
                                     walletBalance to
                                         rate.currencyConversion
@@ -169,6 +184,12 @@ class GetBalanceFragment : BaseDemoFragment<FragmentGetBalanceBinding>() {
     private fun onOrchardBalance(orchardBalance: Pair<WalletBalance, BigDecimal?>?) {
         binding.orchardBalance.apply {
             text = orchardBalance.balanceHumanString()
+        }
+    }
+
+    private fun onIronwoodBalance(ironwoodBalance: Pair<WalletBalance, BigDecimal?>?) {
+        binding.ironwoodBalance.apply {
+            text = ironwoodBalance.balanceHumanString()
         }
     }
 
@@ -225,6 +246,11 @@ class GetBalanceFragment : BaseDemoFragment<FragmentGetBalanceBinding>() {
                 onOrchardBalance(
                     synchronizer.walletBalances.value?.let {
                         Pair(it[account.accountUuid]!!.orchard, rate)
+                    }
+                )
+                onIronwoodBalance(
+                    synchronizer.walletBalances.value?.let {
+                        Pair(it[account.accountUuid]!!.ironwood, rate)
                     }
                 )
                 onSaplingBalance(

--- a/demo-app/src/main/java/cash/z/ecc/android/sdk/demoapp/ui/screen/balance/view/BalanceView.kt
+++ b/demo-app/src/main/java/cash/z/ecc/android/sdk/demoapp/ui/screen/balance/view/BalanceView.kt
@@ -141,6 +141,28 @@ private fun BalanceMainContent(
 
         Spacer(Modifier.padding(8.dp))
 
+        Text(stringResource(id = R.string.balance_ironwood))
+        Text(
+            stringResource(
+                id = R.string.balance_available_amount_format,
+                accountBalance.ironwood.available.toZecString(Locale.getDefault()),
+                exchangeRateUsd
+                    ?.multiply(accountBalance.ironwood.available.convertZatoshiToZec())
+                    .toUsdString(Locale.getDefault())
+            )
+        )
+        Text(
+            stringResource(
+                id = R.string.balance_pending_amount_format,
+                accountBalance.ironwood.pending.toZecString(Locale.getDefault()),
+                exchangeRateUsd
+                    ?.multiply(accountBalance.ironwood.pending.convertZatoshiToZec())
+                    .toUsdString(Locale.getDefault())
+            )
+        )
+
+        Spacer(Modifier.padding(8.dp))
+
         Text(stringResource(id = R.string.balance_sapling))
         Text(
             stringResource(

--- a/demo-app/src/main/res/layout/fragment_get_balance.xml
+++ b/demo-app/src/main/res/layout/fragment_get_balance.xml
@@ -36,6 +36,18 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
+            android:text="Ironwood balance" />
+
+        <TextView
+            android:id="@+id/ironwood_balance"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
             android:text="Sapling balance" />
 
         <TextView

--- a/demo-app/src/main/res/values/strings.xml
+++ b/demo-app/src/main/res/values/strings.xml
@@ -71,6 +71,7 @@
     <string name="balance_transparent">Transparent</string>
     <string name="balance_sapling">Sapling</string>
     <string name="balance_orchard">Orchard</string>
+    <string name="balance_ironwood">Ironwood</string>
     <string name="balance_available_amount_format">Available:
         <xliff:g id="ZEC balance" example="0.3">%1$s</xliff:g>
         (<xliff:g id="USD balance" example="7.2">%2$s</xliff:g> USD)</string>


### PR DESCRIPTION
Stacked on #2100. Last of the Ironwood audit findings, and the least
consequential: demo app only, no SDK behaviour change.

`AccountBalance` has carried an `ironwood: WalletBalance` since Ironwood
support landed, and **neither** balance screen displayed it. Both showed
Orchard, Sapling and transparent, so after a pool migration a demo-app user
could not see where their shielded funds actually were.

## Both screens, because both were wrong

- `ui/screen/balance/view/BalanceView.kt` — the Compose screen; a row mirroring
  the Orchard one, plus a `balance_ironwood` string.
- `demos/getbalance/GetBalanceFragment.kt` — the older fragment demo. I nearly
  skipped this one assuming it was single-pool, but its layout displays
  "Orchard balance", "Sapling balance" and "Transparent balance", so Ironwood
  was a genuine omission there too. Needed a layout entry, a flow collector and
  a handler to match the three already wired.

## Verification

- `:demo-app:compileZcashmainnetDebugKotlin` compiles (exit 0), which is what
  proves the generated `binding.ironwoodBalance` resolves from the new
  `@+id/ironwood_balance`.
- `ktlint` and `detektAll` pass.

Generated with [Claude Code](https://claude.com/claude-code)