### PR TITLE
chore: improve release preparation

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Checkout
         timeout-minutes: 1
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: Release tooling tests
+        timeout-minutes: 1
+        run: ./scripts/tests/run-tests.sh
       - name: Gradle Wrapper Validation
         timeout-minutes: 1
         uses: gradle/actions/wrapper-validation@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Release preparation now uses `scripts/prepare-release.sh`, creates
-  `candidate/vX.Y.Z`, validates and updates the Gradle and Rust versions, and
-  pushes both release branches before opening a draft pull request linked to
-  the release issue.
 - Updated the librustzcash crates to `zcash_client_backend 0.24.0-rc.6` and
   `zcash_client_sqlite 0.22.0-rc.6`, adopting the revised ZIP 318 migration timing
   (shorter transfer and preparation delays, and an anchor-age cap of 4 bucket

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Release preparation now uses `scripts/prepare-release.sh`, creates
+  `candidate/vX.Y.Z`, validates and updates the Gradle and Rust versions, and
+  pushes both release branches before opening a draft pull request linked to
+  the release issue.
 - Updated the librustzcash crates to `zcash_client_backend 0.24.0-rc.6` and
   `zcash_client_sqlite 0.22.0-rc.6`, adopting the revised ZIP 318 migration timing
   (shorter transfer and preparation delays, and an anchor-age cap of 4 bucket

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ already running an older version without shipping them unrelated trunk work.
 | `main` | permanent | Development trunk. New feature work lands here. |
 | `maint/vX.Y.x` | permanent | One per supported release line. Fixes to released versions land here. |
 | `release/vX.Y.Z` | one release | Cut from the previous release tag. The base of the release PR, and what gets tagged. |
-| `review/vX.Y.Z` | one release | Release preparation: version bumps, CHANGELOG promotion, final review. |
+| `candidate/vX.Y.Z` | one release | Release preparation: version bumps, CHANGELOG promotion, final review. |
 
 ### Basing a bug fix
 
@@ -113,21 +113,24 @@ main          ───●───────────────●──
 
 ### Cutting a release
 
-`./scripts/start-release.sh <remote> <version>` performs steps 1 through 4:
+`./scripts/prepare-release.sh --issue <N> <remote> <version>` performs steps 1
+through 4:
 it works out which release this one follows, creates and pushes the release
-branch, creates the review branch, bumps the version and promotes the
-CHANGELOG. Pass `--dry-run` first to see what it will do. The steps below are
-what it automates, and what to do by hand if a release needs to deviate.
+and candidate branches, bumps the version, promotes the CHANGELOG, and opens a
+draft pull request. Pass `--dry-run` first to see what it will do. The steps
+below are what it automates, and what to do by hand if a release needs to
+deviate.
 
 1. Create `release/vX.Y.Z` **from the previous release tag** and push it to
    upstream. It starts out identical to the last release.
-2. Create `review/vX.Y.Z` from the maintenance branch that contains all of the
+2. Create `candidate/vX.Y.Z` from the maintenance branch that contains all of the
    changes to be released.
-3. Open a pull request **on the public repository** from `review/vX.Y.Z` into
-   `release/vX.Y.Z`.
-4. Make the release preparation commits on `review/vX.Y.Z` — version bumps,
-   CHANGELOG promotion, and anything else the release needs. The review branch,
-   not the release branch, is where this work happens.
+3. Open a pull request **on the public repository** from `candidate/vX.Y.Z` into
+   `release/vX.Y.Z`. The script opens it as a draft and links the issue supplied
+   with `--issue`.
+4. Make the release preparation commits on `candidate/vX.Y.Z` — version bumps,
+   CHANGELOG promotion, and anything else the release needs. The candidate
+   branch, not the release branch, is where this work happens.
 5. Merge the pull request, then tag the result `vX.Y.Z`.
 
 Basing the release branch on the previous release tag is what makes the pull
@@ -139,9 +142,9 @@ tag vX.Y.W  (previous release)
       │
       └──▶  release/vX.Y.Z  ●──────────────────────────────●  tag vX.Y.Z
                                                            ▲
-                                                           │  PR: review ──▶ release
+                                                           │  PR: candidate ──▶ release
                                                            │
-        review/vX.Y.Z   ●────●────●────────────────────────┘
+     candidate/vX.Y.Z   ●────●────●────────────────────────┘
                         ▲     version bumps, CHANGELOG promotion
                         │
                         │  branch from maint

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -8,12 +8,13 @@
 # burning CI minutes.
 #
 # Stages (fast -> slow):
-#   1. detekt       -> static_analysis_detekt
-#   2. ktlint       -> static_analysis_ktlint
-#   3. unit tests   -> test_android_modules_unit
-#   4. android lint -> static_analysis_android_lint
-#   5. demo app     -> demo_app_release_build
-#   6. androidTest  -> (approximation of) test_android_modules_wtf
+#   1. shell tests  -> release tooling tests
+#   2. detekt       -> static_analysis_detekt
+#   3. ktlint       -> static_analysis_ktlint
+#   4. unit tests   -> test_android_modules_unit
+#   5. android lint -> static_analysis_android_lint
+#   6. demo app     -> demo_app_release_build
+#   7. androidTest  -> (approximation of) test_android_modules_wtf
 #
 # Stage 6 uses a Gradle Managed Device (pixel2Target, SDK 36). It downloads an
 # AVD on first run (~1.5 GB) and is the slowest stage.
@@ -23,6 +24,7 @@
 #   ./scripts/ci-local.sh fast        # stages 1-2 only (lint + style)
 #   ./scripts/ci-local.sh quick       # stages 1-3 (lint + style + unit tests)
 #   ./scripts/ci-local.sh full        # all stages including androidTest (default)
+#   ./scripts/ci-local.sh shell       # run release tooling tests
 #   ./scripts/ci-local.sh detekt      # run one named stage
 #
 # Requirements:
@@ -39,33 +41,38 @@ cd "${REPO_ROOT}"
 
 GRADLE="./gradlew"
 
+stage_shell() {
+    echo "==> [1/7] shell tests (release tooling tests)"
+    ./scripts/tests/run-tests.sh
+}
+
 stage_detekt() {
-    echo "==> [1/6] detekt (static_analysis_detekt)"
+    echo "==> [2/7] detekt (static_analysis_detekt)"
     "${GRADLE}" detektAll
 }
 
 stage_ktlint() {
-    echo "==> [2/6] ktlint (static_analysis_ktlint)"
+    echo "==> [3/7] ktlint (static_analysis_ktlint)"
     "${GRADLE}" ktlint
 }
 
 stage_unit() {
-    echo "==> [3/6] unit tests (test_android_modules_unit)"
+    echo "==> [4/7] unit tests (test_android_modules_unit)"
     "${GRADLE}" test
 }
 
 stage_lint() {
-    echo "==> [4/6] android lint (static_analysis_android_lint)"
+    echo "==> [5/7] android lint (static_analysis_android_lint)"
     "${GRADLE}" :sdk-lib:lintRelease :demo-app:lintZcashmainnetRelease
 }
 
 stage_demoapp() {
-    echo "==> [5/6] demo app release build (demo_app_release_build)"
+    echo "==> [6/7] demo app release build (demo_app_release_build)"
     "${GRADLE}" assembleRelease
 }
 
 stage_androidtest() {
-    echo "==> [6/6] android instrumentation tests (test_android_modules_wtf approximation)"
+    echo "==> [7/7] android instrumentation tests (test_android_modules_wtf approximation)"
     echo "    Note: CI uses testDebugWithEmulatorWtf (cloud). Local approximation runs the"
     echo "    same tests on a Gradle managed Pixel 2 (SDK 36) virtual device."
     "${GRADLE}" \
@@ -76,6 +83,7 @@ stage_androidtest() {
 }
 
 run_all() {
+    stage_shell
     stage_detekt
     stage_ktlint
     stage_unit
@@ -85,6 +93,7 @@ run_all() {
 }
 
 run_fast() {
+    stage_shell
     stage_detekt
     stage_ktlint
 }
@@ -98,6 +107,7 @@ case "${1:-full}" in
     fast)         run_fast ;;
     quick)        run_quick ;;
     full)         run_all ;;
+    shell)        stage_shell ;;
     detekt)       stage_detekt ;;
     ktlint)       stage_ktlint ;;
     unit)         stage_unit ;;

--- a/scripts/lib/release-lib.sh
+++ b/scripts/lib/release-lib.sh
@@ -24,14 +24,47 @@ run() {
 }
 
 valid_version() {
-    printf '%s\n' "$1" |
-        grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$'
+    printf '%s\n' "$1" | grep -Eq \
+        '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(alpha|beta|rc)\.[0-9]+)?$'
 }
 
-version_sort() { sed 's/-/~/' | sort -V | sed 's/~/-/'; }
+parse_version() {
+    local version="$1" suffix
+    [[ "$version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-(alpha|beta|rc)\.([0-9]+))?$ ]]
+    VERSION_MAJOR="${BASH_REMATCH[1]}"
+    VERSION_MINOR="${BASH_REMATCH[2]}"
+    VERSION_PATCH="${BASH_REMATCH[3]}"
+    suffix="${BASH_REMATCH[5]}"
+    case "$suffix" in
+        alpha) VERSION_RANK=1; VERSION_SEQUENCE="${BASH_REMATCH[6]}" ;;
+        beta)  VERSION_RANK=2; VERSION_SEQUENCE="${BASH_REMATCH[6]}" ;;
+        rc)    VERSION_RANK=3; VERSION_SEQUENCE="${BASH_REMATCH[6]}" ;;
+        *)     VERSION_RANK=4; VERSION_SEQUENCE=0 ;;
+    esac
+}
 
 version_le() {
-    [ "$(printf '%s\n%s\n' "$1" "$2" | version_sort | head -1)" = "$1" ]
+    local lhs_major lhs_minor lhs_patch lhs_rank lhs_sequence
+    local rhs_major rhs_minor rhs_patch rhs_rank rhs_sequence
+
+    parse_version "$1"
+    lhs_major="$VERSION_MAJOR"
+    lhs_minor="$VERSION_MINOR"
+    lhs_patch="$VERSION_PATCH"
+    lhs_rank="$VERSION_RANK"
+    lhs_sequence="$VERSION_SEQUENCE"
+    parse_version "$2"
+    rhs_major="$VERSION_MAJOR"
+    rhs_minor="$VERSION_MINOR"
+    rhs_patch="$VERSION_PATCH"
+    rhs_rank="$VERSION_RANK"
+    rhs_sequence="$VERSION_SEQUENCE"
+
+    if (( lhs_major != rhs_major )); then (( lhs_major < rhs_major )); return; fi
+    if (( lhs_minor != rhs_minor )); then (( lhs_minor < rhs_minor )); return; fi
+    if (( lhs_patch != rhs_patch )); then (( lhs_patch < rhs_patch )); return; fi
+    if (( lhs_rank != rhs_rank )); then (( lhs_rank < rhs_rank )); return; fi
+    (( 10#$lhs_sequence <= 10#$rhs_sequence ))
 }
 
 repo_slug_from_url() {

--- a/scripts/lib/release-lib.sh
+++ b/scripts/lib/release-lib.sh
@@ -196,4 +196,8 @@ require_gh_auth() {
     fi
 }
 
+require_gh_auth_for_run() {
+    [ "$DRY_RUN" = "true" ] || require_gh_auth
+}
+
 repo_for_remote() { repo_slug_from_url "$(git remote get-url "$1")"; }

--- a/scripts/lib/release-lib.sh
+++ b/scripts/lib/release-lib.sh
@@ -1,0 +1,166 @@
+# Shared helpers for prepare-release.sh. Source this; do not execute it.
+#
+# Pure transforms live here so scripts/tests/run-tests.sh can exercise them
+# without a network, a git remote, or a GitHub token. Written for bash 3.2,
+# which is what macOS ships.
+
+DRY_RUN="${DRY_RUN:-false}"
+
+step() { echo; echo "==> $*"; }
+
+die() {
+    echo "error: $1" >&2
+    shift
+    while [ $# -gt 0 ]; do echo "       $1" >&2; shift; done
+    exit 1
+}
+
+run() {
+    if [ "$DRY_RUN" = "true" ]; then
+        echo "  would run: $*"
+    else
+        "$@"
+    fi
+}
+
+valid_version() {
+    printf '%s\n' "$1" |
+        grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$'
+}
+
+version_sort() { sed 's/-/~/' | sort -V | sed 's/~/-/'; }
+
+version_le() {
+    [ "$(printf '%s\n%s\n' "$1" "$2" | version_sort | head -1)" = "$1" ]
+}
+
+repo_slug_from_url() {
+    printf '%s\n' "$1" | sed -E \
+        -e 's|\.git$||' \
+        -e 's|^[a-z+]+://||' \
+        -e 's|^[^/@]+@||' \
+        -e 's|^[^/:]+[:/]||'
+}
+
+gradle_property_value() {
+    awk -F= -v key="$2" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' "$1"
+}
+
+set_gradle_property() {
+    local file="$1" key="$2" value="$3" tmp
+    tmp="$(mktemp)"
+    if ! awk -v key="$key" -v value="$value" '
+        !changed && index($0, key "=") == 1 {
+            print key "=" value
+            changed = 1
+            next
+        }
+        { print }
+        END { if (!changed) exit 1 }
+    ' "$file" > "$tmp"; then
+        rm -f "$tmp"
+        return 1
+    fi
+    mv "$tmp" "$file"
+}
+
+cargo_package_version() {
+    awk '
+        /^\[/ { in_pkg = ($0 == "[package]") }
+        in_pkg && /^version[[:space:]]*=/ {
+            sub(/^version[[:space:]]*=[[:space:]]*"/, "")
+            sub(/"[[:space:]]*$/, "")
+            print
+            exit
+        }
+    ' "$1"
+}
+
+cargo_lock_package_version() {
+    awk -v pkg="$2" '
+        /^name = / {
+            name = $0
+            sub(/^name = "/, "", name)
+            sub(/"$/, "", name)
+            next
+        }
+        /^version = / && name == pkg {
+            sub(/^version = "/, "")
+            sub(/"$/, "")
+            print
+            exit
+        }
+    ' "$1"
+}
+
+bump_cargo_version() {
+    local file="$1" version="$2" tmp
+    tmp="$(mktemp)"
+    if ! awk -v ver="$version" '
+        /^\[/ { in_pkg = ($0 == "[package]") }
+        in_pkg && !changed && /^version[[:space:]]*=/ {
+            print "version = \"" ver "\""
+            changed = 1
+            next
+        }
+        { print }
+        END { if (!changed) exit 1 }
+    ' "$file" > "$tmp"; then
+        rm -f "$tmp"
+        return 1
+    fi
+    mv "$tmp" "$file"
+}
+
+changelog_unreleased_nonempty() {
+    awk '
+        /^## \[Unreleased\]/ { f = 1; next }
+        f && /^## \[/ { exit }
+        f && /^[-*] / { found = 1 }
+        END { exit !found }
+    ' "$1"
+}
+
+promote_changelog() {
+    local file="$1" version="$2" date="$3" tmp
+    tmp="$(mktemp)"
+    if ! awk -v ver="$version" -v date="$date" '
+        !changed && /^## \[Unreleased\]/ {
+            print
+            print ""
+            print "## [" ver "] - " date
+            changed = 1
+            next
+        }
+        { print }
+        END { if (!changed) exit 1 }
+    ' "$file" > "$tmp"; then
+        rm -f "$tmp"
+        return 1
+    fi
+    mv "$tmp" "$file"
+}
+
+require_clean_tree() {
+    if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+        die "the working tree has uncommitted changes." \
+            "Commit or stash them before releasing."
+    fi
+}
+
+require_remote() {
+    if ! git remote get-url "$1" >/dev/null 2>&1; then
+        die "no such remote '$1'." "Available remotes: $(git remote | tr '\n' ' ')"
+    fi
+}
+
+require_gh_auth() {
+    if ! command -v gh >/dev/null 2>&1; then
+        die "the GitHub CLI (gh) is not installed." "See https://cli.github.com/"
+    fi
+    if ! gh auth status >/dev/null 2>&1; then
+        die "gh is not authenticated." "Run: gh auth login"
+    fi
+}
+
+repo_for_remote() { repo_slug_from_url "$(git remote get-url "$1")"; }

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -100,9 +100,13 @@ if [ -n "$PREVIOUS" ]; then
 else
     # Only tags reachable from the revision are candidates: a tag on a newer
     # line is not something this release can be a successor to.
-    PREV_TAG="$(git tag --list --merged "$REV_SHA" "${TAG_PREFIX}[0-9]*" \
-                | sed "s/^${TAG_PREFIX}//" | version_sort | tail -1 \
-                | sed "s/^/${TAG_PREFIX}/")"
+    PREV_TAG="$(git \
+        -c versionsort.suffix=-alpha \
+        -c versionsort.suffix=-beta \
+        -c versionsort.suffix=-rc \
+        -c versionsort.suffix= \
+        tag --list --merged "$REV_SHA" --sort=version:refname \
+        "${TAG_PREFIX}[0-9]*" | tail -1)"
     [ -n "$PREV_TAG" ] || {
         echo "error: no release tags are reachable from ${REVISION}." >&2
         echo "       pass --previous <tag> to say which release this follows." >&2

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -155,9 +155,9 @@ bump_versions() {
     # if another table appears before [package].
     bump_cargo_version backend-lib/Cargo.toml "$VERSION"
 
-    # Let cargo rewrite the lock's package entry rather than editing it by
-    # hand, so the lock stays internally consistent.
-    cargo update --manifest-path backend-lib/Cargo.toml --workspace --offline >/dev/null
+    # Let cargo minimally update the lock while checking that the bumped
+    # manifest still resolves, without requesting dependency upgrades.
+    cargo check --manifest-path backend-lib/Cargo.toml --offline >/dev/null
 }
 
 if $DRY_RUN; then

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
 #
-# start-release.sh: open a release for review.
+# prepare-release.sh: prepare an SDK release and open it for review.
 #
 # Creates the two branches described in CONTRIBUTING.md and makes the version
 # bump commit:
 #
 #   release/vX.Y.Z   cut from the PREVIOUS release tag. It is the base of the
 #                    release PR and what eventually gets tagged.
-#   review/vX.Y.Z    cut from the revision being released. It carries the
+#   candidate/vX.Y.Z cut from the revision being released. It carries the
 #                    version bumps and the CHANGELOG promotion.
 #
-# The PR from review/vX.Y.Z into release/vX.Y.Z then shows exactly what this
+# The PR from candidate/vX.Y.Z into release/vX.Y.Z then shows exactly what this
 # release adds over the previous one, with none of the intervening history.
 #
 # Usage:
-#   ./scripts/start-release.sh [options] <remote> <version> [<revision>]
+#   ./scripts/prepare-release.sh --issue <N> [options] <remote> <version> [<revision>]
 #
 #   <remote>    git remote for zcash/zcash-android-wallet-sdk, e.g. upstream
 #   <version>   version being released, without the leading v, e.g. 2.7.1
@@ -22,68 +22,59 @@
 #               (default: current HEAD, which should be a maint/ branch)
 #
 # Options:
+#   --issue <N>       release tracking issue; the PR body gets `Closes #N`.
+#                     Required: every pull request must reference an issue.
 #   --previous <tag>  base the release branch on this tag rather than the
 #                     detected one. Use when the newest tag reachable from
 #                     <revision> is not the release you are following.
-#   --push-review     also push review/vX.Y.Z, so the PR can be opened at once.
 #   --dry-run         print what would happen and change nothing.
 #
-# It deliberately does not tag, publish, or open the PR: those are the steps
-# worth a human looking at the diff first.
+# It deliberately does not tag or publish. Those happen only after a human
+# reviews and merges the draft pull request this script opens.
 
 set -euo pipefail
 
 readonly TAG_PREFIX="v"
 
-usage() { sed -n '2,33p' "$0" | sed 's|^# \{0,1\}||'; exit "${1:-1}"; }
+cd "$(git rev-parse --show-toplevel)"
+# shellcheck source=lib/release-lib.sh
+. "scripts/lib/release-lib.sh"
 
 PREVIOUS=""
-PUSH_REVIEW=false
+ISSUE=""
 DRY_RUN=false
 while [ $# -gt 0 ]; do
     case "$1" in
+        --issue)        ISSUE="${2:?--issue needs an issue number}"; shift 2 ;;
         --previous)     PREVIOUS="${2:?--previous needs a tag}"; shift 2 ;;
-        --push-review)  PUSH_REVIEW=true; shift ;;
         --dry-run)      DRY_RUN=true; shift ;;
-        -h|--help)      usage 0 ;;
-        --*)            echo "error: unknown option '$1'" >&2; usage ;;
+        -h|--help)      sed -n '2,34p' "$0" | sed 's|^# \{0,1\}||'; exit 0 ;;
+        --*)            die "unknown option '$1'" ;;
         *)              break ;;
     esac
 done
 
-[ $# -ge 2 ] || usage
+[ $# -eq 2 ] || [ $# -eq 3 ] ||
+    die "expected <remote> <version> and optional <revision>."
+[ -n "$ISSUE" ] || die "--issue <N> is required." \
+    "Every pull request must reference an issue (see CONTRIBUTING.md)."
+printf '%s\n' "$ISSUE" | grep -Eq '^[0-9]+$' ||
+    die "--issue must be a numeric GitHub issue number."
 readonly REMOTE="$1"
 readonly VERSION="${2#v}"
 readonly REVISION="${3:-HEAD}"
-
-cd "$(git rev-parse --show-toplevel)"
-
-run() {
-    if $DRY_RUN; then echo "  would run: $*"; else "$@"; fi
-}
-
-step() { echo; echo "==> $*"; }
-
-# Semver ordering. GNU `sort -V` ranks 2.7.0-rc.1 *above* 2.7.0, which is
-# backwards: a pre-release precedes its release. Mapping '-' to '~' fixes it,
-# because sort -V treats '~' as lower than the empty string.
-version_sort() { sed 's/-/~/' | sort -V | sed 's/~/-/'; }
-
-version_le() {
-    [ "$(printf '%s\n%s\n' "$1" "$2" | version_sort | head -1)" = "$1" ]
-}
+valid_version "$VERSION" || die "invalid version '${VERSION}'." \
+    "Expected semantic version syntax such as 2.7.1 or 2.8.0-rc.1."
 
 # ---------------------------------------------------------------- preflight
 
 step "Checking preconditions"
 
-if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
-    echo "error: working tree has uncommitted changes." >&2
-    exit 1
-fi
-
-git remote get-url "$REMOTE" >/dev/null 2>&1 || {
-    echo "error: no such remote '$REMOTE'." >&2; exit 1; }
+require_clean_tree
+require_remote "$REMOTE"
+require_gh_auth
+readonly GH_REPO="$(repo_for_remote "$REMOTE")"
+echo "  repository: ${GH_REPO}"
 
 echo "  fetching $REMOTE ..."
 git fetch --tags "$REMOTE" >/dev/null 2>&1
@@ -126,16 +117,16 @@ if version_le "$VERSION" "$PREV_VERSION"; then
 fi
 
 readonly RELEASE_BRANCH="release/${TAG_PREFIX}${VERSION}"
-readonly REVIEW_BRANCH="review/${TAG_PREFIX}${VERSION}"
+readonly CANDIDATE_BRANCH="candidate/${TAG_PREFIX}${VERSION}"
 
-for b in "$RELEASE_BRANCH" "$REVIEW_BRANCH"; do
+for b in "$RELEASE_BRANCH" "$CANDIDATE_BRANCH"; do
     git rev-parse -q --verify "refs/heads/${b}" >/dev/null && {
         echo "error: branch ${b} already exists locally." >&2; exit 1; }
 done
 
 echo
 echo "  ${RELEASE_BRANCH}  <- ${PREV_TAG}        (PR base, pushed to ${REMOTE})"
-echo "  ${REVIEW_BRANCH}   <- ${REVISION}   (version bumps go here)"
+echo "  ${CANDIDATE_BRANCH}   <- ${REVISION}   (version bumps go here)"
 
 # --------------------------------------------------------------- branches
 
@@ -143,8 +134,8 @@ step "Creating ${RELEASE_BRANCH} from ${PREV_TAG}"
 run git branch "$RELEASE_BRANCH" "refs/tags/${PREV_TAG}"
 run git push "$REMOTE" "${RELEASE_BRANCH}:${RELEASE_BRANCH}"
 
-step "Creating ${REVIEW_BRANCH} from ${REVISION}"
-run git switch -c "$REVIEW_BRANCH" "$REV_SHA"
+step "Creating ${CANDIDATE_BRANCH} from ${REVISION}"
+run git switch -c "$CANDIDATE_BRANCH" "$REV_SHA"
 
 # ------------------------------------------------------------ version bump
 
@@ -154,11 +145,11 @@ bump_versions() {
     # gradle.properties carries the version the Gradle publishing conventions
     # read. IS_SNAPSHOT is deliberately left alone: release publishing passes
     # -PIS_SNAPSHOT=false rather than committing the change.
-    sed -i "s/^LIBRARY_VERSION=.*/LIBRARY_VERSION=${VERSION}/" gradle.properties
+    set_gradle_property gradle.properties LIBRARY_VERSION "$VERSION"
 
-    # Only the [package] version, which is the first `version =` in the file;
-    # the dependency versions below it must not be touched.
-    sed -i "0,/^version = \".*\"$/s//version = \"${VERSION}\"/" backend-lib/Cargo.toml
+    # Only the [package] version; dependency versions must not be touched even
+    # if another table appears before [package].
+    bump_cargo_version backend-lib/Cargo.toml "$VERSION"
 
     # Let cargo rewrite the lock's package entry rather than editing it by
     # hand, so the lock stays internally consistent.
@@ -169,11 +160,10 @@ if $DRY_RUN; then
     echo "  would set LIBRARY_VERSION, backend-lib/Cargo.toml and Cargo.lock to ${VERSION}"
 else
     bump_versions
-    for f in gradle.properties backend-lib/Cargo.toml; do
-        grep -q "${VERSION}" "$f" || { echo "error: ${f} not updated." >&2; exit 1; }
-    done
-    grep -A1 '^name = "zcash-android-wallet-sdk"' backend-lib/Cargo.lock \
-        | grep -q "version = \"${VERSION}\"" \
+    [ "$(gradle_property_value gradle.properties LIBRARY_VERSION)" = "$VERSION" ] &&
+        [ "$(cargo_package_version backend-lib/Cargo.toml)" = "$VERSION" ] ||
+        die "the Gradle or Cargo manifest version was not updated."
+    [ "$(cargo_lock_package_version backend-lib/Cargo.lock zcash-android-wallet-sdk)" = "$VERSION" ] \
         || { echo "error: Cargo.lock package entry not updated." >&2; exit 1; }
     echo "  gradle.properties, backend-lib/Cargo.toml, backend-lib/Cargo.lock"
 fi
@@ -186,7 +176,7 @@ step "Promoting the CHANGELOG"
 # only ever promotes what is already there -- it never generates text. An
 # empty Unreleased section means the entries were not written, which is much
 # more likely to be an oversight than a genuinely invisible release.
-if ! awk '/^## \[Unreleased\]/{f=1;next} f && /^## \[/{exit} f && NF{found=1} END{exit !found}' CHANGELOG.md; then
+if ! changelog_unreleased_nonempty CHANGELOG.md; then
     echo "error: the [Unreleased] section is empty." >&2
     echo "       Every user-visible change needs an entry before release; see" >&2
     echo "       the CHANGELOG discipline in AGENTS.md." >&2
@@ -196,12 +186,8 @@ fi
 if $DRY_RUN; then
     echo "  would insert '## [${VERSION}] - $(date +%Y-%m-%d)' below [Unreleased]"
 else
-    awk -v ver="$VERSION" -v date="$(date +%Y-%m-%d)" '
-        !done && /^## \[Unreleased\]/ { print; print ""; print "## [" ver "] - " date; done=1; next }
-        { print }
-    ' CHANGELOG.md > CHANGELOG.md.tmp && mv CHANGELOG.md.tmp CHANGELOG.md
-    grep -q "^## \[${VERSION}\] - " CHANGELOG.md \
-        || { echo "error: CHANGELOG not promoted." >&2; exit 1; }
+    promote_changelog CHANGELOG.md "$VERSION" "$(date +%Y-%m-%d)" ||
+        die "CHANGELOG.md has no [Unreleased] heading to promote."
     echo "  ## [${VERSION}] - $(date +%Y-%m-%d)"
 fi
 
@@ -211,27 +197,52 @@ step "Committing"
 run git add gradle.properties backend-lib/Cargo.toml backend-lib/Cargo.lock CHANGELOG.md
 run git commit -m "Prepare SDK release ${VERSION}"
 
-if $PUSH_REVIEW; then
-    step "Pushing ${REVIEW_BRANCH}"
-    run git push -u "$REMOTE" "$REVIEW_BRANCH"
+step "Pushing ${CANDIDATE_BRANCH}"
+run git push -u "$REMOTE" "$CANDIDATE_BRANCH"
+
+# --------------------------------------------------------------- draft PR
+
+step "Opening the draft pull request"
+if $DRY_RUN; then
+    echo "  would open a draft PR ${CANDIDATE_BRANCH} -> ${RELEASE_BRANCH} on ${GH_REPO}"
+    echo "  body would close issue #${ISSUE}"
+else
+    PR_BODY_FILE="$(mktemp)"
+    cat > "$PR_BODY_FILE" <<EOF
+Closes #${ISSUE}
+
+Release \`${VERSION}\`, following \`${PREV_TAG}\`.
+
+The base of this pull request is \`${RELEASE_BRANCH}\`, which starts out
+identical to \`${PREV_TAG}\`. Its diff is therefore exactly what users receive
+relative to the previous release.
+EOF
+    if ! gh pr create --repo "$GH_REPO" --draft \
+        --base "$RELEASE_BRANCH" --head "$CANDIDATE_BRANCH" \
+        --title "Release zcash-android-wallet-sdk ${VERSION}" \
+        --body-file "$PR_BODY_FILE"; then
+        die "gh pr create failed." \
+            "${RELEASE_BRANCH} and ${CANDIDATE_BRANCH} are already pushed." \
+            "The PR body remains at ${PR_BODY_FILE}; open the draft PR by hand."
+    fi
+    rm -f "$PR_BODY_FILE"
 fi
 
-# ------------------------------------------------------------- next steps
+if $DRY_RUN; then
+    cat <<EOF
 
-cat <<EOF
-
-Done. ${RELEASE_BRANCH} is on ${REMOTE}; ${REVIEW_BRANCH} is checked out here.
-
-Next:
+Dry run: nothing was changed. ${RELEASE_BRANCH} and ${CANDIDATE_BRANCH} were
+not created, nothing was pushed to ${REMOTE}, and no pull request was opened.
+The working tree is untouched.
 EOF
-$PUSH_REVIEW || echo "  git push -u ${REMOTE} ${REVIEW_BRANCH}"
-cat <<EOF
-  gh pr create --repo zcash/zcash-android-wallet-sdk \\
-      --base ${RELEASE_BRANCH} --head ${REVIEW_BRANCH} \\
-      --title "Release zcash-android-wallet-sdk ${VERSION}"
+else
+    cat <<EOF
 
-Review the PR diff: it is exactly what users get over ${PREV_TAG}. Then merge
-it, tag ${NEW_TAG} on ${RELEASE_BRANCH}, and afterwards merge the release
-branch back into its maint/ branch and forward along the chain, as described
-in CONTRIBUTING.md.
+Done. ${RELEASE_BRANCH} and ${CANDIDATE_BRANCH} are on ${REMOTE}, and the draft
+pull request is open. ${CANDIDATE_BRANCH} is checked out here.
+
+Review the PR diff, then merge it and tag ${NEW_TAG} on ${RELEASE_BRANCH}.
+Afterwards merge the release branch back into its maint/ branch and forward
+along the chain, as described in CONTRIBUTING.md.
 EOF
+fi

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -72,7 +72,7 @@ step "Checking preconditions"
 
 require_clean_tree
 require_remote "$REMOTE"
-require_gh_auth
+require_gh_auth_for_run
 readonly GH_REPO="$(repo_for_remote "$REMOTE")"
 echo "  repository: ${GH_REPO}"
 

--- a/scripts/tests/run-tests.sh
+++ b/scripts/tests/run-tests.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -u
+
+readonly TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+readonly REPO_ROOT="$(cd "${TESTS_DIR}/../.." && pwd)"
+
+# shellcheck source=../lib/release-lib.sh
+. "${REPO_ROOT}/scripts/lib/release-lib.sh"
+
+_assertions=0
+_failures=0
+_current=""
+
+_fail() {
+    _failures=$((_failures + 1))
+    printf 'not ok - %s: %s\n' "$_current" "$*" >&2
+}
+
+assert_eq() {
+    _assertions=$((_assertions + 1))
+    [ "$1" = "$2" ] || _fail "$3 (expected [$1], got [$2])"
+}
+
+assert_succeeds() {
+    _assertions=$((_assertions + 1))
+    local label="$1"
+    shift
+    "$@" >/dev/null 2>&1 || _fail "$label"
+}
+
+assert_fails() {
+    _assertions=$((_assertions + 1))
+    local label="$1"
+    shift
+    "$@" >/dev/null 2>&1 && _fail "$label"
+}
+
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+for file in "${TESTS_DIR}"/test-*.sh; do
+    # shellcheck source=/dev/null
+    . "$file"
+done
+
+for test_name in $(declare -F | awk '{print $3}' | grep '^test_' | sort); do
+    _current="$test_name"
+    "$test_name"
+done
+
+printf '%d assertions, %d failed\n' "$_assertions" "$_failures"
+[ "$_failures" -eq 0 ]

--- a/scripts/tests/test-cli.sh
+++ b/scripts/tests/test-cli.sh
@@ -1,0 +1,37 @@
+_prepare() { "$REPO_ROOT/scripts/prepare-release.sh" "$@"; }
+
+test_prepare_release_is_executable() {
+    assert_succeeds "prepare-release.sh is executable" \
+        test -x "$REPO_ROOT/scripts/prepare-release.sh"
+}
+
+test_help_succeeds() {
+    assert_succeeds "--help succeeds" _prepare --help
+}
+
+test_help_names_prepare_release() {
+    assert_succeeds "help names the current script" \
+        sh -c "'$REPO_ROOT/scripts/prepare-release.sh' --help | grep -q prepare-release.sh"
+}
+
+test_without_issue_fails_before_network() {
+    assert_fails "missing issue fails" _prepare upstream 2.7.1
+}
+
+test_non_numeric_issue_fails_before_network() {
+    assert_fails "non-numeric issue fails" _prepare --issue MOB-1 upstream 2.7.1
+}
+
+test_invalid_version_fails_before_network() {
+    assert_fails "invalid version fails" _prepare --issue 1 upstream release
+}
+
+test_extra_argument_fails_before_network() {
+    assert_fails "extra argument fails" \
+        _prepare --issue 1 upstream 2.7.1 HEAD extra
+}
+
+test_help_mentions_draft_pr() {
+    assert_succeeds "help mentions draft PR" \
+        sh -c "'$REPO_ROOT/scripts/prepare-release.sh' --help | grep -qi 'draft pull request'"
+}

--- a/scripts/tests/test-helpers.sh
+++ b/scripts/tests/test-helpers.sh
@@ -1,0 +1,48 @@
+test_valid_version_accepts_release() {
+    assert_succeeds "release version accepted" valid_version 2.7.1
+}
+
+test_valid_version_accepts_prerelease() {
+    assert_succeeds "prerelease accepted" valid_version 2.8.0-rc.1
+}
+
+test_valid_version_rejects_branch_syntax() {
+    assert_fails "slash rejected" valid_version 2.7.1/topic
+}
+
+test_version_sort_ranks_prerelease_first() {
+    local got
+    got="$(printf '2.7.0\n2.7.0-rc.1\n' | version_sort | tr '\n' ' ')"
+    assert_eq "2.7.0-rc.1 2.7.0 " "$got" "prerelease ordering"
+}
+
+test_repo_slug_from_ssh_url() {
+    assert_eq "zcash/zcash-android-wallet-sdk" \
+        "$(repo_slug_from_url git@github.com:zcash/zcash-android-wallet-sdk.git)" \
+        "SSH repository slug"
+}
+
+test_repo_slug_from_fork_url() {
+    assert_eq "nuttycom/zcash-android-wallet-sdk" \
+        "$(repo_slug_from_url https://github.com/nuttycom/zcash-android-wallet-sdk.git)" \
+        "fork repository slug"
+}
+
+test_set_gradle_property_updates_exact_key() {
+    local file="$SCRATCH/gradle.properties"
+    printf 'LIBRARY_VERSION=2.7.0\nOTHER_VERSION=1.0\n' > "$file"
+    set_gradle_property "$file" LIBRARY_VERSION 2.7.1
+    assert_eq "2.7.1" "$(gradle_property_value "$file" LIBRARY_VERSION)" \
+        "Gradle version updated"
+    assert_eq "1.0" "$(gradle_property_value "$file" OTHER_VERSION)" \
+        "other Gradle property preserved"
+}
+
+test_bump_cargo_version_scopes_to_package() {
+    local file="$SCRATCH/Cargo.toml"
+    printf '[dependencies.foo]\nversion = "1.0"\n[package]\nversion = "2.7.0"\n' > "$file"
+    bump_cargo_version "$file" 2.7.1
+    assert_eq "2.7.1" "$(cargo_package_version "$file")" \
+        "Cargo package version updated"
+    assert_succeeds "dependency version preserved" grep -q 'version = "1.0"' "$file"
+}

--- a/scripts/tests/test-helpers.sh
+++ b/scripts/tests/test-helpers.sh
@@ -78,3 +78,14 @@ test_bump_cargo_version_scopes_to_package() {
         "Cargo package version updated"
     assert_succeeds "dependency version preserved" grep -q 'version = "1.0"' "$file"
 }
+
+_require_gh_auth_fails() (
+    DRY_RUN="$1"
+    require_gh_auth() { return 1; }
+    require_gh_auth_for_run
+)
+
+test_dry_run_skips_gh_authentication() {
+    assert_succeeds "dry run skips GitHub authentication" _require_gh_auth_fails true
+    assert_fails "real run requires GitHub authentication" _require_gh_auth_fails false
+}

--- a/scripts/tests/test-helpers.sh
+++ b/scripts/tests/test-helpers.sh
@@ -6,14 +6,46 @@ test_valid_version_accepts_prerelease() {
     assert_succeeds "prerelease accepted" valid_version 2.8.0-rc.1
 }
 
+test_valid_version_accepts_alpha_and_beta() {
+    assert_succeeds "alpha accepted" valid_version 2.8.0-alpha.1
+    assert_succeeds "beta accepted" valid_version 2.8.0-beta.10
+}
+
+test_valid_version_rejects_unknown_prerelease() {
+    assert_fails "unknown prerelease rejected" valid_version 2.8.0-preview.1
+}
+
+test_valid_version_rejects_leading_zero() {
+    assert_fails "leading major zero rejected" valid_version 02.8.0
+}
+
+test_valid_version_rejects_legacy_prerelease() {
+    assert_fails "legacy alpha rejected" valid_version 2.8.0-alpha01
+    assert_fails "legacy beta rejected" valid_version 2.8.0-beta10
+}
+
 test_valid_version_rejects_branch_syntax() {
     assert_fails "slash rejected" valid_version 2.7.1/topic
 }
 
-test_version_sort_ranks_prerelease_first() {
-    local got
-    got="$(printf '2.7.0\n2.7.0-rc.1\n' | version_sort | tr '\n' ' ')"
-    assert_eq "2.7.0-rc.1 2.7.0 " "$got" "prerelease ordering"
+test_version_comparison_ranks_prerelease_first() {
+    assert_succeeds "prerelease precedes release" version_le 2.7.0-rc.1 2.7.0
+    assert_fails "release does not precede prerelease" version_le 2.7.0 2.7.0-rc.1
+}
+
+test_version_comparison_ranks_suffixes() {
+    assert_succeeds "alpha precedes beta" version_le 2.7.0-alpha.1 2.7.0-beta.1
+    assert_succeeds "beta precedes rc" version_le 2.7.0-beta.1 2.7.0-rc.1
+}
+
+test_version_comparison_ranks_suffix_numbers() {
+    assert_succeeds "rc numbers compare numerically" version_le 2.7.0-rc.2 2.7.0-rc.10
+    assert_fails "newer rc does not precede older" version_le 2.7.0-rc.10 2.7.0-rc.2
+}
+
+test_version_comparison_ranks_core_numerically() {
+    assert_succeeds "minor versions compare numerically" version_le 2.9.0 2.10.0
+    assert_fails "newer minor does not precede older" version_le 2.10.0 2.9.0
 }
 
 test_repo_slug_from_ssh_url() {


### PR DESCRIPTION
## Summary

- rename the release starter to `prepare-release.sh` and consistently use candidate branches
- validate and rewrite release versions through tested, macOS-compatible helpers
- push both branches and open an issue-linked draft release PR automatically
- update release documentation and add an offline shell test suite

## Validation

- `scripts/tests/run-tests.sh` (18 assertions)
- `./scripts/ci-local.sh fast`
- `RUST_ANDROID_GRADLE_PYTHON_COMMAND=/usr/bin/python3 ./scripts/ci-local.sh quick`