### PR TITLE
Surface the v_transactions ZIP 318 classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `TransactionOverview.zip318Kind`, a new `Zip318Kind` reporting how a transaction
+  classifies against ZIP 318, the Orchard to Ironwood pool migration. It is a
+  trailing constructor parameter, so positional construction of `TransactionOverview`
+  will not compile until it is supplied; named construction needs no edit.
+  `Zip318Kind.NOT_CLASSIFIED` means the wallet has not looked at the transaction,
+  not that the transaction is not a migration, and warrants no label in a UI; a
+  transaction the wallet has examined and rejected is `NONCONFORMING` instead. Only
+  `PREPARATION` and `TRANSFER` are the wallet's own migration. `CROSSING_PAYMENT`
+  has the same shape on chain, deliberately, so that ordinary payments join the
+  migration anonymity set, but it pays a third party and must not be presented as a
+  migration. The value is a conformance class, never evidence that a transaction
+  came from this wallet's migration run.
+
 ### Changed
 - Updated the librustzcash crates to `zcash_client_backend 0.24.0-rc.6` and
   `zcash_client_sqlite 0.22.0-rc.6`, adopting the revised ZIP 318 migration timing

--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -1456,8 +1456,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8755958580c6a3d5913ac60fd91ca0174cb1ebe0#8755958580c6a3d5913ac60fd91ca0174cb1ebe0"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1493,8 +1492,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8755958580c6a3d5913ac60fd91ca0174cb1ebe0#8755958580c6a3d5913ac60fd91ca0174cb1ebe0"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2981,8 +2979,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "pczt"
 version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d4693dcb3d72f30064e0fdab122292d803bd9325a95b25df08679cf895452f"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8755958580c6a3d5913ac60fd91ca0174cb1ebe0#8755958580c6a3d5913ac60fd91ca0174cb1ebe0"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -6781,8 +6778,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8755958580c6a3d5913ac60fd91ca0174cb1ebe0#8755958580c6a3d5913ac60fd91ca0174cb1ebe0"
 dependencies = [
  "bech32",
  "bs58",
@@ -6795,8 +6791,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832ace878c125814bb9e82228d3661499124c6f2936e60fc1df3c6876eb54624"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8755958580c6a3d5913ac60fd91ca0174cb1ebe0#8755958580c6a3d5913ac60fd91ca0174cb1ebe0"
 dependencies = [
  "arti-client",
  "base64",
@@ -6863,8 +6858,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a789c0038359968f93bfe3952d2b942e3bae5582f79c2f31137c6fd736a225"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8755958580c6a3d5913ac60fd91ca0174cb1ebe0#8755958580c6a3d5913ac60fd91ca0174cb1ebe0"
 dependencies = [
  "bip32",
  "bitflags",
@@ -6922,8 +6916,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def800f128e459eedebc900f36f408eaf0687634128dcf64ecfeaeebc3e16c14"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8755958580c6a3d5913ac60fd91ca0174cb1ebe0#8755958580c6a3d5913ac60fd91ca0174cb1ebe0"
 dependencies = [
  "bech32",
  "bip32",
@@ -6965,8 +6958,7 @@ dependencies = [
 [[package]]
 name = "zcash_pool_migration"
 version = "0.1.0-rc.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9010904169a92805128b3a8eab0dd4ff79fd164dd416af68aaeac5c7ebbd2522"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8755958580c6a3d5913ac60fd91ca0174cb1ebe0#8755958580c6a3d5913ac60fd91ca0174cb1ebe0"
 dependencies = [
  "corez",
  "getset",
@@ -6986,8 +6978,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ca4de11896f704ffe6319c2cd7bc8fc6ab31a55cec80d26def15c009d83678"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8755958580c6a3d5913ac60fd91ca0174cb1ebe0#8755958580c6a3d5913ac60fd91ca0174cb1ebe0"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7017,8 +7008,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea125021aaa749e966989c7f7aaa18afe2f89474573f5f0dfac8b98083a6d095"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8755958580c6a3d5913ac60fd91ca0174cb1ebe0#8755958580c6a3d5913ac60fd91ca0174cb1ebe0"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7039,8 +7029,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f074493fff337207e28bcfa5bbdf0e2a125c4203a4bdd07e72067eea81e9e7b"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8755958580c6a3d5913ac60fd91ca0174cb1ebe0#8755958580c6a3d5913ac60fd91ca0174cb1ebe0"
 dependencies = [
  "corez",
  "document-features",
@@ -7078,8 +7067,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "547c012778bae17f58007731af074d638aa146ab0ecfc120adebf23d049aff6c"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8755958580c6a3d5913ac60fd91ca0174cb1ebe0#8755958580c6a3d5913ac60fd91ca0174cb1ebe0"
 dependencies = [
  "bip32",
  "bs58",
@@ -7172,8 +7160,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb464491970d9b61889e4f2b7b00fb9f471a33692e5c0de3122fdc575d8067ab"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8755958580c6a3d5913ac60fd91ca0174cb1ebe0#8755958580c6a3d5913ac60fd91ca0174cb1ebe0"
 dependencies = [
  "base64",
  "nom",

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -77,16 +77,19 @@ xz2 = { version = "0.1", features = ["static"] }
 component = "0.1.1"
 rust-analyzer = "0.0.1"
 
-## Uncomment this to test someone else's librustzcash changes in a branch
-#[patch.crates-io]
-#pczt = { git = "https://github.com/zcash/librustzcash.git", branch = "main" }
-#transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash", branch = "main" }
-#zcash_address = { git = "https://github.com/zcash/librustzcash", branch = "main" }
-#zcash_client_backend = { git = "https://github.com/zcash/librustzcash", branch = "main" }
-#zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", branch = "main" }
-#zcash_primitives = { git = "https://github.com/zcash/librustzcash", branch = "main" }
-#zcash_proofs = { git = "https://github.com/zcash/librustzcash", branch = "main" }
-#zcash_protocol = { git = "https://github.com/zcash/librustzcash", branch = "main" }
+## Pinned to the librustzcash branch of zcash/librustzcash#2874, which adds the
+## `zip318_kind` column this SDK reads. Revert to the crates.io versions once that
+## has merged and been released.
+[patch.crates-io]
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "8755958580c6a3d5913ac60fd91ca0174cb1ebe0" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "8755958580c6a3d5913ac60fd91ca0174cb1ebe0" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "8755958580c6a3d5913ac60fd91ca0174cb1ebe0" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "8755958580c6a3d5913ac60fd91ca0174cb1ebe0" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "8755958580c6a3d5913ac60fd91ca0174cb1ebe0" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "8755958580c6a3d5913ac60fd91ca0174cb1ebe0" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "8755958580c6a3d5913ac60fd91ca0174cb1ebe0" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "8755958580c6a3d5913ac60fd91ca0174cb1ebe0" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "8755958580c6a3d5913ac60fd91ca0174cb1ebe0" }
 
 [lib]
 name = "zcashwalletsdk"

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/fixture/TransactionOverviewFixture.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/fixture/TransactionOverviewFixture.kt
@@ -6,6 +6,7 @@ import cash.z.ecc.android.sdk.model.TransactionId
 import cash.z.ecc.android.sdk.model.TransactionOverview
 import cash.z.ecc.android.sdk.model.TransactionState
 import cash.z.ecc.android.sdk.model.Zatoshi
+import cash.z.ecc.android.sdk.model.Zip318Kind
 
 @Suppress("MagicNumber")
 object TransactionOverviewFixture {
@@ -31,6 +32,7 @@ object TransactionOverviewFixture {
     const val SPENT_NOTE_COUNT: Int = 0
     val POOL_CROSSING_VALUE: Zatoshi? = null
     const val IS_TRUSTED: Boolean = false
+    val ZIP318_KIND = Zip318Kind.NOT_CLASSIFIED
 
     @Suppress("LongParameterList")
     fun new(
@@ -53,7 +55,8 @@ object TransactionOverviewFixture {
         isShielding: Boolean = IS_SHIELDING,
         spentNoteCount: Int = SPENT_NOTE_COUNT,
         poolCrossingValue: Zatoshi? = POOL_CROSSING_VALUE,
-        isTrusted: Boolean = IS_TRUSTED
+        isTrusted: Boolean = IS_TRUSTED,
+        zip318Kind: Zip318Kind = ZIP318_KIND
     ) = TransactionOverview(
         txId = txId,
         minedHeight = minedHeight,
@@ -75,5 +78,6 @@ object TransactionOverviewFixture {
         spentNoteCount = spentNoteCount,
         poolCrossingValue = poolCrossingValue,
         isTrusted = isTrusted,
+        zip318Kind = zip318Kind,
     )
 }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/AllTransactionView.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/db/derived/AllTransactionView.kt
@@ -11,6 +11,7 @@ import cash.z.ecc.android.sdk.model.AccountUuid
 import cash.z.ecc.android.sdk.model.BlockHeight
 import cash.z.ecc.android.sdk.model.FirstClassByteArray
 import cash.z.ecc.android.sdk.model.Zatoshi
+import cash.z.ecc.android.sdk.model.Zip318Kind
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import java.util.Locale
@@ -131,6 +132,7 @@ internal class AllTransactionView(
             val poolCrossingValueIndex =
                 cursor.getColumnIndex(AllTransactionViewDefinition.COLUMN_LONG_POOL_CROSSING_VALUE)
             val trustStatusIndex = cursor.getColumnIndex(AllTransactionViewDefinition.COLUMN_BOOLEAN_TRUST_STATUS)
+            val zip318KindIndex = cursor.getColumnIndex(AllTransactionViewDefinition.COLUMN_INTEGER_ZIP318_KIND)
 
             val netValueLong = cursor.getLong(netValueIndex)
             val isSent = netValueLong < 0
@@ -171,7 +173,15 @@ internal class AllTransactionView(
                     },
                 spentNoteCount = cursor.getInt(spentNoteCountIndex),
                 poolCrossingValue = cursor.getLongOrNull(poolCrossingValueIndex)?.let { Zatoshi(it) },
-                isTrusted = cursor.getIntOrNull(trustStatusIndex) == 1
+                isTrusted = cursor.getIntOrNull(trustStatusIndex) == 1,
+                // The column is absent on databases created before librustzcash added it, which
+                // tells us as little about the transaction as an unrecognized code does.
+                zip318Kind =
+                    if (zip318KindIndex < 0) {
+                        Zip318Kind.NOT_CLASSIFIED
+                    } else {
+                        Zip318Kind.new(cursor.getIntOrNull(zip318KindIndex))
+                    }
             )
         }
 
@@ -283,4 +293,6 @@ internal object AllTransactionViewDefinition {
     const val COLUMN_LONG_POOL_CROSSING_VALUE = "pool_crossing_value" // $NON-NLS
 
     const val COLUMN_BOOLEAN_TRUST_STATUS = "trust_status" // $NON-NLS
+
+    const val COLUMN_INTEGER_ZIP318_KIND = "zip318_kind" // $NON-NLS
 }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/DbTransactionOverview.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/DbTransactionOverview.kt
@@ -4,6 +4,7 @@ import cash.z.ecc.android.sdk.internal.ext.toHexReversed
 import cash.z.ecc.android.sdk.model.BlockHeight
 import cash.z.ecc.android.sdk.model.FirstClassByteArray
 import cash.z.ecc.android.sdk.model.Zatoshi
+import cash.z.ecc.android.sdk.model.Zip318Kind
 
 @ConsistentCopyVisibility
 internal data class DbTransactionOverview internal constructor(
@@ -26,7 +27,8 @@ internal data class DbTransactionOverview internal constructor(
     val isExpiredUnmined: Boolean?,
     val spentNoteCount: Int,
     val poolCrossingValue: Zatoshi?,
-    val isTrusted: Boolean
+    val isTrusted: Boolean,
+    val zip318Kind: Zip318Kind
 ) {
     override fun toString() = "DbTransactionOverview"
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/TransactionOverview.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/TransactionOverview.kt
@@ -47,7 +47,14 @@ data class TransactionOverview(
      * spendable after the trusted confirmation count rather than the untrusted
      * one.
      */
-    val isTrusted: Boolean
+    val isTrusted: Boolean,
+    /**
+     * How this transaction classifies against ZIP 318, the Orchard to Ironwood pool migration.
+     *
+     * [Zip318Kind.NOT_CLASSIFIED] means the wallet has not looked, not that the transaction is
+     * not a migration, so it warrants no label at all.
+     */
+    val zip318Kind: Zip318Kind
 ) {
     override fun toString() = "TransactionOverview"
 
@@ -82,7 +89,8 @@ data class TransactionOverview(
                 totalReceived = dbTransactionOverview.totalReceived,
                 spentNoteCount = dbTransactionOverview.spentNoteCount,
                 poolCrossingValue = dbTransactionOverview.poolCrossingValue,
-                isTrusted = dbTransactionOverview.isTrusted
+                isTrusted = dbTransactionOverview.isTrusted,
+                zip318Kind = dbTransactionOverview.zip318Kind
             )
     }
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/Zip318Kind.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/Zip318Kind.kt
@@ -1,0 +1,49 @@
+package cash.z.ecc.android.sdk.model
+
+/**
+ * How a transaction classifies against ZIP 318, the Orchard to Ironwood pool migration.
+ *
+ * This is a conformance class, not a provenance: it describes the shape a transaction has on
+ * chain, and can never establish that a transaction came from this wallet's own migration run.
+ * Only [PREPARATION] and [TRANSFER] are the wallet's own migration; [CROSSING_PAYMENT] has the
+ * same shape by design but pays a third party.
+ */
+@Suppress("MagicNumber")
+enum class Zip318Kind(
+    val code: Int
+) {
+    /**
+     * The transaction has not been classified, either because it predates the classification or
+     * because the wallet has not decrypted it yet. It says nothing about whether the transaction
+     * is a ZIP 318 transaction; deciding that requires rescanning it. Present it with no label
+     * rather than as [NONCONFORMING].
+     */
+    NOT_CLASSIFIED(0),
+
+    /** Classified, and not a ZIP 318 transaction. */
+    NONCONFORMING(1),
+
+    /** A note-preparation self-send that a migration run makes before it crosses. */
+    PREPARATION(2),
+
+    /** A pool crossing paying the account's own internal address, so a migration transfer. */
+    TRANSFER(3),
+
+    /**
+     * A canonical crossing that pays an external third party. The ordinary send path builds such
+     * payments deliberately, so that they join the migration anonymity set; it is a payment and
+     * must not be presented as a migration.
+     */
+    CROSSING_PAYMENT(4);
+
+    companion object {
+        /**
+         * Decodes the `zip318_kind` column value.
+         *
+         * An unrecognized code decodes to [NOT_CLASSIFIED]: a newer librustzcash may classify a
+         * transaction in a way this SDK does not know, and having learned nothing about it is the
+         * honest reading, rather than claiming it is [NONCONFORMING].
+         */
+        internal fun new(code: Int?): Zip318Kind = entries.firstOrNull { it.code == code } ?: NOT_CLASSIFIED
+    }
+}


### PR DESCRIPTION
Stacked on #dw/views-columns-up-to-date, which surfaces the other
`v_transactions` columns the SDK was dropping. Review that one first.

## What this adds

Upstream librustzcash adds a `zip318_kind` column to `v_transactions`
(zcash/librustzcash#2874). It records how a transaction classifies against
ZIP 318, the Orchard to Ironwood pool migration, so a wallet can label a
migration transaction in its history without a migration plan, which does not
survive a seed restore.

`Zip318Kind` carries the five values, and `TransactionOverview.zip318Kind`
exposes it.

| code | case | meaning |
| --- | --- | --- |
| 0 | `NOT_CLASSIFIED` | the column default; nothing has looked at this transaction yet |
| 1 | `NONCONFORMING` | classified, and it is not a ZIP 318 transaction |
| 2 | `PREPARATION` | a note-preparation self-send a migration run makes before crossing |
| 3 | `TRANSFER` | a pool crossing paying the account's own internal address |
| 4 | `CROSSING_PAYMENT` | the same shape, paying an external third party |

## Three things a consumer must get right

**`NOT_CLASSIFIED` is not a decision.** It means "we never looked", not "this
is not a migration". Render it as no label at all. Presenting it as "not a
migration" would claim the wallet examined a transaction it never looked at.
That is why 0 and 1 are distinct codes rather than one falsy value.

**Only `PREPARATION` and `TRANSFER` are the wallet's own migration.**
`CROSSING_PAYMENT` has the identical on-chain shape by design, because the
ordinary send path builds such payments deliberately so that they join the
migration anonymity set. It is a payment to a third party and must not be
shown as a migration.

**This names a conformance class, never a provenance.** ZIP 318's privacy
argument is that every migration transaction looks like every other one, so
recognizing the shape places a transaction in the anonymity set and can never
establish which wallet's run produced it.

## Decoding

`Zip318Kind.new(code: Int?)` is total: null, an unrecognized code, or an absent
column all yield `NOT_CLASSIFIED`, never a throw and never `NONCONFORMING`. A
future librustzcash may add codes, and an SDK that meets one has learned
nothing about the transaction, so saying so is the honest answer. Defaulting to
a decision would assert something the SDK never established.

The absent-column case matters today: the pinned `zcash_client_sqlite
0.22.0-rc.6` does not have this column yet, the view is read with `SELECT *`,
and an unguarded `cursor.getInt(-1)` would throw
`CursorIndexOutOfBoundsException` on every transaction-history read. The parse
checks the column index for that reason.

## Dependency, and a commit that must be reverted

The last commit pins the librustzcash crates to the revision of
zcash/librustzcash#2874, so the column actually exists and this code is
exercised rather than silently reporting `NOT_CLASSIFIED` for everything.

**That pin must be reverted before this merges.** It must not outlive the
upstream release carrying the column. It is pinned to a specific revision
rather than a branch so the build stays reproducible while the upstream branch
moves.

## Testing

`./scripts/ci-local.sh quick` (detekt, ktlint, unit tests) passes. The Rust
stage was not run; this change touches no Rust and does not cross the JNI
boundary. Note the unit tests do not exercise a real `v_transactions` row, so
they give no signal on the decode path against a live database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

