### PR TITLE
fix: repair the sdk-lib unit test call sites the 2.7.x merge broke

### DIFF
--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/SynchronizerWalletInitializationTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/SynchronizerWalletInitializationTest.kt
@@ -261,7 +261,8 @@ class SynchronizerWalletInitializationTest {
                 hash = "hash-$height",
                 time = height.toInt(),
                 saplingTree = "sapling-tree-$height",
-                orchardTree = "orchard-tree-$height"
+                orchardTree = "orchard-tree-$height",
+                ironwoodTree = "ironwood-tree-$height"
             )
 
         fun <T> failure(): Response.Failure<T> =

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessorTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessorTest.kt
@@ -18,6 +18,7 @@ import cash.z.ecc.android.sdk.model.SdkFlags
 import cash.z.ecc.android.sdk.model.TransactionSubmitResult
 import cash.z.ecc.android.sdk.model.Zatoshi
 import cash.z.ecc.android.sdk.model.ZcashNetwork
+import cash.z.ecc.android.sdk.model.Zip318Kind
 import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
@@ -251,7 +252,11 @@ class CompactBlockProcessorTest {
                 memoCount = 0,
                 blockTimeEpochSeconds = null,
                 isShielding = false,
-                isExpiredUnmined = false
+                isExpiredUnmined = false,
+                spentNoteCount = 1,
+                poolCrossingValue = null,
+                isTrusted = false,
+                zip318Kind = Zip318Kind.NOT_CLASSIFIED
             )
 
         private fun encodedTransaction(txId: FirstClassByteArray) =


### PR DESCRIPTION
`maint/v2.8.x` does not compile its own unit tests at its tip
(`01d89122`). `:sdk-lib:compileBenchmarkUnitTestKotlin` fails on two call
sites:

- `CompactBlockProcessorTest.kt:237` builds `DbTransactionOverview`
  without `spentNoteCount`, `poolCrossingValue`, `isTrusted` and
  `zip318Kind`.
- `SynchronizerWalletInitializationTest.kt:259` calls
  `TreeStateUnsafe.fromParts` without `ironwoodTree`.

All five parameters are non-defaulted and all five already exist on this
branch.

### How it landed

The parameters arrived on `maint/v2.7.x`. Both test files are 2.8.x-only
— `SynchronizerWalletInitializationTest` does not exist on 2.7.x, and
2.7.x's `CompactBlockProcessorTest` never mentions
`DbTransactionOverview` — so the merge forward in #2123 brought the new
required parameters in with no file touched on both sides for git to
conflict on. A clean merge, a broken build.

The `Pull Request` workflow never ran on #2123; its head commit carries
only `CodeQL`, `Analyze (rust)` and `Analyze (actions)`. The break was
therefore invisible until #2124 opened against the same base, where it
shows up as a failing `test_android_modules_unit`
([run](https://github.com/zcash/zcash-android-wallet-sdk/actions/runs/30842420380/job/91782507522)).
This is the failure mode AGENTS.md's historical note describes.

### Choices in the fixture values

`spentNoteCount = 1` matches the fixture's `isSentTransaction = true` /
`sentNoteCount = 1`. `ironwoodTree` gets a populated value rather than
`null`, following its sibling fields, so the field travels through the
protobuf round trip these tests assert on — `null` would compile but
would leave the field the 2.7.x change was about untested.

No CHANGELOG entry: this is test-only, with no consumer-visible change.

### Verification

`make test-unit` (the command the failing job runs) and
`./scripts/ci-local.sh fast` both pass on this branch.

### Follow-up, not in this PR

#2124 needs this merged in or a rerun once it lands. Worth a look at why
`pull-request.yml` did not run on #2123 — merge-forward PRs skipping the
build checks is how this reached a maintenance branch in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)