### PR TITLE
Surface ProposalError::AnchorNotFound as TransactionEncoderException.AnchorNotFoundException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `TransactionEncoderException.AnchorNotFoundException`, thrown by the proposal APIs
+  (`Synchronizer.proposeTransfer`, `proposeTransferFromUri` and
+  `proposeOrchardToIronwoodMigration`) when a proposal fails because no anchor is
+  computable at the height the proposal would anchor to (`zcash_client_backend`'s
+  `ProposalError::AnchorNotFound`). This failure previously surfaced as the generic
+  proposal exception, identifiable only by matching the formatted Rust error message.
+  Scanning creates a checkpoint at every height a proposal can anchor to, so syncing
+  further before retrying is expected to resolve it.
+
 ### Changed
 - Updated the librustzcash crates to `zcash_client_backend 0.24.0-rc.6` and
   `zcash_client_sqlite 0.22.0-rc.6`, adopting the revised ZIP 318 migration timing
@@ -29,7 +39,9 @@ All of the following were picked up from the librustzcash update:
   a pool migration was in progress. A new database migration adds the missing
   column. The backfilled value is exact on the production network; on a test
   network, a pool migration planned under a custom anchor grid is reported as
-  `AnchorIntervalMismatch` and must be re-planned.
+  `AnchorIntervalMismatch` and must be re-planned. (That report originates in the
+  `zcash_pool_migration` engine's prove and rebuild steps, which this SDK does not
+  currently invoke, so it is not surfaced through this SDK's API.)
 - A ZIP 318 crossing anchored to a bucket boundary whose block contains no note
   commitments in any pool no longer fails with `ProposalError::AnchorNotFound`:
   scanning now creates a checkpoint at every anchor-retention grid height, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `TransactionEncoderException.AnchorNotFoundException`, thrown by
+  `Synchronizer.createProposedTransactions` and `Broadcaster.createProposedTransactions`
+  when transactions cannot be created from a proposal because no anchor is computable at
+  the height the proposal anchors to
+  (`zcash_client_backend`'s `ProposalError::AnchorNotFound`). When
+  `Synchronizer.createPcztFromProposal` fails for the same reason, the
+  `CreatePcztFromProposalException` it throws now carries this exception as its `cause`.
+  The failure previously surfaced only as the generic
+  `TransactionEncoderException.TransactionNotCreatedException` (or the generic PCZT
+  exception), identifiable only by matching the formatted Rust error message. The new
+  exception is a sibling of `TransactionNotCreatedException`, not a subtype: code that
+  catches `TransactionNotCreatedException` around `createProposedTransactions` and
+  needs to handle this case must add a catch for the new exception. Scanning
+  creates a checkpoint at every height a proposal can anchor to, so the expected
+  recovery is to sync further and then create a new proposal; the failed proposal
+  anchors to the same height, so retrying it unchanged is not expected to succeed on
+  its own.
+
 ## [2.7.0] - 2026-08-20
 
 ### Added

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/ProposalAnchorNotFoundException.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/ProposalAnchorNotFoundException.kt
@@ -1,0 +1,15 @@
+package cash.z.ecc.android.sdk.internal.jni
+
+/**
+ * Thrown across the JNI boundary when a transaction proposal fails because no anchor is
+ * computable at the height the proposal would anchor to (`zcash_client_backend`'s
+ * `ProposalError::AnchorNotFound`).
+ *
+ * This is a distinct type so that `sdk-lib` can surface a typed error instead of matching
+ * message text. It is constructed from native code: the `(String, Long)` constructor
+ * signature is part of the JNI contract with `map_proposal_error` in `lib.rs`.
+ */
+class ProposalAnchorNotFoundException(
+    message: String,
+    val anchorHeight: Long
+) : RuntimeException(message)

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/ProposalAnchorNotFoundException.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/ProposalAnchorNotFoundException.kt
@@ -1,0 +1,19 @@
+package cash.z.ecc.android.sdk.internal.jni
+
+import androidx.annotation.Keep
+
+/**
+ * Thrown across the JNI boundary when creating transactions from a proposal fails because no
+ * anchor is computable at the height the proposal anchors to (`zcash_client_backend`'s
+ * `ProposalError::AnchorNotFound`).
+ *
+ * This is a distinct type so that `sdk-lib` can surface a typed error instead of matching
+ * message text. It is constructed from native code, which is why it must be kept: the class
+ * name and the `(String, Long)` constructor signature are part of the JNI contract with
+ * `map_proposal_error` in `lib.rs`, and are never referenced from bytecode.
+ */
+@Keep
+class ProposalAnchorNotFoundException(
+    message: String,
+    val anchorHeight: Long
+) : RuntimeException(message)

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -47,6 +47,7 @@ use zcash_client_backend::{
         TransactionStatusFilter, TransparentKeyOrigin, WalletCommitmentTrees, WalletRead,
         WalletSummary, WalletWrite, Zip32Derivation,
         chain::{CommitmentTreeRoot, ScanSummary, scan_cached_blocks},
+        error::Error as DataApiError,
         scanning::{ScanPriority, ScanRange},
         wallet::{
             self, SignerView, create_pczt_from_proposal, create_proposed_transactions,
@@ -61,6 +62,7 @@ use zcash_client_backend::{
         DecodingError, Era, ReceiverRequirement, ReceiverRequirementError, UnifiedAddressRequest,
         UnifiedFullViewingKey, UnifiedSpendingKey,
     },
+    proposal::ProposalError,
     proto::{proposal::Proposal, service::TreeState},
     tor::{
         DormantMode,
@@ -2107,6 +2109,47 @@ fn zip317_helper<DbT>(
     )
 }
 
+/// The JVM class thrown when creating transactions from a proposal fails with
+/// [`ProposalError::AnchorNotFound`]. The `(String, long)` constructor signature is part of
+/// the JNI contract with the Kotlin class.
+const ANCHOR_NOT_FOUND_EXCEPTION_CLASS: &str =
+    "cash/z/ecc/android/sdk/internal/jni/ProposalAnchorNotFoundException";
+
+/// Converts a failure from building transactions (or a PCZT) out of a proposal into the
+/// `anyhow` error reported through the generic exception path, first raising a typed
+/// `ProposalAnchorNotFoundException` on the JVM when the failure is
+/// [`ProposalError::AnchorNotFound`], so that callers can react to it without matching
+/// message text. `utils::exception::throw_object` owns the pending-exception contract: the
+/// typed throw wins when it succeeds and the generic `RuntimeException` remains the fallback
+/// when it does not.
+fn map_proposal_error<DE, TE, SE, FE, CE, N>(
+    env: &mut JNIEnv,
+    context: &str,
+    e: DataApiError<DE, TE, SE, FE, CE, N>,
+) -> anyhow::Error
+where
+    DataApiError<DE, TE, SE, FE, CE, N>: std::fmt::Display,
+{
+    if let DataApiError::Proposal(ProposalError::AnchorNotFound(anchor_height)) = &e {
+        let description = format!(
+            "{}: no anchor is computable at height {}",
+            context, anchor_height
+        );
+        utils::exception::throw_object(env, ANCHOR_NOT_FOUND_EXCEPTION_CLASS, |env| {
+            let message = env.new_string(&description)?;
+            env.new_object(
+                ANCHOR_NOT_FOUND_EXCEPTION_CLASS,
+                "(Ljava/lang/String;J)V",
+                &[
+                    JValue::Object(&message),
+                    JValue::Long(u32::from(*anchor_height) as jlong),
+                ],
+            )
+        });
+    }
+    anyhow!("{}: {}", context, e)
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeTransferFromUri<
     'local,
@@ -2119,7 +2162,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeTr
     network_id: jint,
 ) -> jbyteArray {
     let res = catch_unwind(&mut env, |env| {
-        let _span = tracing::info_span!("RustBackend.proposeTransfer").entered();
+        let _span = tracing::info_span!("RustBackend.proposeTransferFromUri").entered();
         let network = parse_network(network_id as u32)?;
         let mut db_data = wallet_db(env, network, db_data)?;
         let account_uuid = account_id_from_jni(env, account_uuid)?;
@@ -2439,7 +2482,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_createPro
             &proposal,
             expiry_height,
         )
-        .map_err(|e| anyhow!("Error while creating transactions: {}", e))?;
+        .map_err(|e| map_proposal_error(env, "Error while creating transactions", e))?;
 
         Ok(
             utils::rust_vec_to_java(env, txids.into(), "[B", |env, txid| {
@@ -2494,7 +2537,9 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_createPcz
                 expiry_height,
                 orchard_pool_padding,
             )
-            .map_err(|e| anyhow!("Error creating PCZT from single-step proposal: {}", e))?;
+            .map_err(|e| {
+                map_proposal_error(env, "Error creating PCZT from single-step proposal", e)
+            })?;
 
             Ok(utils::rust_bytes_to_java(
                 env,

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -2290,8 +2290,12 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeOr
         let mut db_data = wallet_db(env, network, db_data)?;
         let account_uuid = account_id_from_jni(env, account_uuid)?;
 
-        let proposal =
-            crate::migration::propose_orchard_to_ironwood(env, &mut db_data, &network, account_uuid)?;
+        let proposal = crate::migration::propose_orchard_to_ironwood(
+            env,
+            &mut db_data,
+            &network,
+            account_uuid,
+        )?;
 
         Ok(utils::rust_bytes_to_java(
             env,

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -13,7 +13,7 @@ use bytes::Bytes;
 use http_body_util::BodyExt;
 use jni::{
     JNIEnv,
-    objects::{JByteArray, JClass, JObject, JObjectArray, JString, JValue},
+    objects::{JByteArray, JClass, JObject, JObjectArray, JString, JThrowable, JValue},
     sys::{JNI_FALSE, JNI_TRUE, jboolean, jbyteArray, jint, jlong, jobject, jobjectArray, jstring},
 };
 use nonempty::NonEmpty;
@@ -47,6 +47,7 @@ use zcash_client_backend::{
         TransactionStatusFilter, TransparentKeyOrigin, WalletCommitmentTrees, WalletRead,
         WalletSummary, WalletWrite, Zip32Derivation,
         chain::{CommitmentTreeRoot, ScanSummary, scan_cached_blocks},
+        error::Error as DataApiError,
         scanning::{ScanPriority, ScanRange},
         wallet::{
             self, SignerView, create_pczt_from_proposal, create_proposed_transactions,
@@ -61,6 +62,7 @@ use zcash_client_backend::{
         DecodingError, Era, ReceiverRequirement, ReceiverRequirementError, UnifiedAddressRequest,
         UnifiedFullViewingKey, UnifiedSpendingKey,
     },
+    proposal::ProposalError,
     proto::{proposal::Proposal, service::TreeState},
     tor::{
         DormantMode,
@@ -2107,6 +2109,48 @@ fn zip317_helper<DbT>(
     )
 }
 
+/// The JVM class thrown when a proposal fails with [`ProposalError::AnchorNotFound`]. The
+/// `(String, long)` constructor signature is part of the JNI contract with the Kotlin class.
+const ANCHOR_NOT_FOUND_EXCEPTION_CLASS: &str =
+    "cash/z/ecc/android/sdk/internal/jni/ProposalAnchorNotFoundException";
+
+/// Converts a proposal failure into the `anyhow` error reported through the generic exception
+/// path, first raising a typed `ProposalAnchorNotFoundException` on the JVM when the failure is
+/// [`ProposalError::AnchorNotFound`], so that callers can react to it without matching message
+/// text. `unwrap_exc_or` leaves a pending exception in place, so the typed throw wins when it
+/// succeeds and the generic `RuntimeException` remains the fallback when it does not.
+fn map_proposal_error<DE, TE, SE, FE, CE, N>(
+    env: &mut JNIEnv,
+    context: &str,
+    e: DataApiError<DE, TE, SE, FE, CE, N>,
+) -> anyhow::Error
+where
+    DataApiError<DE, TE, SE, FE, CE, N>: std::fmt::Display,
+{
+    if let DataApiError::Proposal(ProposalError::AnchorNotFound(anchor_height)) = &e {
+        let description = format!(
+            "{}: no anchor is computable at height {}",
+            context, anchor_height
+        );
+        let thrown = (|| -> Result<(), jni::errors::Error> {
+            let message = env.new_string(&description)?;
+            let exception = env.new_object(
+                ANCHOR_NOT_FOUND_EXCEPTION_CLASS,
+                "(Ljava/lang/String;J)V",
+                &[
+                    JValue::Object(&message),
+                    JValue::Long(u32::from(*anchor_height) as jlong),
+                ],
+            )?;
+            env.throw(JThrowable::from(exception))
+        })();
+        if let Err(err) = thrown {
+            error!("Unable to throw ProposalAnchorNotFoundException: {}", err);
+        }
+    }
+    anyhow!("{}: {}", context, e)
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeTransferFromUri<
     'local,
@@ -2148,7 +2192,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeTr
             lock_inputs,
             proposed_version,
         )
-        .map_err(|e| anyhow!("Error creating transaction proposal: {}", e))?;
+        .map_err(|e| map_proposal_error(env, "Error creating transaction proposal", e))?;
 
         Ok(utils::rust_bytes_to_java(
             env,
@@ -2217,7 +2261,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeTr
             lock_inputs,
             proposed_version,
         )
-        .map_err(|e| anyhow!("Error creating transaction proposal: {}", e))?;
+        .map_err(|e| map_proposal_error(env, "Error creating transaction proposal", e))?;
 
         Ok(utils::rust_bytes_to_java(
             env,
@@ -2247,7 +2291,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_proposeOr
         let account_uuid = account_id_from_jni(env, account_uuid)?;
 
         let proposal =
-            crate::migration::propose_orchard_to_ironwood(&mut db_data, &network, account_uuid)?;
+            crate::migration::propose_orchard_to_ironwood(env, &mut db_data, &network, account_uuid)?;
 
         Ok(utils::rust_bytes_to_java(
             env,

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -12,6 +12,7 @@
 //! themselves, because the fee depends on which inputs the selector picks.
 
 use anyhow::anyhow;
+use jni::JNIEnv;
 use rand::rngs::OsRng;
 use zcash_address::{ToAddress, ZcashAddress, unified, unified::Encoding as _};
 use zcash_client_backend::{
@@ -64,6 +65,7 @@ type MigrationProposal = Proposal<StandardFeeRule, <Db as InputSource>::NoteRef>
 /// off the chain. Splitting a crossing into less-identifying denominations is
 /// a separate mechanism; this deliberately does not attempt it.
 pub(crate) fn propose_orchard_to_ironwood(
+    env: &mut JNIEnv,
     db_data: &mut Db,
     network: &Network,
     account: AccountUuid,
@@ -148,5 +150,5 @@ pub(crate) fn propose_orchard_to_ironwood(
         &locked_input_policy,
         lock_inputs,
     )
-    .map_err(|e| anyhow!("Error creating the migration proposal: {}", e))
+    .map_err(|e| crate::map_proposal_error(env, "Error creating the migration proposal", e))
 }

--- a/backend-lib/src/main/rust/utils/exception.rs
+++ b/backend-lib/src/main/rust/utils/exception.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use jni::JNIEnv;
+use jni::objects::{JObject, JThrowable};
 use std::any::Any;
 use std::thread;
 use tracing::error;
@@ -28,7 +29,9 @@ pub fn unwrap_exc_or<T>(env: &mut JNIEnv, res: ExceptionResult<T>, error_val: T)
                 Ok(val) => val,
                 Err(jni_error) => {
                     // Do nothing if there is a pending Java-exception that will be thrown
-                    // automatically by the JVM when the native method returns.
+                    // automatically by the JVM when the native method returns. Typed
+                    // exceptions raised through `throw_object` below rely on this check to
+                    // win over the generic `RuntimeException`.
                     if !env.exception_check().unwrap() {
                         // Throw a Java exception manually in case of an internal error.
                         throw(env, &jni_error.to_string())
@@ -62,6 +65,29 @@ fn throw(env: &mut JNIEnv, description: &str) {
     };
     if let Err(e) = env.throw_new(exception, description) {
         error!("Unable to find 'RuntimeException' class: {}", e.to_string());
+    }
+}
+
+/// Throws the exception object built by `construct` on the JVM, so that a typed exception —
+/// rather than the generic `RuntimeException` from `throw` above — is pending when the native
+/// method returns. `class` names the exception class, for logging only; `construct` typically
+/// calls `JNIEnv::new_object` (`JNIEnv::throw_new` cannot be used when the constructor takes
+/// more than a message string).
+///
+/// This helper and `unwrap_exc_or` share a contract: `unwrap_exc_or` skips its own throw
+/// whenever an exception is already pending, so a successful call here wins over the generic
+/// path. When constructing or throwing fails, the failure usually leaves its *own* exception
+/// (e.g. `NoClassDefFoundError`) pending, which would otherwise suppress the generic fallback
+/// and surface an unrelated JVM error instead of the original one — so it is cleared here,
+/// and the generic path reports the original error.
+pub fn throw_object<'local, F>(env: &mut JNIEnv<'local>, class: &str, construct: F)
+where
+    F: FnOnce(&mut JNIEnv<'local>) -> Result<JObject<'local>, jni::errors::Error>,
+{
+    let thrown = construct(env).and_then(|exception| env.throw(JThrowable::from(exception)));
+    if let Err(e) = thrown {
+        error!("Unable to throw '{}': {}", class, e);
+        let _ = env.exception_clear();
     }
 }
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Broadcaster.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Broadcaster.kt
@@ -1,5 +1,6 @@
 package cash.z.ecc.android.sdk
 
+import cash.z.ecc.android.sdk.exception.TransactionEncoderException
 import cash.z.ecc.android.sdk.model.CreatedTransaction
 import cash.z.ecc.android.sdk.model.Pczt
 import cash.z.ecc.android.sdk.model.Proposal
@@ -21,6 +22,15 @@ interface Broadcaster {
      *
      * Created transactions will not be automatically resubmitted until they are
      * submitted through this API.
+     *
+     * @throws TransactionEncoderException.AnchorNotFoundException if the transactions could
+     *         not be created because no anchor was computable at the height the proposal
+     *         anchors to. Scanning creates a checkpoint at every height a proposal can anchor
+     *         to, so the expected recovery is to sync further and then create a new proposal;
+     *         the failed proposal anchors to the same height, so retrying it unchanged is not
+     *         expected to succeed on its own.
+     * @throws TransactionEncoderException.TransactionNotCreatedException if the transactions
+     *         could not be created for another reason.
      */
     suspend fun createProposedTransactions(
         proposal: Proposal,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
@@ -1077,6 +1077,7 @@ class SdkSynchronizer private constructor(
     ): Proposal? = txManager.proposeShielding(account, shieldingThreshold, memo, transparentReceiver)
 
     @Throws(
+        TransactionEncoderException.AnchorNotFoundException::class,
         TransactionEncoderException.TransactionNotCreatedException::class,
         TransactionEncoderException.TransactionNotFoundException::class
     )

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
@@ -9,6 +9,7 @@ import cash.z.ecc.android.sdk.exception.PcztException
 import cash.z.ecc.android.sdk.exception.RustLayerException
 import cash.z.ecc.android.sdk.exception.TorInitializationErrorException
 import cash.z.ecc.android.sdk.exception.TorUnavailableException
+import cash.z.ecc.android.sdk.exception.TransactionEncoderException
 import cash.z.ecc.android.sdk.ext.ZcashSdk
 import cash.z.ecc.android.sdk.internal.FastestServerFetcher
 import cash.z.ecc.android.sdk.internal.Files
@@ -392,6 +393,15 @@ interface Synchronizer {
      * @return a flow of result objects for the transactions that were created as part of
      *         the proposal, indicating whether they were submitted to the network or if
      *         an error occurred.
+     *
+     * @throws TransactionEncoderException.AnchorNotFoundException if the transactions could
+     *         not be created because no anchor was computable at the height the proposal
+     *         anchors to. Scanning creates a checkpoint at every height a proposal can anchor
+     *         to, so the expected recovery is to sync further and then create a new proposal;
+     *         the failed proposal anchors to the same height, so retrying it unchanged is not
+     *         expected to succeed on its own.
+     * @throws TransactionEncoderException.TransactionNotCreatedException if the transactions
+     *         could not be created for another reason.
      */
     suspend fun createProposedTransactions(
         proposal: Proposal,
@@ -409,7 +419,10 @@ interface Synchronizer {
      *
      * @return The partially created transaction in [Pczt] format.
      *
-     * @throws PcztException.CreatePcztFromProposalException as a common indicator of the operation failure
+     * @throws PcztException.CreatePcztFromProposalException as a common indicator of the operation failure.
+     *         When the failure is that no anchor was computable at the height the proposal
+     *         anchors to, its `cause` is a [TransactionEncoderException.AnchorNotFoundException];
+     *         sync further, then create a new proposal.
      */
     @Throws(PcztException.CreatePcztFromProposalException::class)
     suspend fun createPcztFromProposal(

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/exception/Exceptions.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/exception/Exceptions.kt
@@ -558,6 +558,18 @@ sealed class TransactionEncoderException(
             rootCause
         )
 
+    /**
+     * The proposal could not be created because no anchor was computable at [anchorHeight], the
+     * height the proposal would anchor to. Scanning creates a checkpoint at every height a
+     * proposal can anchor to, so syncing further before retrying is expected to resolve this.
+     */
+    data class AnchorNotFoundException(
+        val anchorHeight: BlockHeight
+    ) : TransactionEncoderException(
+            "The proposal could not be created because no anchor was computable at height $anchorHeight. " +
+                "Syncing further before retrying is expected to resolve this."
+        )
+
     data class ProposalFromUriException(
         val rootCause: Throwable
     ) : TransactionEncoderException(

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/exception/Exceptions.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/exception/Exceptions.kt
@@ -558,6 +558,22 @@ sealed class TransactionEncoderException(
             rootCause
         )
 
+    /**
+     * Transactions could not be created from the proposal because no anchor was computable at
+     * [anchorHeight], the height the proposal anchors to. Scanning creates a checkpoint at
+     * every height a proposal can anchor to, so the expected recovery is to sync further and
+     * then create a new proposal; the failed proposal anchors to the same height, so retrying
+     * it unchanged is not expected to succeed on its own.
+     */
+    data class AnchorNotFoundException(
+        val anchorHeight: BlockHeight,
+        val rootCause: Throwable
+    ) : TransactionEncoderException(
+            "Transactions could not be created from the proposal because no anchor was computable" +
+                " at height ${anchorHeight.value}. Sync further, then create a new proposal.",
+            rootCause
+        )
+
     data class ProposalFromUriException(
         val rootCause: Throwable
     ) : TransactionEncoderException(

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/TransactionEncoder.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/TransactionEncoder.kt
@@ -88,10 +88,13 @@ internal interface TransactionEncoder {
      *
      * @return the successfully encoded transactions or an exception
      *
+     * @throws TransactionEncoderException.AnchorNotFoundException if no anchor was computable
+     * at the height the proposal anchors to; sync further, then create a new proposal.
      * @throws TransactionEncoderException.TransactionNotCreatedException
      * @throws TransactionEncoderException.TransactionNotFoundException
      */
     @Throws(
+        TransactionEncoderException.AnchorNotFoundException::class,
         TransactionEncoderException.TransactionNotCreatedException::class,
         TransactionEncoderException.TransactionNotFoundException::class,
     )

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/TransactionEncoderImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/TransactionEncoderImpl.kt
@@ -314,7 +314,11 @@ private inline fun Throwable.asProposalException(
     fallback: () -> TransactionEncoderException
 ): TransactionEncoderException =
     when (this) {
-        is ProposalAnchorNotFoundException ->
+        is ProposalAnchorNotFoundException -> {
             TransactionEncoderException.AnchorNotFoundException(BlockHeight.new(anchorHeight))
-        else -> fallback()
+        }
+
+        else -> {
+            fallback()
+        }
     }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/TransactionEncoderImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/TransactionEncoderImpl.kt
@@ -6,6 +6,7 @@ import cash.z.ecc.android.sdk.ext.masked
 import cash.z.ecc.android.sdk.internal.SaplingParamFetcher
 import cash.z.ecc.android.sdk.internal.Twig
 import cash.z.ecc.android.sdk.internal.TypesafeBackend
+import cash.z.ecc.android.sdk.internal.jni.ProposalAnchorNotFoundException
 import cash.z.ecc.android.sdk.internal.model.EncodedTransaction
 import cash.z.ecc.android.sdk.internal.repository.DerivedDataRepository
 import cash.z.ecc.android.sdk.model.Account
@@ -39,9 +40,13 @@ internal class TransactionEncoderImpl(
      *
      * @return the proposal or an exception
      *
+     * @throws TransactionEncoderException.AnchorNotFoundException
      * @throws TransactionEncoderException.ProposalFromUriException
      */
-    @Throws(TransactionEncoderException.ProposalFromUriException::class)
+    @Throws(
+        TransactionEncoderException.AnchorNotFoundException::class,
+        TransactionEncoderException.ProposalFromUriException::class
+    )
     override suspend fun proposeTransferFromUri(
         account: Account,
         uri: String
@@ -60,11 +65,14 @@ internal class TransactionEncoderImpl(
         }.onFailure {
             Twig.error(it) { "Caught exception while creating proposal from URI String." }
         }.getOrElse {
-            throw TransactionEncoderException.ProposalFromUriException(it)
+            throw it.asProposalException { TransactionEncoderException.ProposalFromUriException(it) }
         }
     }
 
-    @Throws(TransactionEncoderException.ProposalFromParametersException::class)
+    @Throws(
+        TransactionEncoderException.AnchorNotFoundException::class,
+        TransactionEncoderException.ProposalFromParametersException::class
+    )
     override suspend fun proposeOrchardToIronwoodMigration(account: Account): Proposal {
         Twig.debug { "creating proposal to migrate the Orchard balance into Ironwood" }
 
@@ -75,11 +83,14 @@ internal class TransactionEncoderImpl(
         }.onFailure {
             Twig.error(it) { "Caught exception while creating the migration proposal." }
         }.getOrElse {
-            throw TransactionEncoderException.ProposalFromParametersException(it)
+            throw it.asProposalException { TransactionEncoderException.ProposalFromParametersException(it) }
         }
     }
 
-    @Throws(TransactionEncoderException.ProposalFromParametersException::class)
+    @Throws(
+        TransactionEncoderException.AnchorNotFoundException::class,
+        TransactionEncoderException.ProposalFromParametersException::class
+    )
     override suspend fun proposeTransfer(
         account: Account,
         recipient: String,
@@ -103,7 +114,7 @@ internal class TransactionEncoderImpl(
         }.onFailure {
             Twig.error(it) { "Caught exception while creating proposal." }
         }.getOrElse {
-            throw TransactionEncoderException.ProposalFromParametersException(it)
+            throw it.asProposalException { TransactionEncoderException.ProposalFromParametersException(it) }
         }
     }
 
@@ -293,3 +304,17 @@ internal class TransactionEncoderImpl(
         return backend.getBranchIdForHeight(height)
     }
 }
+
+/**
+ * Maps a failure from a proposal call to the typed [TransactionEncoderException] to throw:
+ * [TransactionEncoderException.AnchorNotFoundException] when the native layer reported that no
+ * anchor was computable at the proposal's anchor height, and [fallback] otherwise.
+ */
+private inline fun Throwable.asProposalException(
+    fallback: () -> TransactionEncoderException
+): TransactionEncoderException =
+    when (this) {
+        is ProposalAnchorNotFoundException ->
+            TransactionEncoderException.AnchorNotFoundException(BlockHeight.new(anchorHeight))
+        else -> fallback()
+    }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/TransactionEncoderImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/TransactionEncoderImpl.kt
@@ -6,6 +6,7 @@ import cash.z.ecc.android.sdk.ext.masked
 import cash.z.ecc.android.sdk.internal.SaplingParamFetcher
 import cash.z.ecc.android.sdk.internal.Twig
 import cash.z.ecc.android.sdk.internal.TypesafeBackend
+import cash.z.ecc.android.sdk.internal.jni.ProposalAnchorNotFoundException
 import cash.z.ecc.android.sdk.internal.model.EncodedTransaction
 import cash.z.ecc.android.sdk.internal.repository.DerivedDataRepository
 import cash.z.ecc.android.sdk.model.Account
@@ -15,6 +16,7 @@ import cash.z.ecc.android.sdk.model.Pczt
 import cash.z.ecc.android.sdk.model.Proposal
 import cash.z.ecc.android.sdk.model.UnifiedSpendingKey
 import cash.z.ecc.android.sdk.model.Zatoshi
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Class responsible for encoding a transaction in a consistent way. This bridges the gap by
@@ -60,6 +62,7 @@ internal class TransactionEncoderImpl(
         }.onFailure {
             Twig.error(it) { "Caught exception while creating proposal from URI String." }
         }.getOrElse {
+            if (it is CancellationException) throw it
             throw TransactionEncoderException.ProposalFromUriException(it)
         }
     }
@@ -75,6 +78,7 @@ internal class TransactionEncoderImpl(
         }.onFailure {
             Twig.error(it) { "Caught exception while creating the migration proposal." }
         }.getOrElse {
+            if (it is CancellationException) throw it
             throw TransactionEncoderException.ProposalFromParametersException(it)
         }
     }
@@ -103,6 +107,7 @@ internal class TransactionEncoderImpl(
         }.onFailure {
             Twig.error(it) { "Caught exception while creating proposal." }
         }.getOrElse {
+            if (it is CancellationException) throw it
             throw TransactionEncoderException.ProposalFromParametersException(it)
         }
     }
@@ -124,10 +129,12 @@ internal class TransactionEncoderImpl(
         }.onSuccess { result ->
             Twig.info { "Result of proposeShielding: ${result?.toPrettyString()}" }
         }.getOrElse {
+            if (it is CancellationException) throw it
             throw TransactionEncoderException.ProposalShieldingException(it)
         }
 
     @Throws(
+        TransactionEncoderException.AnchorNotFoundException::class,
         TransactionEncoderException.TransactionNotCreatedException::class,
         TransactionEncoderException.TransactionNotFoundException::class,
     )
@@ -149,7 +156,9 @@ internal class TransactionEncoderImpl(
             }.onSuccess { result ->
                 Twig.info { "Result of createProposedTransactions: $result" }
             }.getOrElse {
-                throw TransactionEncoderException.TransactionNotCreatedException(it)
+                if (it is CancellationException) throw it
+                throw it.asAnchorNotFoundException()
+                    ?: TransactionEncoderException.TransactionNotCreatedException(it)
             }
 
         val txs =
@@ -175,7 +184,8 @@ internal class TransactionEncoderImpl(
         }.onFailure {
             Twig.error(it) { "Caught exception while creating PCZT." }
         }.getOrElse {
-            throw PcztException.CreatePcztFromProposalException(it.message, it.cause)
+            if (it is CancellationException) throw it
+            throw PcztException.CreatePcztFromProposalException(it.message, it.asAnchorNotFoundException() ?: it.cause)
         }
 
     override suspend fun redactPcztForSigner(pczt: Pczt): Pczt =
@@ -293,3 +303,13 @@ internal class TransactionEncoderImpl(
         return backend.getBranchIdForHeight(height)
     }
 }
+
+/**
+ * Returns the typed [TransactionEncoderException.AnchorNotFoundException] equivalent of this
+ * failure when the native layer reported that no anchor was computable at the height the
+ * proposal anchors to, and `null` for every other failure.
+ */
+private fun Throwable.asAnchorNotFoundException(): TransactionEncoderException.AnchorNotFoundException? =
+    (this as? ProposalAnchorNotFoundException)?.let {
+        TransactionEncoderException.AnchorNotFoundException(BlockHeight.new(it.anchorHeight), it)
+    }


### PR DESCRIPTION
Closes #2104. Resolves MOB-1616. Replaces #2110, which targeted `main`; per the maintenance-branch workflow this lands on `maint/v2.7.x` and merges forward.

A failure with `zcash_client_backend`'s `ProposalError::AnchorNotFound` previously reached callers only as a generic exception whose sole signal was the formatted Rust message — no way to distinguish "sync further and re-propose" from any other failure without string matching. This PR surfaces it as a typed exception on the paths that can actually produce it.

**Where the error can occur.** `AnchorNotFound` is constructed only inside `build_proposed_transaction` (`data_api/wallet.rs`), reachable from `create_proposed_transactions` and `create_pczt_from_proposal` — never from the propose entry points: proposal planning selects the anchor *height* but does not compute the root at it. The first revision of this PR instrumented the three propose entry points; per review, that mapping could never fire and has been removed. The PCZT path is included because it shares `build_proposed_transaction` and would otherwise keep the same opaque failure.

**Rust (`backend-lib`)**: `map_proposal_error` inspects the concrete error at the JNI boundary of `createProposedTransactions` and `createPcztFromProposal` and throws a dedicated `ProposalAnchorNotFoundException(message, anchorHeight)` on the JVM. The construct-and-throw plumbing is a new `utils::exception::throw_object` helper next to `unwrap_exc_or`, documenting the shared pending-exception contract; when a typed throw fails it clears the pending JVM exception, so the generic `RuntimeException` remains the fallback in every failure mode rather than leaking an unrelated `NoClassDefFoundError`-style error.

**Kotlin (`sdk-lib`)**:
- `Synchronizer.createProposedTransactions` now throws the public `TransactionEncoderException.AnchorNotFoundException(anchorHeight, rootCause)`, declared along the whole chain (`TransactionEncoder`, the impl, `SdkSynchronizer`, and the `Synchronizer` KDoc). It is a sibling of `TransactionNotCreatedException`, so callers handling this case need a dedicated catch; the CHANGELOG states the call-site edit.
- `Synchronizer.createPcztFromProposal` keeps throwing `PcztException.CreatePcztFromProposalException`, now carrying the same public typed exception as its `cause` (the internal JNI class is not API surface).
- The JNI-constructed exception class is `@Keep`-annotated, matching the `Jni*` precedent, so R8 cannot strip the natively-called constructor in minified consumer builds.
- The `runCatching` chains around the proposal and creation calls rethrow `CancellationException` instead of wrapping it as a failure.
- KDoc documents the recovery: scanning creates a checkpoint at every height a proposal can anchor to, so sync further and then create a **new** proposal — the failed proposal anchors to the same height, so retrying it unchanged is not expected to succeed on its own.

**Scope note on `AnchorIntervalMismatch`** (the other error named in #2104): unchanged from the first revision — it originates in the `zcash_pool_migration` engine's prove/rebuild steps, which `backend-lib` does not invoke, so there is nothing to surface until that engine is wired in.

Also fixed in passing, per review: `proposeTransferFromUri`'s tracing span was copy-paste named `RustBackend.proposeTransfer`.

Rebased onto current `maint/v2.7.x` (`zcash_client_backend 0.24.0-rc.7`; the `AnchorNotFound` construction sites are unchanged between rc.6 and rc.7). #2167 tracks the follow-up of routing all proposal/creation failure mapping through a single choke point.

Verification: `cargo check` and `cargo fmt --check` pass; `:sdk-lib:compileDebugKotlin` and `:backend-lib:compileDebugKotlin` pass (native NDK link excluded in this environment); `./gradlew ktlint` and `./gradlew detektAll` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)