### PR TITLE
Surface ProposalError::AnchorNotFound as TransactionEncoderException.AnchorNotFoundException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `TransactionEncoderException.AnchorNotFoundException`, thrown by the proposal APIs
+  (`Synchronizer.proposeTransfer`, `proposeTransferFromUri` and
+  `proposeOrchardToIronwoodMigration`) when a proposal fails because no anchor is
+  computable at the height the proposal would anchor to (`zcash_client_backend`'s
+  `ProposalError::AnchorNotFound`). This failure previously surfaced as the generic
+  proposal exception, identifiable only by matching the formatted Rust error message.
+  Scanning creates a checkpoint at every height a proposal can anchor to, so syncing
+  further before retrying is expected to resolve it.
+
 ### Changed
 - Updated the librustzcash crates to `zcash_client_backend 0.24.0-rc.6` and
   `zcash_client_sqlite 0.22.0-rc.6`, adopting the revised ZIP 318 migration timing
@@ -163,7 +173,9 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a pool migration was in progress. A new database migration adds the missing
   column. The backfilled value is exact on the production network; on a test
   network, a pool migration planned under a custom anchor grid is reported as
-  `AnchorIntervalMismatch` and must be re-planned.
+  `AnchorIntervalMismatch` and must be re-planned. (That report originates in the
+  `zcash_pool_migration` engine's prove and rebuild steps, which this SDK does not
+  currently invoke, so it is not surfaced through this SDK's API.)
 - A ZIP 318 crossing anchored to a bucket boundary whose block contains no note
   commitments in any pool no longer fails with `ProposalError::AnchorNotFound`:
   scanning now creates a checkpoint at every anchor-retention grid height, and

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/ProposalAnchorNotFoundException.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/ProposalAnchorNotFoundException.kt
@@ -1,0 +1,15 @@
+package cash.z.ecc.android.sdk.internal.jni
+
+/**
+ * Thrown across the JNI boundary when a transaction proposal fails because no anchor is
+ * computable at the height the proposal would anchor to (`zcash_client_backend`'s
+ * `ProposalError::AnchorNotFound`).
+ *
+ * This is a distinct type so that `sdk-lib` can surface a typed error instead of matching
+ * message text. It is constructed from native code: the `(String, Long)` constructor
+ * signature is part of the JNI contract with `map_proposal_error` in `lib.rs`.
+ */
+class ProposalAnchorNotFoundException(
+    message: String,
+    val anchorHeight: Long
+) : RuntimeException(message)

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -13,7 +13,7 @@ use bytes::Bytes;
 use http_body_util::BodyExt;
 use jni::{
     JNIEnv,
-    objects::{JByteArray, JClass, JObject, JObjectArray, JString, JValue},
+    objects::{JByteArray, JClass, JObject, JObjectArray, JString, JThrowable, JValue},
     sys::{JNI_FALSE, JNI_TRUE, jboolean, jbyteArray, jint, jlong, jobject, jobjectArray, jstring},
 };
 use nonempty::NonEmpty;
@@ -47,6 +47,7 @@ use zcash_client_backend::{
         TransactionStatusFilter, TransparentKeyOrigin, WalletCommitmentTrees, WalletRead,
         WalletSummary, WalletWrite, Zip32Derivation,
         chain::{CommitmentTreeRoot, ScanSummary, scan_cached_blocks},
+        error::Error as DataApiError,
         scanning::{ScanPriority, ScanRange},
         wallet::{
             self, SignerView, create_pczt_from_proposal, create_proposed_transactions,
@@ -61,6 +62,7 @@ use zcash_client_backend::{
         DecodingError, Era, ReceiverRequirement, ReceiverRequirementError, UnifiedAddressRequest,
         UnifiedFullViewingKey, UnifiedSpendingKey,
     },
+    proposal::ProposalError,
     proto::{proposal::Proposal, service::TreeState},
     tor::{
         DormantMode,
@@ -2108,6 +2110,48 @@ fn zip317_helper<DbT>(
     )
 }
 
+/// The JVM class thrown when a proposal fails with [`ProposalError::AnchorNotFound`]. The
+/// `(String, long)` constructor signature is part of the JNI contract with the Kotlin class.
+const ANCHOR_NOT_FOUND_EXCEPTION_CLASS: &str =
+    "cash/z/ecc/android/sdk/internal/jni/ProposalAnchorNotFoundException";
+
+/// Converts a proposal failure into the `anyhow` error reported through the generic exception
+/// path, first raising a typed `ProposalAnchorNotFoundException` on the JVM when the failure is
+/// [`ProposalError::AnchorNotFound`], so that callers can react to it without matching message
+/// text. `unwrap_exc_or` leaves a pending exception in place, so the typed throw wins when it
+/// succeeds and the generic `RuntimeException` remains the fallback when it does not.
+fn map_proposal_error<DE, TE, SE, FE, CE, N>(
+    env: &mut JNIEnv,
+    context: &str,
+    e: DataApiError<DE, TE, SE, FE, CE, N>,
+) -> anyhow::Error
+where
+    DataApiError<DE, TE, SE, FE, CE, N>: std::fmt::Display,
+{
+    if let DataApiError::Proposal(ProposalError::AnchorNotFound(anchor_height)) = &e {
+        let description = format!(
+            "{}: no anchor is computable at height {}",
+            context, anchor_height
+        );
+        let thrown = (|| -> Result<(), jni::errors::Error> {
+            let message = env.new_string(&description)?;
+            let exception = env.new_object(
+                ANCHOR_NOT_FOUND_EXCEPTION_CLASS,
+                "(Ljava/lang/String;J)V",
+                &[
+                    JValue::Object(&message),
+                    JValue::Long(u32::from(*anchor_height) as jlong),
+                ],
+            )?;
+            env.throw(JThrowable::from(exception))
+        })();
+        if let Err(err) = thrown {
+            error!("Unable to throw ProposalAnchorNotFoundException: {}", err);
+        }
+    }
+    anyhow!("{}: {}", context, e)
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeTransferFromUri<
     'local,
@@ -2149,7 +2193,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeTr
             lock_inputs,
             proposed_version,
         )
-        .map_err(|e| anyhow!("Error creating transaction proposal: {}", e))?;
+        .map_err(|e| map_proposal_error(env, "Error creating transaction proposal", e))?;
 
         Ok(utils::rust_bytes_to_java(
             env,
@@ -2218,7 +2262,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeTr
             lock_inputs,
             proposed_version,
         )
-        .map_err(|e| anyhow!("Error creating transaction proposal: {}", e))?;
+        .map_err(|e| map_proposal_error(env, "Error creating transaction proposal", e))?;
 
         Ok(utils::rust_bytes_to_java(
             env,
@@ -2248,7 +2292,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeOr
         let account_uuid = account_id_from_jni(env, account_uuid)?;
 
         let proposal =
-            crate::migration::propose_orchard_to_ironwood(&mut db_data, &network, account_uuid)?;
+            crate::migration::propose_orchard_to_ironwood(env, &mut db_data, &network, account_uuid)?;
 
         Ok(utils::rust_bytes_to_java(
             env,

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -2291,8 +2291,12 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeOr
         let mut db_data = wallet_db(env, network, db_data)?;
         let account_uuid = account_id_from_jni(env, account_uuid)?;
 
-        let proposal =
-            crate::migration::propose_orchard_to_ironwood(env, &mut db_data, &network, account_uuid)?;
+        let proposal = crate::migration::propose_orchard_to_ironwood(
+            env,
+            &mut db_data,
+            &network,
+            account_uuid,
+        )?;
 
         Ok(utils::rust_bytes_to_java(
             env,

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -12,6 +12,7 @@
 //! themselves, because the fee depends on which inputs the selector picks.
 
 use anyhow::anyhow;
+use jni::JNIEnv;
 use rand::rngs::OsRng;
 use zcash_address::{ToAddress, ZcashAddress, unified, unified::Encoding as _};
 use zcash_client_backend::{
@@ -64,6 +65,7 @@ type MigrationProposal = Proposal<StandardFeeRule, <Db as InputSource>::NoteRef>
 /// off the chain. Splitting a crossing into less-identifying denominations is
 /// a separate mechanism; this deliberately does not attempt it.
 pub(crate) fn propose_orchard_to_ironwood(
+    env: &mut JNIEnv,
     db_data: &mut Db,
     network: &Network,
     account: AccountUuid,
@@ -148,5 +150,5 @@ pub(crate) fn propose_orchard_to_ironwood(
         &locked_input_policy,
         lock_inputs,
     )
-    .map_err(|e| anyhow!("Error creating the migration proposal: {}", e))
+    .map_err(|e| crate::map_proposal_error(env, "Error creating the migration proposal", e))
 }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/exception/Exceptions.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/exception/Exceptions.kt
@@ -558,6 +558,18 @@ sealed class TransactionEncoderException(
             rootCause
         )
 
+    /**
+     * The proposal could not be created because no anchor was computable at [anchorHeight], the
+     * height the proposal would anchor to. Scanning creates a checkpoint at every height a
+     * proposal can anchor to, so syncing further before retrying is expected to resolve this.
+     */
+    data class AnchorNotFoundException(
+        val anchorHeight: BlockHeight
+    ) : TransactionEncoderException(
+            "The proposal could not be created because no anchor was computable at height $anchorHeight. " +
+                "Syncing further before retrying is expected to resolve this."
+        )
+
     data class ProposalFromUriException(
         val rootCause: Throwable
     ) : TransactionEncoderException(

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/TransactionEncoderImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/TransactionEncoderImpl.kt
@@ -314,7 +314,11 @@ private inline fun Throwable.asProposalException(
     fallback: () -> TransactionEncoderException
 ): TransactionEncoderException =
     when (this) {
-        is ProposalAnchorNotFoundException ->
+        is ProposalAnchorNotFoundException -> {
             TransactionEncoderException.AnchorNotFoundException(BlockHeight.new(anchorHeight))
-        else -> fallback()
+        }
+
+        else -> {
+            fallback()
+        }
     }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/TransactionEncoderImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/TransactionEncoderImpl.kt
@@ -6,6 +6,7 @@ import cash.z.ecc.android.sdk.ext.masked
 import cash.z.ecc.android.sdk.internal.SaplingParamFetcher
 import cash.z.ecc.android.sdk.internal.Twig
 import cash.z.ecc.android.sdk.internal.TypesafeBackend
+import cash.z.ecc.android.sdk.internal.jni.ProposalAnchorNotFoundException
 import cash.z.ecc.android.sdk.internal.model.EncodedTransaction
 import cash.z.ecc.android.sdk.internal.repository.DerivedDataRepository
 import cash.z.ecc.android.sdk.model.Account
@@ -39,9 +40,13 @@ internal class TransactionEncoderImpl(
      *
      * @return the proposal or an exception
      *
+     * @throws TransactionEncoderException.AnchorNotFoundException
      * @throws TransactionEncoderException.ProposalFromUriException
      */
-    @Throws(TransactionEncoderException.ProposalFromUriException::class)
+    @Throws(
+        TransactionEncoderException.AnchorNotFoundException::class,
+        TransactionEncoderException.ProposalFromUriException::class
+    )
     override suspend fun proposeTransferFromUri(
         account: Account,
         uri: String
@@ -60,11 +65,14 @@ internal class TransactionEncoderImpl(
         }.onFailure {
             Twig.error(it) { "Caught exception while creating proposal from URI String." }
         }.getOrElse {
-            throw TransactionEncoderException.ProposalFromUriException(it)
+            throw it.asProposalException { TransactionEncoderException.ProposalFromUriException(it) }
         }
     }
 
-    @Throws(TransactionEncoderException.ProposalFromParametersException::class)
+    @Throws(
+        TransactionEncoderException.AnchorNotFoundException::class,
+        TransactionEncoderException.ProposalFromParametersException::class
+    )
     override suspend fun proposeOrchardToIronwoodMigration(account: Account): Proposal {
         Twig.debug { "creating proposal to migrate the Orchard balance into Ironwood" }
 
@@ -75,11 +83,14 @@ internal class TransactionEncoderImpl(
         }.onFailure {
             Twig.error(it) { "Caught exception while creating the migration proposal." }
         }.getOrElse {
-            throw TransactionEncoderException.ProposalFromParametersException(it)
+            throw it.asProposalException { TransactionEncoderException.ProposalFromParametersException(it) }
         }
     }
 
-    @Throws(TransactionEncoderException.ProposalFromParametersException::class)
+    @Throws(
+        TransactionEncoderException.AnchorNotFoundException::class,
+        TransactionEncoderException.ProposalFromParametersException::class
+    )
     override suspend fun proposeTransfer(
         account: Account,
         recipient: String,
@@ -103,7 +114,7 @@ internal class TransactionEncoderImpl(
         }.onFailure {
             Twig.error(it) { "Caught exception while creating proposal." }
         }.getOrElse {
-            throw TransactionEncoderException.ProposalFromParametersException(it)
+            throw it.asProposalException { TransactionEncoderException.ProposalFromParametersException(it) }
         }
     }
 
@@ -293,3 +304,17 @@ internal class TransactionEncoderImpl(
         return backend.getBranchIdForHeight(height)
     }
 }
+
+/**
+ * Maps a failure from a proposal call to the typed [TransactionEncoderException] to throw:
+ * [TransactionEncoderException.AnchorNotFoundException] when the native layer reported that no
+ * anchor was computable at the proposal's anchor height, and [fallback] otherwise.
+ */
+private inline fun Throwable.asProposalException(
+    fallback: () -> TransactionEncoderException
+): TransactionEncoderException =
+    when (this) {
+        is ProposalAnchorNotFoundException ->
+            TransactionEncoderException.AnchorNotFoundException(BlockHeight.new(anchorHeight))
+        else -> fallback()
+    }


### PR DESCRIPTION
Closes #2104.

A proposal failing with `zcash_client_backend`'s `ProposalError::AnchorNotFound` previously reached callers as a generic `RuntimeException` whose only signal was the formatted Rust message — no way to distinguish "sync further and retry" from any other proposal failure without string matching.

**Rust (`backend-lib`)**: a new `map_proposal_error` helper inspects the concrete proposal error at the JNI boundary. For `Error::Proposal(ProposalError::AnchorNotFound(height))` it constructs and throws a dedicated `ProposalAnchorNotFoundException(message, anchorHeight)` on the JVM, relying on `unwrap_exc_or`'s existing pending-exception check so the typed throw wins and the generic `RuntimeException` remains the fallback. Applied to `proposeTransfer`, `proposeTransferFromUri`, and the Orchard → Ironwood migration proposal (which now takes the `JNIEnv` for error mapping). `proposeShielding` is deliberately untouched: it spends only transparent inputs, where the anchor lookup does not apply.

**Kotlin (`sdk-lib`)**: `TransactionEncoderImpl` translates the internal exception into the new public `TransactionEncoderException.AnchorNotFoundException(anchorHeight: BlockHeight)`, whose KDoc documents the recovery path (scanning creates a checkpoint at every height a proposal can anchor to, so syncing further before retrying is expected to resolve it). `@Throws` contracts updated on the three encoder methods.

**Scope note on `AnchorIntervalMismatch`** (the other error named in #2104): it originates in the `zcash_pool_migration` engine's prove/rebuild steps (`ProveError`/`RebuildError`), and `backend-lib` does not currently invoke that engine anywhere — the SDK's migration entry point is a pinned `propose_send_max_transfer` call. There is nothing for a typed surface to attach to until the engine is wired in, so this PR clarifies the inherited CHANGELOG bullet accordingly instead of adding dead error plumbing. Details on the issue.

Verification: `cargo check` on `backend-lib` passes cleanly; `:sdk-lib:compileDebugKotlin` and `:backend-lib:compileDebugKotlin` pass (native cargo linking excluded — no NDK toolchain in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
