### PR TITLE
CI: check branch topology invariants

### DIFF
--- a/.github/scripts/check-merge-forward.sh
+++ b/.github/scripts/check-merge-forward.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Check that one hop of the maintenance chain still merges cleanly, optionally
+# with a pending change applied to either side.
+#
+# Usage: check-merge-forward.sh <source> <target> [pr-base] [pr-ref]
+#
+#   source    branch merged from, e.g. maint/v2.7.x
+#   target    branch merged into, e.g. maint/v2.8.x
+#   pr-base   branch a pending change targets; when it is <source> or <target>
+#             that side is replaced by <pr-ref>. Omit to check the branches as
+#             they stand.
+#   pr-ref    the pending change; defaults to HEAD (refs/pull/N/merge in CI).
+#
+# Branches resolve under refs/remotes/origin, so run `git fetch origin` first.
+# Exits 1 only when the change introduces the conflict, 0 otherwise.
+
+set -euo pipefail
+
+SOURCE="${1:?usage: check-merge-forward.sh <source> <target> [pr-base] [pr-ref]}"
+TARGET="${2:?usage: check-merge-forward.sh <source> <target> [pr-base] [pr-ref]}"
+PR_BASE="${3:-}"
+PR_REF="${4:-HEAD}"
+
+# commit-tree needs an identity. Fall back only when git has none of its own, so
+# a local run keeps the user's; git var fails exactly when commit-tree would.
+if ! git var GIT_COMMITTER_IDENT >/dev/null 2>&1; then
+  export GIT_AUTHOR_NAME='merge-forward check' GIT_AUTHOR_EMAIL='ci@localhost'
+  export GIT_COMMITTER_NAME='merge-forward check' GIT_COMMITTER_EMAIL='ci@localhost'
+fi
+
+CONFLICTS=''
+
+# Merge $2 into $1 in memory. Sets CONFLICTS and returns 1 on conflict.
+merge_hop() {
+  local into="$1" from="$2" out rc=0
+  out="$(git merge-tree --write-tree --name-only "$into" "$from")" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    # Line 1 is the tree, then the conflicting paths up to a blank line.
+    CONFLICTS="$(printf '%s\n' "$out" | tail -n +2 | sed -n '/^$/q;p')"
+    return 1
+  fi
+}
+
+say() {
+  printf '%s\n' "$*"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then printf '%s\n' "$*" >>"$GITHUB_STEP_SUMMARY"; fi
+}
+
+src="origin/${SOURCE}"
+dst="origin/${TARGET}"
+applied='no'
+if [ -n "$PR_BASE" ]; then
+  if [ "$PR_BASE" = "$SOURCE" ]; then src="$(git rev-parse "$PR_REF")"; applied='yes'; fi
+  if [ "$PR_BASE" = "$TARGET" ]; then dst="$(git rev-parse "$PR_REF")"; applied='yes'; fi
+fi
+
+say "## Merge-forward: \`${SOURCE}\` -> \`${TARGET}\`"
+say ''
+
+if merge_hop "$dst" "$src"; then
+  if [ "$applied" = 'yes' ]; then
+    say ':white_check_mark: Still merges cleanly with this change applied.'
+  elif [ -n "$PR_BASE" ]; then
+    say ':white_check_mark: Merges cleanly. This change touches neither side.'
+  else
+    say ':white_check_mark: Merges cleanly.'
+  fi
+  exit 0
+fi
+
+conflicts="$CONFLICTS"
+
+say 'Conflicting paths:'
+say ''
+say '```'
+say "$conflicts"
+say '```'
+say ''
+
+if [ "$applied" = 'no' ]; then
+  say ':warning: **Pre-existing.** This change touches neither side of the hop.'
+  exit 0
+fi
+
+# Re-run untouched, so a conflict the branches already carry is not blamed on
+# this change.
+if ! merge_hop "origin/${TARGET}" "origin/${SOURCE}"; then
+  say ':warning: **Pre-existing.** This hop already conflicts without the change.'
+  exit 0
+fi
+
+say ':x: **Introduced by this change.** The hop merges cleanly without it.'
+say ''
+say 'Advisory only. Resolve during the merge-forward, or reshape the change.'
+exit 1

--- a/.github/scripts/check-release-merged-back.sh
+++ b/.github/scripts/check-release-merged-back.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# Check that every tagged release/ branch has been merged back into its
+# maintenance line, and forward down to main.
+#
+# Usage: check-release-merged-back.sh [pr-base] [pr-ref]
+#
+#   pr-base   branch a pending change targets; that branch is then evaluated
+#             as it would be with the change applied. Omit to check the
+#             branches as they stand.
+#   pr-ref    the pending change; defaults to HEAD (refs/pull/N/merge in CI).
+#
+# A release/ branch counts as released only when a tag points at its tip, so
+# in-flight release branches are skipped. The maintenance line comes from the
+# TAG, not the branch name: release/v3.0.0 is tagged v2.8.0-rc.1 and belongs to
+# maint/v2.8.x.
+#
+# Branches resolve under refs/remotes/origin, so run `git fetch origin` first.
+# Exits 1 when a tagged release is missing from a branch it should be in.
+
+set -euo pipefail
+
+PR_BASE="${1:-}"
+PR_REF="${2:-HEAD}"
+
+say() {
+  printf '%s\n' "$*"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then printf '%s\n' "$*" >>"$GITHUB_STEP_SUMMARY"; fi
+}
+
+# Maintenance lines in version order, then main. v:refname sorts v2.10.x after
+# v2.9.x.
+CHAIN=()
+while IFS= read -r ref; do
+  CHAIN+=("$ref")
+done < <(
+  git for-each-ref --sort=v:refname --format='%(refname:lstrip=3)' \
+    'refs/remotes/origin/maint/v*'
+)
+CHAIN+=('main')
+
+# Resolve a chain branch, substituting the pending change when it targets it.
+resolve() {
+  if [ -n "$PR_BASE" ] && [ "$1" = "$PR_BASE" ]; then
+    git rev-parse "$PR_REF"
+  else
+    printf 'origin/%s\n' "$1"
+  fi
+}
+
+say '## Release branches merged back'
+say ''
+
+failed=0
+checked=0
+
+while IFS= read -r rel; do
+  [ -n "$rel" ] || continue
+  ref="origin/${rel}"
+
+  tags="$(git tag --points-at "$ref" | tr '\n' ' ')"
+  tags="${tags% }"
+  if [ -z "$tags" ]; then
+    say ":grey_question: \`${rel}\` has no tag at its tip; not a released branch, skipped."
+    continue
+  fi
+
+  # vMAJOR.MINOR.PATCH[-rc.N] -> maint/vMAJOR.MINOR.x
+  tag="${tags%% *}"
+  ver="${tag#v}"
+  major="${ver%%.*}"
+  rest="${ver#*.}"
+  minor="${rest%%.*}"
+  maint="maint/v${major}.${minor}.x"
+
+  # Its own line is the obligation. Anything downstream of it is merge-forward
+  # lag, which the merge-forward jobs already track, so it warns rather than
+  # fails; otherwise the merge-back PR itself would report red for main.
+  # A retired line is simply absent from the chain.
+  own=''
+  downstream=()
+  seen=0
+  for b in "${CHAIN[@]}"; do
+    if [ "$b" = "$maint" ]; then seen=1; own="$b"; continue; fi
+    if [ "$seen" -eq 1 ]; then downstream+=("$b"); fi
+  done
+  if [ "$seen" -eq 0 ]; then
+    own='main'
+    downstream=()
+    say ":grey_question: \`${rel}\` (\`${tag}\`) belongs to \`${maint}\`, which no longer exists; checking main only."
+  fi
+
+  checked=$((checked + 1))
+
+  lagging=()
+  for b in ${downstream[@]+"${downstream[@]}"}; do
+    if ! git merge-base --is-ancestor "$ref" "$(resolve "$b")"; then
+      lagging+=("$b")
+    fi
+  done
+
+  if ! git merge-base --is-ancestor "$ref" "$(resolve "$own")"; then
+    failed=1
+    say ":x: \`${rel}\` (\`${tag}\`) is **not** merged back into \`${own}\`."
+  elif [ "${#lagging[@]}" -ne 0 ]; then
+    list="$(printf '%s, ' "${lagging[@]}")"
+    say ":warning: \`${rel}\` (\`${tag}\`) is in \`${own}\` but has not reached ${list%, } yet."
+  else
+    say ":white_check_mark: \`${rel}\` (\`${tag}\`) is in \`${own}\` and downstream."
+  fi
+done < <(
+  git for-each-ref --sort=v:refname --format='%(refname:lstrip=3)' \
+    'refs/remotes/origin/release/*'
+)
+
+say ''
+
+if [ "$checked" -eq 0 ]; then
+  say 'No tagged release branches to check.'
+  exit 0
+fi
+
+if [ "$failed" -eq 0 ]; then
+  say "All ${checked} tagged release branches are merged back into their line."
+  exit 0
+fi
+
+say 'Advisory only. Merge the release branch back into its maintenance line and'
+say 'let it flow forward, rather than cherry-picking, so the tag stays reachable.'
+exit 1

--- a/.github/workflows/merge-forward.yml
+++ b/.github/workflows/merge-forward.yml
@@ -1,0 +1,71 @@
+# Checks each hop of the maintenance chain (maint/v2.7.x -> maint/v2.8.x -> main)
+# still merges once a PR lands. One job per hop, so the failing hop is visible
+# from the checks list without opening the run.
+#
+# Advisory only: continue-on-error keeps these from blocking, since a
+# merge-forward conflict is often legitimate and is resolved by hand at merge
+# time. Read the detail in the run summary.
+#
+# No paths-ignore, unlike pull-request.yml: a conflict in README.md or docs/
+# counts just as much as one in Kotlin.
+#
+# Run locally with:
+#   ./.github/scripts/check-merge-forward.sh maint/v2.7.x maint/v2.8.x
+#
+# A new release line needs a new job here.
+
+name: Merge Forward
+
+on:
+  pull_request:
+    branches:
+      - 'maint/v*'
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  merge_forward_v2_7_into_v2_8:
+    name: maint/v2.7.x into maint/v2.8.x
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        timeout-minutes: 5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          # Merge bases are needed across branches.
+          fetch-depth: 0
+      - name: Check hop
+        timeout-minutes: 5
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch --quiet --no-tags origin '+refs/heads/*:refs/remotes/origin/*'
+          ./.github/scripts/check-merge-forward.sh \
+            maint/v2.7.x maint/v2.8.x "${BASE_REF}"
+
+  merge_forward_v2_8_into_main:
+    name: maint/v2.8.x into main
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        timeout-minutes: 5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+      - name: Check hop
+        timeout-minutes: 5
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch --quiet --no-tags origin '+refs/heads/*:refs/remotes/origin/*'
+          ./.github/scripts/check-merge-forward.sh \
+            maint/v2.8.x main "${BASE_REF}"

--- a/.github/workflows/release-merged-back.yml
+++ b/.github/workflows/release-merged-back.yml
@@ -1,0 +1,47 @@
+# Checks that every tagged release/ branch has been merged back into its
+# maintenance line, and flowed forward to main. A release that is only
+# cherry-picked back leaves its tag unreachable from any live branch, so the
+# released commit stops being part of the history it shipped from.
+#
+# Advisory only: continue-on-error keeps this from blocking. Read the detail in
+# the run summary.
+#
+# Only missing from its OWN maint line fails; not having reached main yet is a
+# warning, since the merge-forward jobs already track that.
+#
+# Run locally with:
+#   ./.github/scripts/check-release-merged-back.sh
+
+name: Release Merged Back
+
+on:
+  pull_request:
+    branches:
+      - 'maint/v*'
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release_merged_back:
+    name: release branches merged back
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        timeout-minutes: 5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+      - name: Check release branches
+        timeout-minutes: 5
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          # Tags are what mark a release branch as released, so fetch them.
+          git fetch --quiet --tags origin '+refs/heads/*:refs/remotes/origin/*'
+          ./.github/scripts/check-release-merged-back.sh "${BASE_REF}"


### PR DESCRIPTION
Two advisory checks over the branch topology, both non-blocking and both
runnable locally.

## 1. Merge forward

The maintenance branches only work as a chain if every hop still merges: a fix
lands on the oldest line that needs it and is merged forward, oldest to newest,
with conflicts resolved explicitly at each hop. A conflict costs far less to see
while the change and its rationale are still in front of the author than weeks
later, when whoever runs the merge has to reconstruct the intent from a diff.

| Job | Checks |
|---|---|
| `maint/v2.7.x into maint/v2.8.x` | `check-merge-forward.sh maint/v2.7.x maint/v2.8.x "$BASE_REF"` |
| `maint/v2.8.x into main` | `check-merge-forward.sh maint/v2.8.x main "$BASE_REF"` |

One job per hop, so the failing hop is visible from the checks list without
opening the run. Both share one script with the source and target swapped.

**Pre-existing vs introduced.** When a hop conflicts, the script re-runs it on
the untouched branches. If the conflict is there without the change, it warns
and exits 0; only a conflict the change introduces exits non-zero. This matters
immediately: `maint/v2.8.x -> main` currently conflicts in `.gitignore` and
`AGENTS.md`. Without the split, every PR to `maint/v2.7.x` or `maint/v2.8.x`
would report red for a reason unrelated to it and the check would be tuned out.

## 2. Release merged back

A release is cut on a `release/` branch and tagged there. If that branch is only
cherry-picked back instead of merged, the tag stops being reachable from any
live branch: the commit that actually shipped is no longer part of the history
it shipped from, and every later "is this fix in the release" question has to be
answered by reading diffs instead of asking git.

`release branches merged back` walks every `release/` branch on origin and
checks it is an ancestor of the maintenance line it belongs to, and of
everything downstream to main.

- A branch counts as released only when a **tag points at its tip**, so
  in-flight release branches are skipped rather than reported.
- The maintenance line comes from the **tag**, not the branch name, because the
  two disagree: `release/v3.0.0` is tagged `v2.8.0-rc.1` and belongs to
  `maint/v2.8.x`. Deriving from the name would look for `maint/v3.0.x`.
- Only a release missing from its **own** line fails. Not having reached main
  yet is a warning, since the merge-forward jobs already track that, and failing
  on it would make the merge-back PR itself report red for a branch it was never
  going to update.

Current state on this PR:

```
:grey_question: release/v2.7.0-rc.4 has no tag at its tip; not a released branch, skipped.
:white_check_mark: release/v2.8.0-rc.2 (v2.8.0-rc.2) is in maint/v2.8.x and downstream.
:grey_question: release/v2.8.0-rc.3 has no tag at its tip; not a released branch, skipped.
:white_check_mark: release/v3.0.0 (v2.8.0-rc.1) is in maint/v2.8.x and downstream.
```

## Notes

- Neither trigger carries `paths-ignore`, unlike `pull-request.yml`. A merge
  conflict in `README.md` or `docs/` counts just as much as one in Kotlin, and
  the conflict we have right now is in `.gitignore` and `AGENTS.md`.
- The merge-forward hops are checked in isolation. A PR to `maint/v2.7.x` that
  merges fine into 2.8.x but would conflict with `main` after that merge is not
  caught, since the second job compares plain `origin/maint/v2.8.x` against
  `main`. Chaining the hops would catch it at the cost of the one-job-per-flow
  shape.
- The logic is in scripts rather than inline YAML so it can be run locally:
  ```
  ./.github/scripts/check-merge-forward.sh maint/v2.7.x maint/v2.8.x
  ./.github/scripts/check-release-merged-back.sh
  ```
  Both defer to a locally configured git identity, so no setup is needed.
- A new release line needs a new job in `merge-forward.yml`.
- No `CHANGELOG.md` entry: per `AGENTS.md` that file is for changes visible to
  consumers of the published library.

## Testing

`shellcheck` clean, `bash -n` clean, YAML parses, ASCII only, both scripts
committed executable.

- Merge forward: six scenarios against the real branches, including a synthetic
  conflicting commit to confirm the introduced case exits 1.
- Release merged back: exercised against a purpose-built synthetic repo covering
  a merged-back release, a released branch never merged back (exits 1), an
  untagged in-flight branch (skipped), the merge-back PR itself (warns on main,
  exits 0), and the state after main catches up.
- All three jobs then verified green in CI on this PR, with output matching the
  local runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)