### PR TITLE
Adopt the zcash_pool_migration satisfiability API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `MigrationAdvanceStep.Reevaluate` and `MigrationAdvanceStep.Replan`. `Reevaluate` is returned
+  while a broadcast-failure report stands: a node refused a broadcast citing chain state this
+  wallet has not scanned, so sync — at least to the tip observed with the rejection — and ask
+  `nextStep` again. `Replan` means enough of the committed plan's value can never mine that the
+  plan itself must be rebuilt; `nextStep()` marks the plan superseded before returning it, so the
+  ordinary planning flow accepts a replacement — re-propose the remaining balance.
+- `MigrationBlocker.UNSATISFIABLE`, `.AWAITING_REEVALUATION` and `.EXPIRY_IMMINENT`, plus
+  `MigrationTransferState.unsatisfiableKind` (`MigrationUnsatisfiableKind`) carrying why a
+  transaction can never execute. The kind is a separate field because `UNSATISFIABLE` carries no
+  payload, and the two are independent: a marked transaction may report a different blocker.
 - `CompactBlockProcessor.enhanceTransactionDetails` and the per-transaction `enhanceTransaction`
   step now emit structured diagnostic logs at each step of an enhance cycle — cycle start with
   request count, per-request type, fetch response shape (whether a tx was returned, whether it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `zcash_client_sqlite 0.22.0-rc.7`, adopting the revised ZIP 318 migration timing
   (shorter transfer and preparation delays, and an anchor-age cap of 4 bucket
   boundaries rather than 16).
+- Whether a pool-migration transaction has been mined is now derived from the wallet's own scan
+  data by the migration engine, instead of being observed by the SDK and recorded with an explicit
+  mark. A migration transaction is promoted to mined only once the wallet has scanned to the height
+  carrying it, so the promotion can no longer outlive a rollback of the block that justified it.
+- A pool-migration transfer whose expiry has probably passed — at or above the wallet's fully
+  scanned height, but below its estimate of the chain tip — is now withheld from the broadcast and
+  prove queues rather than offered. This is protective and reversible: nothing is recorded and no
+  artifact is discarded, and such a transfer becomes available again if the wallet's own scan shows
+  it has not in fact lapsed.
 - A canonical ZIP 318 crossing is now funded from the single oldest Orchard note
   that covers the payment and its fee, falling back to ordinary multi-note funding
   when no such note exists. Canonical-denomination payments that previously lost

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/migration/JniMigrationModels.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/migration/JniMigrationModels.kt
@@ -164,6 +164,16 @@ class JniMigrationTransferState(
      * 7 expiry imminent, 8 awaiting reevaluation, 9 unsatisfiable.
      */
     val blocker: Int,
+    /**
+     * Why this transaction can never execute, when the engine has marked it: 0 not marked,
+     * 1 inputs spent, 2 inputs invalidated, 3 anchor invalidated, 4 inherited (dead only through
+     * a dependency), 5 a cause this boundary does not name yet.
+     *
+     * Independent of [blocker] in both directions — the mark carries the cause, the blocker
+     * carries no payload — so a marked transaction may report a higher-precedence blocker while
+     * still answering here.
+     */
+    val unsatisfiableKind: Int,
     /** The engine-persisted crossing value (`transfer_crossing_value`); -1 for preparations. */
     val amountZatoshi: Long,
     /** Preparation layer/index within the note-split tree; -1/-1 for transfers. */

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -66,7 +66,8 @@ use zcash_pool_migration::{
     },
     preparation::{PrepInput, PreparationPlan},
     satisfiability::{
-        AdvanceConfig, DuenessTargets, ReorgSettleDepth, ReplanThreshold, advance_migration,
+        AdvanceConfig, DuenessTargets, ReorgSettleDepth, ReplanThreshold, UnsatisfiableKind,
+        advance_migration,
     },
     state::{AdvanceStep, NextAction, StepKind},
 };
@@ -2655,6 +2656,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
             bool,
             i32,
             i32,
+            i32,
             i64,
             i32,
             i32,
@@ -2677,6 +2679,23 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                         | MigrationTxState::Broadcast { .. }
                         | MigrationTxState::Mined { .. }
                 );
+                // Read from the transaction's own persisted mark, not from the blocker: the
+                // blocker carries no payload, and the two are independent — a row can be marked
+                // while a higher-precedence blocker is what it reports.
+                let unsatisfiable_kind = match t.unsatisfiable_kind() {
+                    None => UNSATISFIABLE_KIND_NONE,
+                    Some(UnsatisfiableKind::InputsSpent) => UNSATISFIABLE_KIND_INPUTS_SPENT,
+                    Some(UnsatisfiableKind::InputsInvalidated) => {
+                        UNSATISFIABLE_KIND_INPUTS_INVALIDATED
+                    }
+                    Some(UnsatisfiableKind::AnchorInvalidated) => {
+                        UNSATISFIABLE_KIND_ANCHOR_INVALIDATED
+                    }
+                    Some(UnsatisfiableKind::Inherited) => UNSATISFIABLE_KIND_INHERITED,
+                    // `#[non_exhaustive]`: a cause added upstream reads as "marked, kind not yet
+                    // surfaced here" rather than as "not marked", which would be a lie.
+                    Some(_) => UNSATISFIABLE_KIND_OTHER,
+                };
                 let (ready, action, blocker) = {
                     let action = match status.action() {
                         Some(zcash_pool_migration::state::NextAction::Prove) => ACTION_PROVE,
@@ -2736,6 +2755,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                     ready,
                     action,
                     blocker,
+                    unsatisfiable_kind,
                     amount_zatoshi,
                     prep_layer,
                     prep_index,
@@ -2761,6 +2781,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                 ready,
                 action,
                 blocker,
+                unsatisfiable_kind,
                 amount_zatoshi,
                 prep_layer,
                 prep_index,
@@ -2772,7 +2793,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                 env.set_long_array_region(&jdeps, 0, &depends_on)?;
                 env.new_object(
                     JNI_MIGRATION_TRANSFER_STATE,
-                    "(JZZZJJZIIJII[JJJ)V",
+                    "(JZZZJJZIIIJII[JJJ)V",
                     &[
                         JValue::Long(encode_transfer_id(id)),
                         JValue::Bool(is_transfer as jboolean),
@@ -2783,6 +2804,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                         JValue::Bool(ready as jboolean),
                         JValue::Int(action),
                         JValue::Int(blocker),
+                        JValue::Int(unsatisfiable_kind),
                         JValue::Long(amount_zatoshi),
                         JValue::Int(prep_layer),
                         JValue::Int(prep_index),
@@ -7425,6 +7447,19 @@ const BLOCKER_AWAITING_REEVALUATION: i32 = 8;
 /// The transaction can never mine — marked unsatisfiable, or stranded behind one that is. The
 /// remedy is a migration-level replan, never more syncing. New in `zcash_pool_migration 0.1.0-rc.6`.
 const BLOCKER_UNSATISFIABLE: i32 = 9;
+
+// The cause recorded beside a transaction's unsatisfiability mark, surfaced as its own field
+// because `Blocker::Unsatisfiable` carries no payload. The mark is orthogonal to both the blocker
+// and the lifecycle state: a marked row keeps its `Proved`/`Broadcast` state, and can report a
+// different (higher-precedence) blocker while still carrying its cause.
+const UNSATISFIABLE_KIND_NONE: i32 = 0;
+const UNSATISFIABLE_KIND_INPUTS_SPENT: i32 = 1;
+const UNSATISFIABLE_KIND_INPUTS_INVALIDATED: i32 = 2;
+const UNSATISFIABLE_KIND_ANCHOR_INVALIDATED: i32 = 3;
+/// Dead only through the dependency closure — this transaction's own inputs are intact.
+const UNSATISFIABLE_KIND_INHERITED: i32 = 4;
+/// A cause added to the upstream `#[non_exhaustive]` enum that this boundary does not name yet.
+const UNSATISFIABLE_KIND_OTHER: i32 = 5;
 
 /// Two-tip decision (spec §3): the underlying `advance_migration` call is driven by
 /// `DuenessTargets::new(scanned, estimated)`, which folds the ESTIMATED tip into its `effective`

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -341,6 +341,31 @@ fn target_height(wallet: &Wallet) -> anyhow::Result<BlockHeight> {
     Ok(tip + 1)
 }
 
+/// The advance policy every drive of `advance_migration` in this file runs under — one
+/// constructor, so the reorg-settlement depth ([`SETTLE_DEPTH`]) cannot diverge between the
+/// step-query and read-reconciliation paths.
+fn advance_config() -> AdvanceConfig {
+    AdvanceConfig::new(SETTLE_DEPTH)
+}
+
+/// The two heights `satisfiability::advance_migration` judges against, in the crate's `height + 1`
+/// TARGET convention: what this wallet's chain data SUPPORTS (its fully-scanned frontier), and
+/// where the tip has probably reached (its chain view).
+///
+/// Every determination that persists a verdict or destroys work is made at `scanned`; the estimate
+/// only re-orders or protectively withholds. `DuenessTargets::new` clamps `effective >= scanned`,
+/// so an estimate lagging the wallet's own observations can never withhold work the chain data
+/// already justifies — which is why this can be derived here rather than trusted from the caller.
+fn dueness_targets(wallet: &Wallet) -> anyhow::Result<DuenessTargets> {
+    let scanned = wallet
+        .block_fully_scanned()
+        .map_err(|e| anyhow!("fully-scanned height lookup failed: {}", e))?
+        .map(|meta| meta.block_height() + 1)
+        .unwrap_or(BlockHeight::from_u32(0));
+    let estimated = target_height(wallet)?;
+    Ok(DuenessTargets::new(scanned, estimated))
+}
+
 /// The wallet's real, currently-witnessable anchor height (the same one ordinary, non-migration
 /// sends use, via `get_target_and_anchor_heights`) — NOT just "chain tip minus one", which isn't
 /// necessarily checkpointed (confirmed live: `root_at_checkpoint_id` returned `None` for a raw
@@ -1522,12 +1547,21 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     unwrap_exc_or(&mut env, res, ())
 }
 
-/// Reconciles mined-ness against the wallet's own transaction history before returning migration
-/// state, so `InProgress`/`Complete` derivation reflects broadcast truth instead of staying stuck at
-/// whatever `mark_broadcast` last recorded. The engine's own contract intentionally leaves mining
-/// detection to the caller (`state.rs` module doc: "the state machine's only job is to ORDER the
-/// broadcasts") — this is that caller-side reconciliation, run at read time rather than a background
-/// job, matching the iOS SDK's own `derive_state` reconciliation approach.
+/// Reads migration state after letting the engine reconcile it against the chain.
+///
+/// This used to walk every `Broadcast` transaction, ask the wallet `get_tx_height`, and call
+/// `MigrationState::mark_mined` by hand, because the engine's contract then left mining detection
+/// to the caller. It no longer does: `PoolMigrationRead::mined_height` asks the same question
+/// through the store, and `advance_migration` asks it about every in-flight transaction it
+/// sweeps, so minedness is now chain-derived on the engine's side — as its doc puts it, "a driver
+/// that never calls [`MigrationState::mark_mined`] is the intended shape": the consumer records
+/// what only it can know (that it submitted), and the engine derives inclusion from the wallet's
+/// own scan.
+///
+/// Driving here rather than only at the step-query site keeps every read path (progress, proposals,
+/// attention state) seeing the same adjudicated state, and the drive is idempotent — it persists
+/// only what it determined. The returned step is deliberately discarded; callers that act on a step
+/// call `advance_migration` themselves.
 fn read_reconciled(
     wallet: &Wallet,
     backend: &mut Backend<Wallet>,
@@ -1539,24 +1573,9 @@ fn read_reconciled(
         Some(s) => s,
         None => return Ok(None),
     };
-    let mut newly_mined = Vec::new();
-    for tx in state.transactions() {
-        if let MigrationTxState::Broadcast { txid } = tx.state()
-            && let Some(height) = wallet
-                .get_tx_height(txid)
-                .map_err(|e| anyhow!("Error reading tx height for {:?}: {:?}", txid, e))?
-        {
-            newly_mined.push((tx.id(), height));
-        }
-    }
-    if !newly_mined.is_empty() {
-        for (id, height) in newly_mined {
-            state.mark_mined(id, height);
-        }
-        backend
-            .replace_migration(&state)
-            .map_err(|e| anyhow!("Error persisting reconciled migration state: {:?}", e))?;
-    }
+    let targets = dueness_targets(wallet)?;
+    advance_migration(backend, &mut state, targets, &advance_config(), &mut OsRng)
+        .map_err(|e| anyhow!("Error advancing migration: {:?}", e))?;
     Ok(Some(state))
 }
 
@@ -1580,11 +1599,14 @@ fn pczt_txid(bytes: &[u8]) -> Option<[u8; 32]> {
 /// `"invalid_transfer"`, reason-first ordering — the same mechanism `recordTransferResultNative`
 /// tag 2 uses). Returns `true` iff the plan is (or already was) invalidated.
 ///
-///   1. `read_reconciled` — existing pass: any `Broadcast` transfer the wallet now knows a height
-///      for is promoted to `Mined`.
+///   1. `read_reconciled` — drives `advance_migration`, whose in-flight sweep promotes any
+///      broadcast transaction the wallet's scan now covers to `Mined`.
 ///   2. Submit-crash probe: for each `Proved` transfer, extract its txid from its proven PCZT and
 ///      ask the wallet `get_tx_height`; if the wallet already knows a height, our broadcast landed
-///      (we just never recorded it, e.g. crashed after broadcast) — `mark_broadcast` + `mark_mined`.
+///      (we just never recorded it, e.g. crashed after broadcast) — `mark_broadcast`. Only the
+///      broadcast: the engine's sweep considers only rows it knows were broadcast, so this
+///      observation is the consumer's to make, but the `mark_mined` that used to follow it is not —
+///      the engine derives that from `mined_height` on the next drive.
 ///
 /// A third, foreign-spend-detecting pass used to run here (comparing each candidate transfer's
 /// funding nullifier against the wallet's unspent set). It was removed — see
@@ -1615,8 +1637,9 @@ fn reconcile_invalidated(
         return Ok(matches!(state.status(), engine::MigrationStatus::Failed));
     }
 
-    // --- Pass 2: submit-crash probe. Promote any Proved transfer whose txid is already on chain. ---
-    let mut promotions: Vec<(MigrationTransferId, BlockHeight)> = Vec::new();
+    // --- Pass 2: submit-crash probe. Record the BROADCAST of any Proved transfer whose txid is
+    // already on chain (we submitted it and crashed before recording that). ---
+    let mut promotions: Vec<MigrationTransferId> = Vec::new();
     for tx in state.transactions() {
         if !matches!(tx.state(), MigrationTxState::Proved) {
             continue;
@@ -1625,17 +1648,17 @@ fn reconcile_invalidated(
             continue;
         };
         let txid = zcash_protocol::TxId::from_bytes(txid_bytes);
-        if let Some(height) = wallet
+        if wallet
             .get_tx_height(txid)
             .map_err(|e| anyhow!("Error reading tx height for {:?}: {:?}", txid, e))?
+            .is_some()
         {
-            promotions.push((tx.id(), height));
+            promotions.push(tx.id());
         }
     }
     if !promotions.is_empty() {
-        for (id, height) in &promotions {
+        for id in &promotions {
             state.mark_broadcast(*id);
-            state.mark_mined(*id, *height);
         }
         let mut backend = Backend::new(&*wallet, account, None, store_conn, *wallet.params())?;
         backend
@@ -1646,9 +1669,10 @@ fn reconcile_invalidated(
     Ok(false)
 }
 
-/// Reconciles a committed migration against on-chain truth via two passes: own-broadcast/mined
-/// promotion (submit-crash recovery), matching what `advance_migration`'s own in-flight sweep also
-/// does on every `nextStep` call. Returns `JNI_TRUE` iff the plan is (or already was) `Failed`.
+/// Reconciles a committed migration against on-chain truth via two passes: an engine drive
+/// (`read_reconciled`, whose in-flight sweep promotes mined transactions) and the submit-crash
+/// probe (recording an own broadcast that landed unrecorded, so the next sweep can promote it).
+/// Returns `JNI_TRUE` iff the plan is (or already was) `Failed`.
 ///
 /// Foreign-spend detection (formerly a third pass here) was removed — see
 /// spec/2026-08-05-migration-engine-full-delegation-design.md §4: its terminal `Failed` action
@@ -5929,7 +5953,9 @@ mod reconcile_tests {
             .expect("get_tx_height")
             .expect("fixture txid is mined");
 
-        // Simulate pass 2's promotion of an own crashed broadcast.
+        // Simulate the recovery of an own crashed broadcast: pass 2 records the broadcast, and
+        // the engine's in-flight sweep would then derive the mined promotion (constructed
+        // directly here — this test exercises the outstanding-filter, not the sweep).
         state.mark_broadcast(some_tx_id);
         state.mark_mined(some_tx_id, mined_height);
 
@@ -7422,7 +7448,7 @@ fn advance_step(
     estimated_target: BlockHeight,
 ) -> anyhow::Result<(i64, i64, i64, i64)> {
     let targets = DuenessTargets::new(scanned_target, estimated_target);
-    let config = AdvanceConfig::new(SETTLE_DEPTH);
+    let config = advance_config();
     let mut rng = OsRng;
     let advance = advance_migration(backend, state, targets, &config, &mut rng)
         .map_err(|e| anyhow!("Error advancing migration: {:?}", e))?;

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -5224,6 +5224,55 @@ mod next_due_transfer_tests {
         }
     }
 
+    /// A reported rejection the wallet cannot yet explain WITHHOLDS everything: the node saw chain
+    /// state below a tip this wallet has not scanned to, so the answer is "sync, then ask again"
+    /// rather than the broadcast that was otherwise due. Nothing is marked — the report is
+    /// testimony, and this step is what the engine offers while it stands.
+    #[test]
+    fn an_unadjudicable_broadcast_failure_report_withholds_every_step() {
+        let mut st = make_state(
+            MigrationStatus::InProgress,
+            vec![transfer(7, MigrationTxState::Proved, 1000, 0)],
+        );
+        assert_eq!(
+            step_at(&st, 995, 1001),
+            (STEP_BROADCAST, 7),
+            "precondition: without a report this transfer is due for broadcast"
+        );
+
+        // The node reported a tip well above what this wallet has scanned, so its rejection
+        // cannot be checked against anything yet.
+        st.report_broadcast_failure(
+            MigrationTransferId::new(7),
+            BlockHeight::from_u32(995 + 200),
+        );
+
+        assert_eq!(
+            step_at(&st, 995, 1001),
+            (STEP_REEVALUATE, -1),
+            "a standing report outranks the due broadcast: sync to the reported tip first"
+        );
+    }
+
+    /// Once the wallet HAS scanned past the reported tip, the same report is adjudicated rather
+    /// than obeyed. Against a chain showing nothing wrong it is cleared and the broadcast
+    /// re-offered in the same call — which is what makes a wrong or stale node verdict
+    /// self-healing, and why a consumer re-reports freely instead of debouncing.
+    #[test]
+    fn an_adjudicable_report_clears_and_the_broadcast_is_reoffered() {
+        let mut st = make_state(
+            MigrationStatus::InProgress,
+            vec![transfer(7, MigrationTxState::Proved, 1000, 0)],
+        );
+        st.report_broadcast_failure(MigrationTransferId::new(7), BlockHeight::from_u32(995 - 5));
+
+        assert_eq!(
+            step_at(&st, 995, 1001),
+            (STEP_BROADCAST, 7),
+            "the wallet has scanned past the reported tip and sees no obstruction"
+        );
+    }
+
     #[test]
     fn broadcast_due_at_estimated_but_not_scanned_returns_broadcast() {
         // proved transfer scheduled at 1000; scanned tip behind (target 995), estimated at/after 1000.

--- a/backend-lib/src/main/rust/migration_engine.rs
+++ b/backend-lib/src/main/rust/migration_engine.rs
@@ -30,6 +30,7 @@ use zcash_client_backend::keys::UnifiedSpendingKey;
 use zcash_client_backend::proposal::Proposal;
 use zcash_client_sqlite::AccountUuid;
 use zcash_protocol::ShieldedPool;
+use zcash_protocol::TxId;
 use zcash_protocol::consensus::{BlockHeight, Network, Parameters};
 use zcash_protocol::value::Zatoshis;
 
@@ -42,7 +43,6 @@ use zcash_pool_migration::engine::{
 };
 use zcash_pool_migration::satisfiability::{ReorgSettleDepth, StepSatisfiability};
 use zcash_pool_migration::scheduling::SchedulingParams;
-use zcash_protocol::TxId;
 
 use crate::migration::Wallet;
 
@@ -245,10 +245,10 @@ where
             .map_err(|e| anyhow::anyhow!("reading persisted migration failed: {e:?}"))
     }
 
-    /// Delegated wholesale. The satisfiability oracle answers per cached spend nullifier from the
-    /// wallet's own Orchard note and note-spend tables, bounded by the fully-scanned height; the
-    /// inner store is the thing that owns those tables, and answering here from anything else would
-    /// break the one-view consistency `mined_height` is required to share with it.
+    /// Delegated wholesale to the `zcash_client_sqlite` store, which answers the oracle's
+    /// mechanical questions (per-nullifier spend observations, expiry, anchor survival) from the
+    /// wallet's own scan data. Nothing about the answer is this adapter's to decide: the engine
+    /// adjudicates, and a wallet-side verdict is exactly what the satisfiability design removes.
     fn check_step_satisfiability(
         &self,
         tx: &MigrationTransaction,
@@ -259,6 +259,10 @@ where
             .map_err(|e| anyhow::anyhow!("checking migration step satisfiability failed: {e:?}"))
     }
 
+    /// Likewise delegated: the store answers from scan data, withholding a height it has not
+    /// scanned to. This is the roll-forward half of chain-derived state, and answering it is what
+    /// lets `advance_migration` promote a broadcast transaction to `Mined` by itself — which is
+    /// why this file's JNI layer no longer observes minedness by hand.
     fn mined_height(&self, txid: TxId) -> Result<Option<BlockHeight>, Self::Error> {
         self.store.mined_height(txid).map_err(|e| {
             anyhow::anyhow!("reading migration transaction mined height failed: {e:?}")

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
@@ -216,6 +216,13 @@ data class MigrationTransferState(
     val action: MigrationNextAction? = null,
     /** Why a waiting transaction is not yet actionable, or null when none/ready. */
     val blocker: MigrationBlocker? = null,
+    /**
+     * Why the engine marked this transaction as one that can never execute, or null when it holds
+     * no such mark. Independent of [blocker]: the mark carries the cause and the blocker carries
+     * no payload, so a marked transaction can report a higher-precedence blocker and still answer
+     * here.
+     */
+    val unsatisfiableKind: MigrationUnsatisfiableKind? = null,
     /** The engine-persisted crossing value in zatoshi; null for preparations. */
     val amountZatoshi: Long? = null,
     /** Preparation layer/index within the note-split tree; null for transfers. */
@@ -291,6 +298,28 @@ enum class MigrationBlocker {
      * migration-level replan — more syncing can never help.
      */
     UNSATISFIABLE,
+}
+
+/**
+ * Why the engine marked a migration transaction as one that can never execute. The mark is
+ * evidence-stamped against scanned chain data, so it is cleared exactly by a reorg that removes
+ * the evidence — and by the transaction mining, which outranks any prior judgment.
+ */
+enum class MigrationUnsatisfiableKind {
+    /** The wallet saw this transaction's inputs spent: their nullifiers appeared in mined blocks. */
+    INPUTS_SPENT,
+
+    /** Its inputs' creating transaction can never mine, so those inputs will never exist. */
+    INPUTS_INVALIDATED,
+
+    /** It is broadcast but unmined, and a settled reorg removed the anchor it was proven against. */
+    ANCHOR_INVALIDATED,
+
+    /** Dead only through the dependency closure — its own inputs are intact. */
+    INHERITED,
+
+    /** A cause added upstream that this SDK version does not name yet; treat as unsatisfiable. */
+    OTHER,
 }
 
 /**

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
@@ -27,6 +27,7 @@ import cash.z.ecc.android.sdk.MigrationSummary
 import cash.z.ecc.android.sdk.MigrationSyncWakeup
 import cash.z.ecc.android.sdk.MigrationTransferState
 import cash.z.ecc.android.sdk.MigrationTransferStates
+import cash.z.ecc.android.sdk.MigrationUnsatisfiableKind
 import cash.z.ecc.android.sdk.NetworkPrivacyOptions
 import cash.z.ecc.android.sdk.NoteSplitProposal
 import cash.z.ecc.android.sdk.OrchardMigrationSdk
@@ -1638,6 +1639,17 @@ private fun JniMigrationTransferState.toPublic(): MigrationTransferState =
                 8 -> MigrationBlocker.AWAITING_REEVALUATION
                 9 -> MigrationBlocker.UNSATISFIABLE
                 else -> null
+            },
+        unsatisfiableKind =
+            when (unsatisfiableKind) {
+                1 -> MigrationUnsatisfiableKind.INPUTS_SPENT
+                2 -> MigrationUnsatisfiableKind.INPUTS_INVALIDATED
+                3 -> MigrationUnsatisfiableKind.ANCHOR_INVALIDATED
+                4 -> MigrationUnsatisfiableKind.INHERITED
+                // Any further cause the engine adds still means "can never execute"; reading it as
+                // "not marked" would be the one wrong answer.
+                0 -> null
+                else -> MigrationUnsatisfiableKind.OTHER
             },
         amountZatoshi = amountZatoshi.takeIf { it >= 0 },
         prepLayer = prepLayer.takeIf { it >= 0 },


### PR DESCRIPTION
Closes #2119. Resolves MOB-1627

Adopts [zcash/librustzcash#2871](https://github.com/zcash/librustzcash/pull/2871), which replaces
the consumer-diagnoses invalidation surface with an engine-side satisfiability oracle and moves
step selection behind a public drive API.

Pinned to `d5529776cd095fce23b40cc23ada189014e927ed` rather than a branch: a hash pin fails loudly
if the PR is rebased, which is what we want while it is under review. Re-pin to crates.io at the
first release containing it. `zcash_pool_migration` moves rc.3 → rc.5.

## The division of labour

The engine now discovers most transaction death itself, from the wallet's own scan data, through
`PoolMigrationRead::check_step_satisfiability`. `zcash_client_sqlite` implements that, so both new
trait methods here are pure delegations — no wallet-side verdict is formed anywhere in this SDK,
which is precisely what the design removes.

What remains ours is the one thing only an app can observe: a node's rejection.

## Commits

**`Adopt the zcash_pool_migration satisfiability drive API`** — the pin, the adapter delegations,
and the Rust drive loop.

`MigrationState::next_step` and `next_broadcastable` are no longer public, so step selection goes
through `satisfiability::advance_migration`. That is the right shape rather than an imposition:
`DuenessTargets` subsumes this branch's own two-tip work (81b8b481, 46eb4119) exactly — it carries
the scanned frontier and the estimated tip as separate targets, anchors every persisted or
destructive judgment to the scanned one, and clamps `effective >= scanned` so a lagging estimate
cannot withhold work the chain data already justifies.

Two manual chain observations are removed as obviated. `read_reconciled` walked every broadcast
transaction, asked `get_tx_height`, and called `mark_mined`; `advance_migration` now asks
`mined_height` about every in-flight transaction it sweeps, so minedness is chain-derived, with the
discipline that a promotion cannot outlive a rollback of the block justifying it. The submit-crash
probe keeps its `mark_broadcast` — the engine only sweeps rows it knows were broadcast, so that
observation is still genuinely the consumer's — but drops the `mark_mined` that followed it.

`any_overdue` becomes the engine's own sync gate (some status `ready` with `NextAction::Broadcast`)
rather than a restated conjunction, so the kernel's protective withholds apply automatically.

**`Surface the satisfiability capabilities through JNI and Kotlin`** — the consumer surface.

- `reportBroadcastFailure(transferId, observedTip)` records that a node rejected a submission. It is
  testimony, not a verdict: no reason is stored and nothing is marked, because the engine never
  trusts a node's stated reason and every mark it does write rests on chain state this wallet has
  scanned. `observedTip` is the **node's** height — an app has one even when its wallet is far
  behind, because it reached the network in order to broadcast at all.
- `markSuperseded()` answers `Replan`, ending a plan replanned away with a terminal status the
  planning flow's commit guard accepts.
- `MigrationAdvanceStep.Reevaluate` / `.Replan`, the three new blockers, and `unsatisfiableKind`
  beside them. The kind is its own field rather than a blocker payload because the mark is
  orthogonal to the blocker in both directions. An upstream cause this boundary does not name yet
  maps to `OTHER`, never to "not marked".

**`Pin the broadcast-failure report's two outcomes through the drive path`** — tests.

## Two things worth reviewer attention

**The late-dependency veto survives, and had to.** I checked whether the oracle subsumes it: it does
not. For a transfer whose dependency mined past its drawn anchor boundary, the funding note is
unspent and known, so `check_step_satisfiability` correctly answers `Satisfiable` — it asks about
nullifiers, not about anchor ordering. Dropping the guard would reinstate the wedge it was written
for. It is now a post-filter on the engine's answer. Because the engine exhausts every due broadcast
before offering any prove, a vetoed prove implies no broadcast work remains, so the fallback only
re-runs the prove and rebuild queues — and needs no explicit exclusion, since `is_prove_ready` *is*
the guard.

**`recordTransferResult` tags 2|3 are deliberately unchanged.** `TransferResult.InvalidNote` and
`.Expired` still write the invalidation side table and flip the migration to `Failed`. That is
structurally the pattern this PR replaces, and `reportBroadcastFailure` now exists to do it
properly — but re-routing those tags turns `RequiresAttention` into a driving `Reevaluate` state,
which the consuming app's recovery UI depends on, and `observedTip` is not plumbed to that call. It
is a cross-repo product decision, not part of the mechanical adoption, so it is left as follow-up.
Note for whoever takes it up: tag 1 (`NetworkError`) must stay a no-op — a Tor or gRPC failure is
not a node rejection, the node never saw the transaction.

One behavioural note that is *not* a public change: the engine dispatches every due broadcast before
any proving work, so proves and broadcasts interleave where the raw ordering used to batch them. The
state-machine trace expectations move accordingly. This SDK's own `nextStep` already consulted the
broadcast queue first, so nothing observable through the JNI surface changes.

## Verification

`git rebase --exec` confirms every commit builds **and** tests clean on its own, not just the tip.
At the tip, `cargo check --all-targets` exits 0 with zero warnings at default, `slipstream`, and
`--all-features`; 62 Rust tests pass; `:sdk-lib:compileDebugUnitTestKotlin` and
`:sdk-lib:testDebugUnitTest` both succeed.

---
*Opened with Claude Code assistance.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
