### PR TITLE
Expose v_transactions.pool_crossing_value as TransactionOverview.poolCrossingValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `TransactionOverview.poolCrossingValue`: the amount a wallet-internal transfer moved
+  between the account's own shielded pools (for example, a ZIP 318 Orchard -> Ironwood
+  migration transfer), read from the `pool_crossing_value` column that
+  `zcash_client_sqlite 0.22.0-rc.6` added to the `v_transactions` view; null for a
+  transaction that is not such a transfer. For a pool-crossing transfer, `netValue` is
+  just the fee, and `totalSpent`/`totalReceived` overstate the crossing whenever the
+  transaction also returns change to a pool it spent from, so wallets should display
+  `poolCrossingValue` as the migrated amount.
+
 ### Changed
 - Updated the librustzcash crates to `zcash_client_backend 0.24.0-rc.6` and
   `zcash_client_sqlite 0.22.0-rc.6`, adopting the revised ZIP 318 migration timing

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/fixture/TransactionOverviewFixture.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/fixture/TransactionOverviewFixture.kt
@@ -28,6 +28,7 @@ object TransactionOverviewFixture {
     const val BLOCK_TIME_EPOCH_SECONDS: Long = 1234
     val STATE = TransactionState.Confirmed
     const val IS_SHIELDING = false
+    val POOL_CROSSING_VALUE: Zatoshi? = null
 
     @Suppress("LongParameterList")
     fun new(
@@ -47,7 +48,8 @@ object TransactionOverviewFixture {
         memoCount: Int = MEMO_COUNT,
         blockTimeEpochSeconds: Long = BLOCK_TIME_EPOCH_SECONDS,
         transactionState: TransactionState = STATE,
-        isShielding: Boolean = IS_SHIELDING
+        isShielding: Boolean = IS_SHIELDING,
+        poolCrossingValue: Zatoshi? = POOL_CROSSING_VALUE
     ) = TransactionOverview(
         txId = txId,
         minedHeight = minedHeight,
@@ -66,5 +68,6 @@ object TransactionOverviewFixture {
         blockTimeEpochSeconds = blockTimeEpochSeconds,
         transactionState = transactionState,
         isShielding = isShielding,
+        poolCrossingValue = poolCrossingValue,
     )
 }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/AllTransactionView.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/AllTransactionView.kt
@@ -126,6 +126,10 @@ internal class AllTransactionView(
             val blockTimeIndex = cursor.getColumnIndex(AllTransactionViewDefinition.COLUMN_INTEGER_BLOCK_TIME)
             val isShielding = cursor.getColumnIndex(AllTransactionViewDefinition.COLUMN_BOOLEAN_IS_SHIELDING)
             val isExpiredUnmined = cursor.getColumnIndex(AllTransactionViewDefinition.COLUMN_EXPIRED_UNMINED)
+            val poolCrossingValueIndex =
+                cursor.getColumnIndex(
+                    AllTransactionViewDefinition.COLUMN_LONG_POOL_CROSSING_VALUE
+                )
 
             val netValueLong = cursor.getLong(netValueIndex)
             val isSent = netValueLong < 0
@@ -163,7 +167,8 @@ internal class AllTransactionView(
                         1 -> true
                         null -> null
                         else -> false
-                    }
+                    },
+                poolCrossingValue = cursor.getLongOrNull(poolCrossingValueIndex)?.let { Zatoshi(it) }
             )
         }
 
@@ -269,4 +274,6 @@ internal object AllTransactionViewDefinition {
     const val COLUMN_BLOB_ACCOUNT_UUID = "account_uuid" // $NON-NLS
 
     const val COLUMN_EXPIRED_UNMINED = "expired_unmined"
+
+    const val COLUMN_LONG_POOL_CROSSING_VALUE = "pool_crossing_value" // $NON-NLS
 }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/DbTransactionOverview.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/DbTransactionOverview.kt
@@ -23,7 +23,8 @@ internal data class DbTransactionOverview internal constructor(
     val memoCount: Int,
     val blockTimeEpochSeconds: Long?,
     val isShielding: Boolean,
-    val isExpiredUnmined: Boolean?
+    val isExpiredUnmined: Boolean?,
+    val poolCrossingValue: Zatoshi?
 ) {
     override fun toString() = "DbTransactionOverview"
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/TransactionOverview.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/TransactionOverview.kt
@@ -12,6 +12,11 @@ import cash.z.ecc.android.sdk.internal.repository.DerivedDataRepository
  *
  * Pending transactions are identified by a null [minedHeight].  Pending transactions are considered expired if the
  * last synced block exceeds the [expiryHeight].
+ *
+ * A wallet-internal pool-crossing transfer (for example, a ZIP 318 Orchard -> Ironwood migration transfer) is
+ * identified by a non-null [poolCrossingValue].  For such a transaction, display [poolCrossingValue] as the migrated
+ * amount: [netValue] is just the fee, and [totalSpent] and [totalReceived] overstate the crossing whenever the
+ * transaction also returns change to a pool it spent from.
  */
 data class TransactionOverview(
     val txId: TransactionId,
@@ -30,7 +35,19 @@ data class TransactionOverview(
     val memoCount: Int,
     val blockTimeEpochSeconds: Long?,
     val transactionState: TransactionState,
-    val isShielding: Boolean
+    val isShielding: Boolean,
+    /**
+     * The amount this transaction moved between the account's own shielded pools, or null when the transaction is
+     * not a wallet-internal pool-crossing transfer.
+     *
+     * Non-null exactly when every wallet-spent note and wallet-received output in the transaction is shielded, the
+     * account spent at least one note, at least one output was received in a pool the account spent nothing from,
+     * and no external outputs of the transaction are known; the value is then the total received in the pools the
+     * account did not spend from.  A payment that returns value to one of the wallet's own addresses is classified
+     * once the wallet has observed the returned output; while such a transaction is unmined it is treated as an
+     * ordinary payment.
+     */
+    val poolCrossingValue: Zatoshi? = null
 ) {
     override fun toString() = "TransactionOverview"
 
@@ -62,7 +79,8 @@ data class TransactionOverview(
                     ),
                 isShielding = dbTransactionOverview.isShielding,
                 totalSpent = dbTransactionOverview.totalSpent,
-                totalReceived = dbTransactionOverview.totalReceived
+                totalReceived = dbTransactionOverview.totalReceived,
+                poolCrossingValue = dbTransactionOverview.poolCrossingValue
             )
     }
 

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessorTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessorTest.kt
@@ -251,7 +251,8 @@ class CompactBlockProcessorTest {
                 memoCount = 0,
                 blockTimeEpochSeconds = null,
                 isShielding = false,
-                isExpiredUnmined = false
+                isExpiredUnmined = false,
+                poolCrossingValue = null
             )
 
         private fun encodedTransaction(txId: FirstClassByteArray) =


### PR DESCRIPTION
Closes #2103. Resolves MOB-1615.

`zcash_client_sqlite 0.22.0-rc.6` (adopted in #2090) added a `pool_crossing_value` column to `v_transactions`, classifying wallet-internal transfers that move an account's own funds between shielded pools (e.g. ZIP 318 Orchard → Ironwood migration transfers) and reporting the amount that crossed. Its changelog directs clients to present `pool_crossing_value` as the migrated amount, because for such a transaction `account_balance_delta` is just the negated fee and `total_spent`/`total_received` overstate the crossing whenever change returns to a spent-from pool. The SDK previously read none of this.

Changes:
- `AllTransactionView` reads the column (the query already selects `*`, so only the cursor parser and column definition change).
- `DbTransactionOverview` carries it internally.
- **New public API**: `TransactionOverview.poolCrossingValue: Zatoshi?`, non-null exactly when the transaction is a wallet-internal pool-crossing transfer, with the upstream classification predicate and display guidance in the KDoc. The parameter defaults to `null`, so existing constructor call sites remain source compatible.
- `TransactionOverviewFixture` and CHANGELOG updated.

Verified with `:sdk-lib:compileDebugKotlin` (passes; native cargo tasks excluded, as this change touches no Rust). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
