### PR TITLE
feat(slipstream): deferred preparation with DbReady read phase

### DIFF
--- a/sdk-lib/src/main/java/com/zodl/slipstream/SlipstreamSyncException.kt
+++ b/sdk-lib/src/main/java/com/zodl/slipstream/SlipstreamSyncException.kt
@@ -10,3 +10,20 @@ package com.zodl.slipstream
 class SlipstreamSyncException(
     val chainTip: Long
 ) : RuntimeException("Slipstream sync failed (state=2, chainTip=$chainTip)")
+
+/**
+ * Thrown by every engine- or database-backed [SlipstreamSynchronizer] member that was called while
+ * the synchronizer's deferred preparation (`Companion.new`'s heavy tail - anchor resolution, data-DB
+ * provisioning, `engine.open`/`start`) had already failed, or while it was cancelled by
+ * [SlipstreamSynchronizer.close]. Callers that arrive while preparation is still running suspend
+ * until it settles instead of seeing this.
+ *
+ * [cause] is the preparation failure when there was one, and `null` when preparation never
+ * completed because the synchronizer was closed underneath it.
+ */
+class SlipstreamNotReadyException(
+    cause: Throwable?
+) : IllegalStateException(
+        "Slipstream synchronizer preparation did not complete; this instance is not usable",
+        cause
+    )

--- a/sdk-lib/src/main/java/com/zodl/slipstream/SlipstreamSynchronizer.kt
+++ b/sdk-lib/src/main/java/com/zodl/slipstream/SlipstreamSynchronizer.kt
@@ -40,6 +40,7 @@ import cash.z.ecc.android.sdk.internal.model.LazyTorClient
 import cash.z.ecc.android.sdk.internal.model.TorClient
 import cash.z.ecc.android.sdk.internal.model.TorDormantMode
 import cash.z.ecc.android.sdk.internal.model.TorHttp
+import cash.z.ecc.android.sdk.internal.model.TreeState
 import cash.z.ecc.android.sdk.internal.transaction.submitTransaction
 import cash.z.ecc.android.sdk.model.Account
 import cash.z.ecc.android.sdk.model.AccountCreateSetup
@@ -79,9 +80,9 @@ import co.electriccoin.lightwallet.client.ServiceMode
 import co.electriccoin.lightwallet.client.model.BlockHeightUnsafe
 import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
 import co.electriccoin.lightwallet.client.model.Response
-import com.zodl.slipstream.SlipstreamSynchronizer.Companion.newLocked
 import com.zodl.slipstream.internal.DataDbPath
 import com.zodl.slipstream.internal.InstanceGuard
+import com.zodl.slipstream.internal.PrepareInputs
 import com.zodl.slipstream.internal.SlipstreamEngine
 import com.zodl.slipstream.internal.SlipstreamKey
 import com.zodl.slipstream.internal.db.SlipstreamTransactionReader
@@ -104,33 +105,43 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.transformWhile
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
 
 /**
@@ -143,9 +154,54 @@ import kotlin.time.Duration
  */
 private data class WalletProvisioningPlan(
     val startBirthday: BlockHeight,
-    val treeState: ByteArray,
+    val treeState: TreeState,
     val recoverUntil: Long?
 )
+
+/**
+ * The deferred-preparation lifecycle of one [SlipstreamSynchronizer] instance (see
+ * [SlipstreamSynchronizer.Companion.new]'s KDoc for why preparation is deferred at all).
+ *
+ * Linear order: [Preparing] -> [DbReady] -> [Ready], with [Failed] and [Closed] reachable from
+ * either of the first two. [DbReady] is the iOS twin's "truthful from open" point - `Initializer`
+ * migrates the data DB BEFORE it resolves the network anchor - and exists so read-only surfaces
+ * can be served from the wallet database while the tail's anchor, `engine.open` and `engine.start`
+ * are all still outstanding.
+ *
+ * Carried in a `MutableStateFlow` rather than a `CompletableDeferred` because all five states must
+ * stay distinguishable: [Closed] is not a failure (a cancelled `Deferred` would throw
+ * `CancellationException` into awaiters that were never themselves cancelled), [Preparing] must be
+ * probeable synchronously (`syncBurst` runs under a worker's time budget and must never block on
+ * it), and every gated caller needs its own fresh wrapper exception rather than a shared instance.
+ */
+private sealed interface PrepareState {
+    /** The preparation job is still running; gated callers suspend. */
+    data object Preparing : PrepareState
+
+    /**
+     * `initDataDb` has returned, so the wallet database's schema is current and every read-only
+     * surface can be served straight from it. Writes and engine-backed members keep suspending -
+     * the anchor is unresolved, so [SlipstreamSynchronizer.latestBirthdayHeight] is still
+     * provisional and the engine handle does not exist yet.
+     */
+    data object DbReady : PrepareState
+
+    /** Preparation completed; the instance behaves exactly as a fully-constructed one always did. */
+    data object Ready : PrepareState
+
+    /**
+     * Preparation threw; gated callers fail with [SlipstreamNotReadyException] carrying [cause].
+     * Terminal for the relaxed read-only surfaces too, not just for writes: an `ExistingWallet`
+     * tail resolves no anchor at all, so a failure there IS an `initDataDb` failure and the
+     * database is unusable, and a failed restore leaves an empty database with nothing to read.
+     */
+    data class Failed(
+        val cause: Throwable
+    ) : PrepareState
+
+    /** [SlipstreamSynchronizer.close] ran before preparation finished; gated callers fail without a cause. */
+    data object Closed : PrepareState
+}
 
 /**
  * `SlipstreamSynchronizer : CloseableSynchronizer` - the drop-in replacement for `SdkSynchronizer`
@@ -156,6 +212,14 @@ private data class WalletProvisioningPlan(
  * Two single-threaded lanes throughout: all [SlipstreamEngine] calls serialize on
  * `slipstream-io`; all [Backend]/`RustBackend` calls serialize on `sdk-lib`'s own `zc-io`.
  * Cross-lane DB safety is WAL + `busy_timeout`, never thread exclusion.
+ *
+ * Construction is cheap and preparation is deferred (the iOS twin's `prepare()` split, mirrored
+ * behind the unchanged Android API - see [Companion.new]). An instance built with a non-null
+ * [prepareInputs] starts in [PrepareState.Preparing] with `status == INITIALIZING`, and preparation
+ * failures surface through [onSetupErrorHandler] rather than out of [Companion.new]. Members await
+ * one of two gates: read-only, database-backed ones await [PrepareState.DbReady] - published as
+ * soon as the tail's `initDataDb` returns, before the network anchor - while writes and every
+ * engine-backed member await [PrepareState.Ready].
  */
 class SlipstreamSynchronizer internal constructor(
     private val context: Context,
@@ -178,10 +242,19 @@ class SlipstreamSynchronizer internal constructor(
     private val broadcasterImpl: SlipstreamBroadcaster,
     private val resubmissionTicker: ResubmissionTicker,
     private var startBirthday: BlockHeight,
+    /** `null` means "already prepared" - the instance is [PrepareState.Ready] from the first line of init. */
+    private val prepareInputs: PrepareInputs? = null,
 ) : CloseableSynchronizer {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
-    private val accountsBus = MutableSharedFlow<Unit>(replay = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    /**
+     * Bumped by every writer of the `accounts` table - the preparation tail's `createAccount`,
+     * [importAccountByUfvk], [deleteAccount] - so [accountsFlow] re-reads. A `MutableStateFlow`
+     * rather than a replaying `MutableSharedFlow` because a state flow replays its current value to
+     * a fresh subscriber on its own, which drops [accountsFlow]'s `onStart` primer and with it the
+     * duplicate first fetch that primer caused.
+     */
+    private val accountsVersion = MutableStateFlow(0)
     private val refreshExchangeRateTrigger = MutableSharedFlow<Unit>()
     private var lastExchangeRateValue = ObserveFiatCurrencyResult()
 
@@ -190,6 +263,28 @@ class SlipstreamSynchronizer internal constructor(
 
     /** True while a migration sync-block is pausing this synchronizer (see [pause]/[resume]). */
     private val migrationPaused = MutableStateFlow(false)
+
+    /**
+     * The deferred-preparation gate every engine- or database-backed member awaits (see
+     * [awaitReady]/[awaitPrepared]). Declared before [status] because that combine reads it eagerly.
+     */
+    private val prepareState =
+        MutableStateFlow(
+            if (prepareInputs == null) {
+                PrepareState.Ready
+            } else {
+                PrepareState.Preparing
+            }
+        )
+
+    /** The job running [runPrepare]; cancelled and joined as [close]'s first shutdown step. */
+    private var prepareJob: Job? = null
+
+    /**
+     * The preparation failure, latched so it can be replayed to an [onSetupErrorHandler] that is
+     * attached after the failure already happened (see that property's KDoc).
+     */
+    private val latchedSetupError = AtomicReference<Throwable?>(null)
 
     /*
      * Last lifecycle signal seen via [onForeground]/[onBackground]; [syncBurst]'s restore reads it
@@ -206,19 +301,40 @@ class SlipstreamSynchronizer internal constructor(
      */
     private val burstActive = AtomicBoolean(false)
 
+    /**
+     * The `paused -> SYNCED` mask applies only once preparation is [PrepareState.Ready]: [pause]
+     * sets [migrationPaused] regardless of readiness, so an unmasked combine would report a failed
+     * preparation (which forces `DISCONNECTED`) as SYNCED for as long as the pause lasts.
+     */
     override val status: Flow<Synchronizer.Status> =
-        combine(engine.status, migrationPaused) { status, paused ->
-            if (paused) Synchronizer.Status.SYNCED else status
+        combine(engine.status, migrationPaused, prepareState) { status, paused, prepare ->
+            if (paused && prepare is PrepareState.Ready) Synchronizer.Status.SYNCED else status
         }
     override val progress: Flow<PercentDecimal> = engine.progress
     override val areFundsSpendable: Flow<Boolean> = engine.areFundsSpendable
     override val networkHeight = engine.networkHeight
     override val fullyScannedHeight = engine.fullyScannedHeight
     override val walletBalances = engine.walletBalances
-    override val allTransactions: Flow<List<TransactionOverview>> = transactionsController.allTransactions
+
+    /**
+     * Served from [PrepareState.DbReady] onwards: the rows this reads live in
+     * `zcash_client_sqlite`'s own views, which `initDataDb` creates, so an existing wallet's history
+     * renders while the tail's network anchor is still outstanding. The engine-created `reconcile`
+     * view is only joined while `isRecovering` is true, which it cannot be before `engine.open`.
+     *
+     * Gated non-throwingly, and terminated by [untilPreparationFails] rather than left idling: the
+     * app collects this in an eager `stateIn`, so a preparation that fails AFTER this flow was
+     * already subscribed must complete it rather than kill the collector or strand it forever on a
+     * requery tick that will never come.
+     */
+    override val allTransactions: Flow<List<TransactionOverview>> =
+        flow {
+            if (dbReadyReached()) emitAll(transactionsController.allTransactions.untilPreparationFails())
+        }
 
     /** Degraded on purpose - `overallSyncRange`/`firstUnenhancedHeight` describe processor internals that don't exist under this engine. */
-    override val processorInfo: Flow<CompactBlockProcessor.ProcessorInfo> = engine.networkHeight.map(::toProcessorInfo)
+    override val processorInfo: Flow<CompactBlockProcessor.ProcessorInfo> =
+        engine.networkHeight.map(::toProcessorInfo)
 
     @OptIn(ExperimentalCoroutinesApi::class)
     override val exchangeRateUsd: StateFlow<ObserveFiatCurrencyResult> =
@@ -263,7 +379,13 @@ class SlipstreamSynchronizer internal constructor(
                 ?.takeIf { it > 0 }
                 ?.let(BlockHeight::new)
 
-    override val latestBirthdayHeight: BlockHeight?
+    /**
+     * While preparation is still running this reports a provisional value (the requested birthday,
+     * or sapling activation when there is none); the resolved anchor overwrites it before
+     * preparation publishes [PrepareState.Ready]. [rewindToNearestHeight]/[rewindToHeight] coerce
+     * against the resolved value precisely because a caller may have read the provisional one.
+     */
+    override val latestBirthdayHeight: BlockHeight
         get() = startBirthday
 
     /**
@@ -277,8 +399,41 @@ class SlipstreamSynchronizer internal constructor(
 
     override val broadcaster: Broadcaster get() = broadcasterImpl
 
+    /**
+     * Leads with `null` ("not loaded yet") so a collector attached during preparation gets an
+     * immediate emission, then switches to the account rows from [PrepareState.DbReady] onwards -
+     * `getAccounts` reads a table `initDataDb` has by then created.
+     *
+     * Empty reads are filtered out while [isAccountCreationPending] holds, because to the host `null`
+     * means "still loading" while an empty list means "loaded, and this wallet has no accounts". A
+     * restore reaches [PrepareState.DbReady] before the tail's `createAccount` - that call needs the
+     * network anchor's `recoverUntil` - so the `accounts` table is briefly, and untruthfully, empty;
+     * swallowing that read leaves the collector on the leading `null` until `createAccount` bumps
+     * [accountsVersion] and the real rows flow through. Non-empty lists always pass, so an existing
+     * wallet's rows still surface at [PrepareState.DbReady] unchanged, and an empty list still passes
+     * once no creation can happen any more (no [PrepareInputs.setup], or preparation already
+     * [PrepareState.Ready]).
+     *
+     * Gated non-throwingly for the same reason as [allTransactions]: a failed preparation completes
+     * the flow after that leading `null` instead of cancelling the app's eager collector - including
+     * a failure that lands while an empty read is being suppressed, which simply leaves the leading
+     * `null` as the only emission. [untilPreparationFails] covers a failure landing after this flow
+     * subscribed; the [catch] then covers the narrow race where [getAccounts]' own gate observes the
+     * failure first.
+     */
     override val accountsFlow: Flow<List<Account>?> =
-        accountsBus.onStart { emit(Unit) }.map { getAccounts() }
+        flow {
+            emit(null)
+            if (dbReadyReached()) {
+                emitAll(
+                    accountsVersion
+                        .untilPreparationFails()
+                        .map { getAccounts() }
+                        .filter { accounts -> accounts.isNotEmpty() || !isAccountCreationPending() }
+                        .catch { if (it !is SlipstreamNotReadyException) throw it }
+                )
+            }
+        }
 
     /** R62-R64: forwarded straight to the engine, which owns the tick and the error-episode state (Phase 4 T10). */
     override var onCriticalErrorHandler: ((Throwable?) -> Boolean)?
@@ -300,11 +455,23 @@ class SlipstreamSynchronizer internal constructor(
         }
 
     /**
-     * Settable for interface completeness, but never invoked: [Companion.new] throws directly on
-     * construction-time failures rather than returning a half-built instance to call this on.
-     * Server-mismatch and runtime setup problems surface through [onProcessorErrorHandler] instead.
+     * Invoked with the failure of the deferred preparation tail ([Companion.new]'s heavy work, which
+     * no longer throws out of `new()`). Latch-and-replay: the failure is retained, so a handler
+     * attached after it already happened is invoked immediately on assignment - the host attaches
+     * its handlers only once the synchronizer has been emitted, which is routinely later than the
+     * failure. Assigning `null` (the host's teardown) never replays anything. A handler that is
+     * detached and re-attached is therefore invoked once per attachment; that repeat is benign,
+     * since the host maps it onto the same latched error state.
+     *
+     * Server-mismatch and runtime sync problems still surface through [onProcessorErrorHandler].
      */
     override var onSetupErrorHandler: ((Throwable?) -> Boolean)? = null
+        set(value) {
+            field = value
+            if (value != null) {
+                latchedSetupError.get()?.let { value.invoke(it) }
+            }
+        }
 
     // Settable, but never invoked - the engine owns reorg recovery internally; there is no host-visible chain-error event.
     override var onChainErrorHandler: ((BlockHeight, BlockHeight) -> Any)? = null
@@ -317,20 +484,315 @@ class SlipstreamSynchronizer internal constructor(
      */
     init {
         engine.onTick =
-            { snap -> resubmissionTicker.onTick(engine.status.value == Synchronizer.Status.SYNCED, snap.chainTip) }
-        engine.startPolling()
+            { snap ->
+                resubmissionTicker.onTick(
+                    isSynced = engine.status.value == Synchronizer.Status.SYNCED,
+                    chainTip = snap.chainTip
+                )
+            }
+        val inputs = prepareInputs
+        if (inputs == null) {
+            engine.startPolling()
+        } else {
+            prepareJob = scope.launch { runPrepare(inputs) }
+        }
     }
 
-    override suspend fun getAccounts(): List<Account> =
-        runCatchingCancellable { backend.getAccounts().map(Account::new) }
+    /**
+     * The single predicate behind [awaitReady]/[awaitPrepared]: preparation has run to completion,
+     * one way or another. [PrepareState.DbReady] is deliberately NOT settled here, so a write or an
+     * engine-backed call that arrives during the tail's network anchor still waits for the engine
+     * instead of failing against a handle that does not exist yet.
+     */
+    private suspend fun awaitSettled(): PrepareState =
+        prepareState.first {
+            it is PrepareState.Ready || it is PrepareState.Failed || it is PrepareState.Closed
+        }
+
+    /**
+     * Suspends until preparation settles.
+     *
+     * @throws SlipstreamNotReadyException when preparation failed or was cancelled by [close].
+     */
+    private suspend fun awaitReady() {
+        val settled = awaitSettled()
+        if (settled !is PrepareState.Ready) {
+            throw SlipstreamNotReadyException((settled as? PrepareState.Failed)?.cause)
+        }
+    }
+
+    /**
+     * The non-throwing twin of [awaitReady], for fire-and-forget lifecycle work: a
+     * settled-but-not-ready instance makes the caller a no-op instead of spamming
+     * [onCriticalErrorHandler].
+     *
+     * @return `true` when preparation succeeded.
+     */
+    private suspend fun awaitPrepared(): Boolean = awaitSettled() is PrepareState.Ready
+
+    /**
+     * The single predicate behind [awaitDbReady]/[dbReadyReached]: preparation has got at least as
+     * far as [PrepareState.DbReady], or has stopped short of it.
+     */
+    private suspend fun awaitDbSettled(): PrepareState =
+        prepareState.first { it !is PrepareState.Preparing }
+
+    /**
+     * The read-only gate: suspends only until the wallet database is usable, so an existing wallet
+     * serves its accounts, transactions and addresses as soon as `initDataDb`'s migrations are
+     * done - instead of behind the tail's network anchor, which on a cold Tor bootstrap during a
+     * restore is bounded in tens of seconds.
+     *
+     * @throws SlipstreamNotReadyException when preparation failed or was cancelled by [close].
+     */
+    private suspend fun awaitDbReady() {
+        val settled = awaitDbSettled()
+        if (settled is PrepareState.Failed || settled is PrepareState.Closed) {
+            throw SlipstreamNotReadyException((settled as? PrepareState.Failed)?.cause)
+        }
+    }
+
+    /**
+     * The non-throwing twin of [awaitDbReady], for the cold flows the host collects eagerly: an
+     * instance that never reached [PrepareState.DbReady] completes the flow instead of killing its
+     * collector.
+     *
+     * @return `true` when the wallet database is usable.
+     */
+    private suspend fun dbReadyReached(): Boolean =
+        awaitDbSettled().let { it is PrepareState.DbReady || it is PrepareState.Ready }
+
+    /**
+     * True while the preparation tail may still write this wallet's first account row: it does so
+     * only when it was given an [PrepareInputs.setup], and only after the network anchor resolves -
+     * well past [PrepareState.DbReady]. [accountsFlow] reads it to tell a database that is empty
+     * because the row is not written YET from one that is empty because there is nothing to read.
+     */
+    private fun isAccountCreationPending(): Boolean =
+        prepareInputs?.setup != null && prepareState.value !is PrepareState.Ready
+
+    /**
+     * Completes [this] - rather than letting it fail, or idle forever on a tick that will never
+     * come - as soon as preparation leaves [PrepareState.DbReady] for [PrepareState.Failed] or
+     * [PrepareState.Closed]. Both cold flows are subscribed from [PrepareState.DbReady] onwards, so
+     * unlike under the old all-or-nothing gate the tail can still fail underneath a live collector.
+     * The terminal transition is merged in as a `null` sentinel precisely so it COMPLETES the
+     * collector instead of cancelling it.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun <T : Any> Flow<T>.untilPreparationFails(): Flow<T> =
+        merge(
+            this,
+            prepareState
+                .filter { it is PrepareState.Failed || it is PrepareState.Closed }
+                .take(1)
+                .map { null }
+        ).transformWhile { value ->
+            if (value == null) {
+                false
+            } else {
+                emit(value)
+                true
+            }
+        }
+
+    /**
+     * Runs the deferred preparation tail and publishes its verdict. Every terminal transition is a
+     * compare-and-set against the two non-terminal states, never a plain assignment: [close] may
+     * write [PrepareState.Closed] concurrently and must win, so a teardown-induced throw can neither
+     * overwrite it nor paint a setup error over an ordinary shutdown.
+     *
+     * [CancellationException] is rethrown untouched - a cancelled preparation is [close]'s business,
+     * not a failure.
+     */
+    private suspend fun runPrepare(inputs: PrepareInputs) {
+        try {
+            withContext(Dispatchers.IO) { prepare(inputs) }
+            prepareState.update {
+                if (it is PrepareState.Preparing || it is PrepareState.DbReady) PrepareState.Ready else it
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (t: Throwable) {
+            Twig.error(t) { "Slipstream synchronizer preparation failed" }
+            val landedFailed =
+                prepareState.updateAndGet {
+                    if (it is PrepareState.Preparing || it is PrepareState.DbReady) PrepareState.Failed(
+                        t
+                    ) else it
+                } is PrepareState.Failed
+            if (landedFailed) {
+                /*
+                 * Safe to force: the engine writes `status` only from a tick, ticks no-op while the
+                 * handle is 0, and the poll loop is the tail's very last step - so nothing can be
+                 * racing this write. A failure after a successful `open` merely repeats what that
+                 * open's own tick already reported.
+                 */
+                engine.status.value = Synchronizer.Status.DISCONNECTED
+                latchedSetupError.set(t)
+                onSetupErrorHandler?.invoke(t)
+            }
+        }
+    }
+
+    /**
+     * The heavy tail [Companion.newLocked] used to run inline, reordered the way the iOS twin's
+     * `Initializer.initialize` already runs it - data-DB provisioning FIRST, network anchor second:
+     * fallback checkpoint -> `initDataDb` -> publish [PrepareState.DbReady] -> anchor resolution ->
+     * `createAccount` -> `engine.open` -> `engine.start` -> the poll loop's first start. Post-tail
+     * state is identical to what `new()` used to return; the reorder is safe because `initDataDb`
+     * consumes no anchor input, and the anchor's three derived facts are consumed only by the steps
+     * that follow it.
+     *
+     * Two consequences the reorder buys and costs:
+     * - every read-only surface is served from [PrepareState.DbReady], so an existing wallet
+     *   renders its accounts and history without waiting for a cold-Tor anchor fetch;
+     * - an anchor failure during a restore now leaves a migrated but account-less database file.
+     *   The next launch's retry is safe: `createAccount` is gated on [shouldCreateAccount]'s
+     *   `accountsAreEmpty`, which such a database still satisfies.
+     *
+     * WAL nuance for the [PrepareState.DbReady] window: on a FRESH database WAL mode is only
+     * established at [SlipstreamEngine.open], so reads served before it run against
+     * rollback-journal mode. `createAccount`'s millisecond-long commit is covered by the readers'
+     * 5 s `busy_timeout`, and [backend] reads serialize on the single-threaded `zc-io` dispatcher
+     * regardless.
+     *
+     * The final [SlipstreamEngine.startPolling] is skipped while [migrationPaused] holds, mirroring
+     * [onForeground]: a migration privacy pause that landed mid-preparation would otherwise get a
+     * stray polling tick, since [pause]'s own queued `stopPolling` block only runs once
+     * [PrepareState.Ready] is published.
+     */
+    private suspend fun prepare(inputs: PrepareInputs) {
+        val fallbackCheckpoint = inputs.fallbackCheckpointHeight()
+
+        /*
+         * Mirrors `DerivedDataDb.new`: unconditional [Backend.initDataDb], then
+         * [Backend.createAccount] gated on `setup != null && accounts.isEmpty()`.
+         */
+        when (backend.initDataDb(inputs.setup?.seed?.byteArray)) {
+            0 -> Unit
+            1 -> throw InitializeException.SeedRequired
+            2 -> throw InitializeException.SeedNotRelevant
+            -1 -> error("Rust backend only uses -1 as an error sentinel")
+            else -> error("Rust backend used a code that needs to be defined here")
+        }
+
+        /*
+         * Losing this compare-and-set means [close] already published [PrepareState.Closed]. Bail
+         * out before the anchor rather than after it: the anchor is a blocking, engine-bounded
+         * network call that close()'s `cancelAndJoin` would otherwise have to wait out for a result
+         * nothing will ever read.
+         */
+        val dbReady =
+            prepareState.updateAndGet { if (it is PrepareState.Preparing) PrepareState.DbReady else it }
+        if (dbReady !is PrepareState.DbReady) return
+
+        /*
+         * Truthful FROM DbReady, not merely from the engine's first tick: the account row and the
+         * balances the database already knows surface in the same phase, so an existing wallet never
+         * renders a hard zero while the anchor is still in flight. Best-effort by design - a
+         * never-scanned database answers null or throws ("Target height not available"), which
+         * simply leaves the balances null and the host on its shimmer, the correct restore
+         * behaviour. The first engine tick overwrites the seed wholesale, including the stale-tip
+         * masking [toAccountBalances] applies and this raw summary does not: totals are identical,
+         * only the spendable/pending split may shift at that tick.
+         */
+        runCatchingCancellable { inputs.dbWalletSummary() }
+            .getOrNull()
+            ?.let { engine.walletBalances.value = it.accountBalances }
+
+        val provisioning = resolveProvisioning(inputs, fallbackCheckpoint)
+        startBirthday = provisioning.startBirthday
+
+        if (shouldCreateAccount(
+                hasSetup = inputs.setup != null,
+                accountsAreEmpty = backend.getAccounts().isEmpty()
+            )
+        ) {
+            val accountSetup = requireNotNull(inputs.setup)
+            runCatchingCancellable {
+                backend.createAccount(
+                    accountName = accountSetup.accountName,
+                    keySource = accountSetup.keySource,
+                    seed = accountSetup.seed.byteArray,
+                    treeState = provisioning.treeState.encoded,
+                    recoverUntil = provisioning.recoverUntil
+                )
+            }.getOrElse { throw InitializeException.CreateAccountException(it) }
+            /* Releases [accountsFlow], which suppressed the empty reads of the whole DbReady window. */
+            accountsVersion.update { it + 1 }
+        }
+
+        engine.open(totalMemoryBytes = inputs.totalMemoryBytes)
+        /*
+         * `ufvk` stays non-null even though the account row already exists: `FFI_JNI_CONTRACT.md`
+         * section 3.5's `start(ufvk != null)` is a no-op when an account is already present.
+         */
+        engine.start(inputs.ufvk, provisioning.startBirthday.value)
+        if (!migrationPaused.value) engine.startPolling()
+    }
+
+    /** The `when(intent)` block of the original `newLocked`, verbatim but behind [PrepareInputs]' lambdas. */
+    private suspend fun resolveProvisioning(
+        inputs: PrepareInputs,
+        fallbackCheckpoint: Long
+    ): WalletProvisioningPlan =
+        when (val intent = resolveIntent(inputs.walletInitMode)) {
+            1 -> {
+                val requestedBirthday = requireNotNull(inputs.requestedBirthday)
+                val anchor =
+                    inputs.anchorSource(
+                        intent = intent,
+                        birthdayHeight = requestedBirthday.value,
+                        fallbackCheckpointHeight = fallbackCheckpoint
+                    )
+                WalletProvisioningPlan(
+                    startBirthday = BlockHeight.new(anchor.height),
+                    treeState = inputs.treeState(requestedBirthday),
+                    recoverUntil = anchor.height
+                )
+            }
+
+            0 -> {
+                val anchor =
+                    inputs.anchorSource(
+                        intent = intent,
+                        birthdayHeight = 0L,
+                        fallbackCheckpointHeight = fallbackCheckpoint
+                    )
+                WalletProvisioningPlan(
+                    startBirthday =
+                        anchor.height.takeIf { it > 0 }?.let(BlockHeight::new)
+                            ?: BlockHeight.new(fallbackCheckpoint),
+                    treeState = anchor.treestate?.let(::TreeState) ?: inputs.lastCheckpointTreeState(),
+                    recoverUntil = null
+                )
+            }
+
+            else -> {
+                WalletProvisioningPlan(
+                    startBirthday = inputs.requestedBirthday ?: BlockHeight.new(fallbackCheckpoint),
+                    treeState =
+                        inputs.treeState(
+                            inputs.requestedBirthday ?: network.saplingActivationHeight
+                        ),
+                    recoverUntil = null
+                )
+            }
+        }
+
+    override suspend fun getAccounts(): List<Account> {
+        awaitDbReady()
+        return runCatchingCancellable { backend.getAccounts().map(Account::new) }
             .onFailure { Twig.error(it) { "Get wallet accounts failed." } }
             .getOrElse { throw InitializeException.GetAccountsException(it) }
+    }
 
     /**
      * The keyless engine restart every stop-then-restart call site below runs from a
      * [NonCancellable] context, so the engine always comes back up even when the caller itself
      * was cancelled; a restart failure is logged rather than thrown, so it can never mask
-     * whatever outcome the caller was already returning or throwing. [operation] is a short,
+     * whatever outcome the caller was already returning or throwing. 'operation' is a short,
      * human-readable name for the log message only (e.g. "account import", "rewind").
      */
     /**
@@ -346,6 +808,7 @@ class SlipstreamSynchronizer internal constructor(
      */
     override suspend fun restartSyncSession(): Boolean {
         if (closed.get()) return false
+        if (!awaitPrepared()) return false
         engine.stop()
         restartEngineAfter("migration-plan commit (anchor-retention floor refresh)")
         return true
@@ -376,6 +839,7 @@ class SlipstreamSynchronizer internal constructor(
      * instead of risking a write racing the still-unwinding sync pass.
      */
     override suspend fun importAccountByUfvk(setup: AccountImportSetup): Account {
+        awaitReady()
         val fallbackCheckpoint = newestBundledCheckpointHeight(context, network)
         val anchor =
             withContext(Dispatchers.IO) {
@@ -391,7 +855,8 @@ class SlipstreamSynchronizer internal constructor(
                 )
             }
         val recoverUntil = anchor.height
-        val treeState = CheckpointTool.loadNearest(context, network, setup.birthday).treeState().encoded
+        val treeState =
+            CheckpointTool.loadNearest(context, network, setup.birthday).treeState().encoded
         val purpose = setup.purpose
 
         val quiescent = engine.stop()
@@ -400,7 +865,7 @@ class SlipstreamSynchronizer internal constructor(
             throw InitializeException.ImportAccountCheckpointsNotReadyException(
                 IllegalStateException(
                     "Slipstream engine did not quiesce before account import; refusing to import " +
-                        "to avoid racing the still-unwinding sync pass."
+                            "to avoid racing the still-unwinding sync pass."
                 )
             )
         }
@@ -428,11 +893,12 @@ class SlipstreamSynchronizer internal constructor(
             } finally {
                 restartEngineAfter("account import")
             }
-        accountsBus.tryEmit(Unit)
+        accountsVersion.update { it + 1 }
         return Account.new(jniAccount)
     }
 
-    override suspend fun getFastestServers(servers: List<LightWalletEndpoint>) = fastestServerFetcher(servers)
+    override suspend fun getFastestServers(servers: List<LightWalletEndpoint>) =
+        fastestServerFetcher(servers)
 
     override suspend fun getUnifiedAddress(account: Account): String =
         wrapGetAddress { backend.getCurrentAddress(account.accountUuid.value) }
@@ -440,7 +906,8 @@ class SlipstreamSynchronizer internal constructor(
     override suspend fun getCustomUnifiedAddress(
         account: Account,
         request: UnifiedAddressRequest
-    ): String = wrapGetAddress { backend.getNextAvailableAddress(account.accountUuid.value, request.flags) }
+    ): String =
+        wrapGetAddress { backend.getNextAvailableAddress(account.accountUuid.value, request.flags) }
 
     override suspend fun getSaplingAddress(account: Account): String =
         wrapGetAddress {
@@ -454,8 +921,21 @@ class SlipstreamSynchronizer internal constructor(
             requireNotNull(backend.getTransparentReceiver(ua)) { "No transparent receiver for this account's address" }
         }
 
-    private suspend fun wrapGetAddress(block: suspend () -> String): String =
-        runCatchingCancellable { block() }.getOrElse { throw RustLayerException.GetAddressException(it) }
+    /**
+     * The single readiness gate for all four address getters above; it sits OUTSIDE
+     * [runCatchingCancellable] so a [SlipstreamNotReadyException] propagates as itself rather than
+     * as a [RustLayerException.GetAddressException]. Relaxed to [awaitDbReady] - all four are pure
+     * reads of address rows `initDataDb` provisions; the reserving
+     * [getSingleUseTransparentAddress] is deliberately NOT one of them.
+     */
+    private suspend fun wrapGetAddress(block: suspend () -> String): String {
+        awaitDbReady()
+        return runCatchingCancellable { block() }.getOrElse {
+            throw RustLayerException.GetAddressException(
+                it
+            )
+        }
+    }
 
     override fun refreshExchangeRateUsd() {
         scope.launch { refreshExchangeRateTrigger.emit(Unit) }
@@ -466,57 +946,85 @@ class SlipstreamSynchronizer internal constructor(
         recipient: String,
         amount: Zatoshi,
         memo: String
-    ): Proposal = spendService.proposeTransfer(account, recipient, amount, memo)
+    ): Proposal {
+        awaitReady()
+        return spendService.proposeTransfer(account, recipient, amount, memo)
+    }
 
     override suspend fun proposeFulfillingPaymentUri(
         account: Account,
         uri: String
-    ): Proposal = spendService.proposeFulfillingPaymentUri(account, uri)
+    ): Proposal {
+        awaitReady()
+        return spendService.proposeFulfillingPaymentUri(account, uri)
+    }
 
     override suspend fun proposeShielding(
         account: Account,
         shieldingThreshold: Zatoshi,
         memo: String,
         transparentReceiver: String?
-    ): Proposal? = spendService.proposeShielding(account, shieldingThreshold, memo, transparentReceiver)
+    ): Proposal? {
+        awaitReady()
+        return spendService.proposeShielding(account, shieldingThreshold, memo, transparentReceiver)
+    }
 
-    override suspend fun proposeOrchardToIronwoodMigration(account: Account): Proposal =
-        spendService.proposeOrchardToIronwoodMigration(account)
+    override suspend fun proposeOrchardToIronwoodMigration(account: Account): Proposal {
+        awaitReady()
+        return spendService.proposeOrchardToIronwoodMigration(account)
+    }
 
     override suspend fun createProposedTransactions(
         proposal: Proposal,
         usk: UnifiedSpendingKey
-    ): Flow<TransactionSubmitResult> = spendService.createProposedTransactions(proposal, usk)
+    ): Flow<TransactionSubmitResult> {
+        awaitReady()
+        return spendService.createProposedTransactions(proposal, usk)
+    }
 
     override suspend fun createPcztFromProposal(
         accountUuid: AccountUuid,
         proposal: Proposal
-    ): Pczt =
-        runCatchingCancellable { spendService.createPcztFromProposal(accountUuid, proposal) }
+    ): Pczt {
+        awaitReady()
+        return runCatchingCancellable { spendService.createPcztFromProposal(accountUuid, proposal) }
             .getOrElse { throw PcztException.CreatePcztFromProposalException(it.message, it) }
+    }
 
-    override suspend fun redactPcztForSigner(pczt: Pczt): Pczt =
-        runCatchingCancellable { spendService.redactPcztForSigner(pczt) }
+    override suspend fun redactPcztForSigner(pczt: Pczt): Pczt {
+        awaitReady()
+        return runCatchingCancellable { spendService.redactPcztForSigner(pczt) }
             .getOrElse { throw PcztException.RedactPcztForSignerException(it.message, it) }
+    }
 
-    override suspend fun pcztRequiresSaplingProofs(pczt: Pczt): Boolean =
-        runCatchingCancellable { spendService.pcztRequiresSaplingProofs(pczt) }
+    override suspend fun pcztRequiresSaplingProofs(pczt: Pczt): Boolean {
+        awaitReady()
+        return runCatchingCancellable { spendService.pcztRequiresSaplingProofs(pczt) }
             .getOrElse { throw PcztException.PcztRequiresSaplingProofsException(it.message, it) }
+    }
 
-    override suspend fun addProofsToPczt(pczt: Pczt): Pczt =
-        runCatchingCancellable { spendService.addProofsToPczt(pczt) }
+    override suspend fun addProofsToPczt(pczt: Pczt): Pczt {
+        awaitReady()
+        return runCatchingCancellable { spendService.addProofsToPczt(pczt) }
             .getOrElse { throw PcztException.AddProofsToPcztException(it.message, it) }
+    }
 
     override suspend fun createTransactionFromPczt(
         pcztWithProofs: Pczt,
         pcztWithSignatures: Pczt
-    ): Flow<TransactionSubmitResult> = spendService.createTransactionFromPczt(pcztWithProofs, pcztWithSignatures)
+    ): Flow<TransactionSubmitResult> {
+        awaitReady()
+        return spendService.createTransactionFromPczt(pcztWithProofs, pcztWithSignatures)
+    }
 
-    override suspend fun isValidShieldedAddr(address: String): Boolean = backend.isValidSaplingAddr(address)
+    override suspend fun isValidShieldedAddr(address: String): Boolean =
+        backend.isValidSaplingAddr(address)
 
-    override suspend fun isValidTransparentAddr(address: String): Boolean = backend.isValidTransparentAddr(address)
+    override suspend fun isValidTransparentAddr(address: String): Boolean =
+        backend.isValidTransparentAddr(address)
 
-    override suspend fun isValidUnifiedAddr(address: String): Boolean = backend.isValidUnifiedAddr(address)
+    override suspend fun isValidUnifiedAddr(address: String): Boolean =
+        backend.isValidUnifiedAddr(address)
 
     override suspend fun isValidTexAddr(address: String): Boolean = backend.isValidTexAddr(address)
 
@@ -538,7 +1046,8 @@ class SlipstreamSynchronizer internal constructor(
      * Behavior-preserving beats silently-fixed - see `KOTLIN_ROSETTA.md` section 4.8.
      */
     override suspend fun validateConsensusBranch(): ConsensusMatchType {
-        val serviceMode = sdkFlags ifTor ServiceMode.Group("SlipstreamSynchronizer.validateConsensusBranch")
+        val serviceMode =
+            sdkFlags ifTor ServiceMode.Group("SlipstreamSynchronizer.validateConsensusBranch")
         val serverBranchId =
             runCatchingCancellable {
                 (walletClient.getServerInfo(serviceMode) as? Response.Success)?.result?.consensusBranchId
@@ -609,13 +1118,21 @@ class SlipstreamSynchronizer internal constructor(
                     }
                 }
             val sdkBranchId =
-                runCatchingCancellable { "%x".format(Locale.ROOT, backend.getBranchIdForHeight(currentChainTip.value)) }
+                runCatchingCancellable {
+                    "%x".format(
+                        Locale.ROOT,
+                        backend.getBranchIdForHeight(currentChainTip.value)
+                    )
+                }
                     .getOrElse { return ServerValidation.InValid(it) }
             return if (remoteInfo.consensusBranchId.equals(sdkBranchId, ignoreCase = true)) {
                 ServerValidation.Valid
             } else {
                 ServerValidation.InValid(
-                    CompactBlockProcessorException.MismatchedConsensusBranch(sdkBranchId, remoteInfo.consensusBranchId)
+                    CompactBlockProcessorException.MismatchedConsensusBranch(
+                        sdkBranchId,
+                        remoteInfo.consensusBranchId
+                    )
                 )
             }
         } finally {
@@ -623,13 +1140,17 @@ class SlipstreamSynchronizer internal constructor(
         }
     }
 
-    override suspend fun getTransparentBalance(tAddr: String): Zatoshi = spendService.getTransparentBalance(tAddr)
+    override suspend fun getTransparentBalance(tAddr: String): Zatoshi {
+        awaitDbReady()
+        return spendService.getTransparentBalance(tAddr)
+    }
 
     override suspend fun refreshUtxos(
         account: Account,
         since: BlockHeight
-    ): Int? =
-        runCatchingCancellable {
+    ): Int? {
+        awaitReady()
+        return runCatchingCancellable {
             var count = 0
             val tAddresses = backend.listTransparentReceivers(account.accountUuid.value)
             walletClient
@@ -652,6 +1173,7 @@ class SlipstreamSynchronizer internal constructor(
                 }
             count
         }.getOrNull()
+    }
 
     /**
      * The `engine.start(ufvk = null, ...)` restart below is keyless (`FFI_JNI_CONTRACT.md` section
@@ -659,11 +1181,17 @@ class SlipstreamSynchronizer internal constructor(
      * any restart runs. Restarted from a [NonCancellable] `finally` so the engine always comes back
      * up - even under cancellation - and a restart failure is logged rather than masking the
      * original rewind outcome.
+     *
+     * [height] is coerced to at least the resolved [startBirthday]: `WalletCoordinator.rescanBlockchain`
+     * reads [latestBirthdayHeight] BEFORE this call suspends on the readiness gate, so during
+     * preparation it captures the provisional birthday - rewinding to which would mean a full-chain
+     * rescan of a wallet whose real birthday is far higher.
      */
     override suspend fun rewindToNearestHeight(height: BlockHeight): BlockHeight? {
+        awaitReady()
         engine.stop()
         return try {
-            rewindRetrying(height)
+            rewindRetrying(maxOf(height, startBirthday))
         } finally {
             restartEngineAfter("rewind")
         }
@@ -684,11 +1212,15 @@ class SlipstreamSynchronizer internal constructor(
         }
     }
 
-    /** Same `ufvk = null` keyless-restart contract as [rewindToNearestHeight] (`FFI_JNI_CONTRACT.md` section 3.5). */
+    /**
+     * Same `ufvk = null` keyless-restart contract as [rewindToNearestHeight]
+     * (`FFI_JNI_CONTRACT.md` section 3.5), and the same [startBirthday] coercion.
+     */
     override suspend fun rewindToHeight(height: BlockHeight) {
+        awaitReady()
         engine.stop()
         try {
-            backend.rewindToHeight(height.value)
+            backend.rewindToHeight(maxOf(height, startBirthday).value)
         } finally {
             restartEngineAfter("rewind")
         }
@@ -712,18 +1244,26 @@ class SlipstreamSynchronizer internal constructor(
                     emit(memo ?: "")
                 }
             }
-        }
+        }.onStart { awaitDbReady() }
 
     override fun getTransactionsByMemoSubstring(query: String): Flow<List<TransactionId>> =
-        flow { emit(transactionReader.getTransactionsByMemoSubstring(query).map { TransactionId.new(it) }) }
+        flow {
+            emit(
+                transactionReader.getTransactionsByMemoSubstring(query)
+                    .map { TransactionId.new(it) })
+        }.onStart { awaitDbReady() }
 
     override fun getRecipients(transactionOverview: TransactionOverview): Flow<TransactionRecipient> {
         require(transactionOverview.isSentTransaction) { "Recipients can only be queried for sent transactions" }
-        return flow { transactionReader.getRecipients(transactionOverview.txId.value).forEach { emit(it) } }
+        return flow {
+            transactionReader.getRecipients(transactionOverview.txId.value).forEach { emit(it) }
+        }.onStart { awaitDbReady() }
     }
 
-    override suspend fun getRecipients(): Map<TransactionId, List<TransactionRecipient>> =
-        transactionReader.getAllRecipients().mapKeys { (txId, _) -> TransactionId.new(txId) }
+    override suspend fun getRecipients(): Map<TransactionId, List<TransactionRecipient>> {
+        awaitDbReady()
+        return transactionReader.getAllRecipients().mapKeys { (txId, _) -> TransactionId.new(txId) }
+    }
 
     override suspend fun getExistingDataDbFilePath(
         context: Context,
@@ -735,20 +1275,37 @@ class SlipstreamSynchronizer internal constructor(
         return dbFile.absolutePath
     }
 
-    override suspend fun getTransactionOutputs(transactionOverview: TransactionOverview): List<TransactionOutput> =
-        transactionReader.getTransactionOutputs(transactionOverview.txId.value)
+    override suspend fun getTransactionOutputs(transactionOverview: TransactionOverview): List<TransactionOutput> {
+        awaitDbReady()
+        return transactionReader.getTransactionOutputs(transactionOverview.txId.value)
+    }
 
-    override suspend fun getTransactionOutputs(): Map<TransactionId, List<TransactionOutput>> =
-        transactionReader.getAllTransactionOutputs().mapKeys { (txId, _) -> TransactionId.new(txId) }
+    override suspend fun getTransactionOutputs(): Map<TransactionId, List<TransactionOutput>> {
+        awaitDbReady()
+        return transactionReader.getAllTransactionOutputs()
+            .mapKeys { (txId, _) -> TransactionId.new(txId) }
+    }
 
-    override suspend fun getTransactions(accountUuid: AccountUuid): Flow<List<TransactionOverview>> =
-        transactionsController.forAccount(accountUuid)
+    override suspend fun getTransactions(accountUuid: AccountUuid): Flow<List<TransactionOverview>> {
+        awaitDbReady()
+        return transactionsController.forAccount(accountUuid)
+    }
 
-    override suspend fun getSingleUseTransparentAddress(accountUuid: AccountUuid): SingleUseTransparentAddress =
-        SingleUseTransparentAddress.new(backend.getSingleUseTransparentAddress(accountUuid.value))
+    /**
+     * Gated on full readiness, unlike its read-only neighbours: `getSingleUseTransparentAddress`
+     * RESERVES an address (`reserve_next_n_ephemeral_addresses`), so it writes to the very tables
+     * the preparation tail is still provisioning.
+     */
+    override suspend fun getSingleUseTransparentAddress(accountUuid: AccountUuid): SingleUseTransparentAddress {
+        awaitReady()
+        return SingleUseTransparentAddress.new(backend.getSingleUseTransparentAddress(accountUuid.value))
+    }
 
     override suspend fun checkSingleUseTransparentAddress(accountUuid: AccountUuid): Boolean =
-        when (val response = walletClient.checkSingleUseTransparentAddress(accountUuid.value, ServiceMode.UniqueTor)) {
+        when (val response = walletClient.checkSingleUseTransparentAddress(
+            accountUuid.value,
+            ServiceMode.UniqueTor
+        )) {
             is Response.Success -> response.result != null
             is Response.Failure -> false
         }
@@ -757,7 +1314,8 @@ class SlipstreamSynchronizer internal constructor(
         accountUuid: AccountUuid,
         address: String
     ): Boolean =
-        when (val response = walletClient.fetchUtxosByAddress(accountUuid.value, address, ServiceMode.UniqueTor)) {
+        when (val response =
+            walletClient.fetchUtxosByAddress(accountUuid.value, address, ServiceMode.UniqueTor)) {
             is Response.Success -> response.result != null
             is Response.Failure -> false
         }
@@ -794,6 +1352,7 @@ class SlipstreamSynchronizer internal constructor(
     override fun enhanceTransaction(txId: TransactionId) {
         if (closed.get()) return
         launchGuarded("enhanceTransaction") {
+            if (!awaitPrepared()) return@launchGuarded
             val serviceMode = sdkFlags ifTor ServiceMode.Group("enhance-${txId.txIdString()}")
             when (val response = walletClient.fetchTransaction(txId.value.byteArray, serviceMode)) {
                 is Response.Success -> {
@@ -801,7 +1360,10 @@ class SlipstreamSynchronizer internal constructor(
                 }
 
                 is Response.Failure -> {
-                    backend.setTransactionStatus(txId.value.byteArray, status = TXID_NOT_RECOGNIZED_STATUS)
+                    backend.setTransactionStatus(
+                        txId.value.byteArray,
+                        status = TXID_NOT_RECOGNIZED_STATUS
+                    )
                 }
             }
             engine.notifyTxChange()
@@ -819,6 +1381,7 @@ class SlipstreamSynchronizer internal constructor(
         // A burst owns the engine while it runs; its restore will apply this backgrounded state.
         if (burstActive.get()) return
         launchGuarded("onBackground") {
+            if (!awaitPrepared()) return@launchGuarded
             engine.stopPolling()
             engine.stop()
             lazyTorClient?.ifCreated { it.setDormant(TorDormantMode.SOFT) }
@@ -827,14 +1390,20 @@ class SlipstreamSynchronizer internal constructor(
 
     override fun pause() {
         if (closed.get()) return
-        migrationPaused.value = true
-        launchGuarded("pause") { engine.stopPolling() }
+        migrationPaused.update { true }
+        launchGuarded("pause") {
+            if (!awaitPrepared()) return@launchGuarded
+            engine.stopPolling()
+        }
     }
 
     override fun resume() {
         if (closed.get()) return
-        migrationPaused.value = false
-        launchGuarded("resume") { engine.startPolling() }
+        migrationPaused.update { false }
+        launchGuarded("resume") {
+            if (!awaitPrepared()) return@launchGuarded
+            engine.startPolling()
+        }
     }
 
     /**
@@ -842,6 +1411,9 @@ class SlipstreamSynchronizer internal constructor(
      * restores the pre-burst lifecycle state in a [NonCancellable] `finally`. Refuses to run while a
      * migration privacy pause is active — sync traffic and a later migration broadcast must stay
      * decoupled — and never broadcasts itself. See [Synchronizer.syncBurst].
+     *
+     * Readiness is PROBED, never awaited: the callers are background workers under a time budget,
+     * so an instance that is still preparing reports UNAVAILABLE instead of blocking one.
      */
     override suspend fun syncBurst(
         timeout: Duration,
@@ -849,6 +1421,7 @@ class SlipstreamSynchronizer internal constructor(
         isTargetReached: suspend () -> Boolean,
     ): Synchronizer.SyncBurstResult {
         if (closed.get()) return Synchronizer.SyncBurstResult.UNAVAILABLE
+        if (prepareState.value !is PrepareState.Ready) return Synchronizer.SyncBurstResult.UNAVAILABLE
         if (migrationPaused.value) return Synchronizer.SyncBurstResult.PRIVACY_BLOCKED
         if (!burstActive.compareAndSet(false, true)) return Synchronizer.SyncBurstResult.UNAVAILABLE
 
@@ -929,6 +1502,7 @@ class SlipstreamSynchronizer internal constructor(
         // A burst owns the engine while it runs; its restore will apply this foregrounded state.
         if (burstActive.get()) return
         launchGuarded("onForeground") {
+            if (!awaitPrepared()) return@launchGuarded
             lazyTorClient?.ifCreated { it.setDormant(TorDormantMode.NORMAL) }
             if (!engine.isRunning) {
                 engine.start(ufvk = null, birthday = startBirthday.value)
@@ -963,14 +1537,18 @@ class SlipstreamSynchronizer internal constructor(
         }
     }
 
-    override suspend fun debugQuery(query: String): String = transactionReader.debugQuery(query)
+    override suspend fun debugQuery(query: String): String {
+        awaitDbReady()
+        return transactionReader.debugQuery(query)
+    }
 
     /**
-     * Sequence: stop engine -> delete -> restart -> poke the accounts bus. The restart's
+     * Sequence: stop engine -> delete -> restart -> bump [accountsVersion]. The restart's
      * `ufvk = null` is `FFI_JNI_CONTRACT.md` section 3.5's keyless mode - safe here because any
      * other accounts still exist in `data.db` for the engine to read.
      */
     override suspend fun deleteAccount(accountUuid: AccountUuid): Boolean {
+        awaitReady()
         engine.stop()
         val deleted =
             try {
@@ -979,13 +1557,14 @@ class SlipstreamSynchronizer internal constructor(
                 restartEngineAfter("account deletion")
             }
         engine.notifyTxChange()
-        accountsBus.tryEmit(Unit)
+        accountsVersion.update { it + 1 }
         return deleted
     }
 
     override suspend fun getTreeState(height: BlockHeight): ByteArray {
         val serviceMode = sdkFlags ifTor ServiceMode.UniqueTor
-        return when (val response = walletClient.getTreeState(BlockHeightUnsafe(height.value), serviceMode)) {
+        return when (val response =
+            walletClient.getTreeState(BlockHeightUnsafe(height.value), serviceMode)) {
             is Response.Success -> response.result.encoded
             is Response.Failure -> throw response.toThrowable()
         }
@@ -1000,9 +1579,23 @@ class SlipstreamSynchronizer internal constructor(
      * shutdown job synchronously, on the caller's thread, before this function returns; the
      * actual stop/free work then runs asynchronously on [scope]. This makes `close()` safe to
      * call from `Dispatchers.Main`.
+     *
+     * [prepareState] flips to [PrepareState.Closed] synchronously, before this returns - from
+     * [PrepareState.DbReady] just as from [PrepareState.Preparing], since the tail is still live in
+     * both - so gated callers waiting on either readiness gate are released immediately rather than
+     * at the end of the shutdown. Cancelling and joining [prepareJob] is then the FIRST shutdown
+     * step: it keeps a still-running [prepare] from calling [SlipstreamEngine.open] (which asserts
+     * `handle == 0`) against a handle [SlipstreamEngine.free] has meanwhile dropped. The join can
+     * take as long as the in-flight `restoreAnchor` JNI call - a blocking, engine-bounded network
+     * call, which is why [prepare] checks for a lost [PrepareState.DbReady] compare-and-set before
+     * starting one - but [InstanceGuard.markShuttingDown] already makes a concurrent `acquire` wait
+     * for exactly this job, so a synchronizer replacement still sequences correctly.
      */
     override fun close() {
         if (closed.compareAndSet(false, true)) {
+            prepareState.update {
+                if (it is PrepareState.Preparing || it is PrepareState.DbReady) PrepareState.Closed else it
+            }
             val shutdownJob =
                 scope.launch {
                     /*
@@ -1024,6 +1617,7 @@ class SlipstreamSynchronizer internal constructor(
                         }
                     }
 
+                    step("prepare-cancel") { prepareJob?.cancelAndJoin() }
                     step("stopPolling") { engine.stopPolling() }
                     step("stop") { engine.stop() }
                     step("free") { engine.free() }
@@ -1055,11 +1649,28 @@ class SlipstreamSynchronizer internal constructor(
 
         /**
          * Mirrors `Synchronizer.new` parameter-for-parameter - same names, order, and defaults -
-         * so an app call site changes exactly one token. Sequence: alias + instance guard ->
-         * `SlipstreamNative.ensureLoaded()` -> resolve the UFVK -> NewWallet/RestoreWallet call
-         * `restoreAnchor` -> `engine.open` -> `engine.start` -> store `latestBirthdayHeight`.
+         * so an app call site changes exactly one token.
          *
-         * Runs on `Dispatchers.IO`: construction is disk/JNI-heavy and callers include
+         * DELIBERATE DEVIATION from `Synchronizer.new`'s "returns a ready instance" contract, and
+         * the reason this factory now returns in milliseconds: only the cheap wiring runs here
+         * (`ensureLoaded`, UFVK derivation, directories, `RustBackend.new`, the collaborators).
+         * Everything heavy - `restoreAnchor` (a blocking network call that, on a cold Tor bootstrap
+         * during a restore, is bounded in tens of seconds), `initDataDb`/`createAccount`,
+         * `engine.open`, `engine.start` - is deferred into the returned instance's own preparation
+         * job, exactly as the iOS twin splits `init` from `prepare()`. The host therefore gets a
+         * live synchronizer reporting `INITIALIZING` instead of a null `synchronizer` StateFlow for
+         * the whole of provisioning, and a provisioning failure surfaces on
+         * [onSetupErrorHandler] instead of killing the host's `callbackFlow` with no UI feedback.
+         *
+         * Consequences a caller must know:
+         * - argument validation still throws synchronously (alias, single-instance guard, a
+         *   missing seed or birthday);
+         * - every engine- or database-backed member awaits preparation, so a call made immediately
+         *   after this returns suspends rather than failing;
+         * - a preparation failure does NOT release the [InstanceGuard] key - the instance owns it
+         *   until [close], which the host's `awaitClose` always calls.
+         *
+         * Runs on `Dispatchers.IO`: even the cheap wiring touches disk, and callers include
          * `Dispatchers.Main` scopes, so dispatching here keeps every caller agnostic to that.
          */
         suspend fun new(
@@ -1093,6 +1704,10 @@ class SlipstreamSynchronizer internal constructor(
                     )
                 }
             } catch (t: Throwable) {
+                /*
+                 * Only cheap-wiring failures can land here now; the preparation tail's failures are
+                 * latched on the instance, which keeps the guard key until its own close().
+                 */
                 InstanceGuard.release(key)
                 throw t
             }
@@ -1113,7 +1728,8 @@ class SlipstreamSynchronizer internal constructor(
             key: SlipstreamKey
         ): CloseableSynchronizer {
             SlipstreamNative.ensureLoaded(logLevel = "info")
-            val sdkFlags = SdkFlags(isTorEnabled = isTorEnabled, isExchangeRateEnabled = isExchangeRateEnabled)
+            val sdkFlags =
+                SdkFlags(isTorEnabled = isTorEnabled, isExchangeRateEnabled = isExchangeRateEnabled)
 
             val ufvk: String? =
                 when (walletInitMode) {
@@ -1138,87 +1754,29 @@ class SlipstreamSynchronizer internal constructor(
             val noBackupRoot = applicationContext.getNoBackupFilesDirSuspend()
             val zcashNoBackupDir = Files.getZcashNoBackupSubdirectory(applicationContext)
             val engineTorDir =
-                if (isTorEnabled) File(zcashNoBackupDir, ENGINE_TOR_SUBDIR).apply { mkdirs() }.absolutePath else null
-            val fallbackCheckpoint = newestBundledCheckpointHeight(applicationContext, zcashNetwork)
+                if (isTorEnabled) File(
+                    zcashNoBackupDir,
+                    ENGINE_TOR_SUBDIR
+                ).apply { mkdirs() }.absolutePath else null
+            /*
+             * Fail-fast on caller bugs stays here, synchronous to `new()`: a missing restore
+             * birthday must never degrade into an asynchronous setup error.
+             */
+            val requestedBirthday =
+                when (walletInitMode) {
+                    WalletInitMode.RestoreWallet ->
+                        requireNotNull(birthday) { "birthday is required for WalletInitMode.RestoreWallet" }
 
-            val intent = resolveIntent(walletInitMode)
-            val provisioning: WalletProvisioningPlan =
-                when (intent) {
-                    1 -> {
-                        val requestedBirthday =
-                            requireNotNull(birthday) { "birthday is required for WalletInitMode.RestoreWallet" }
-                        val anchor =
-                            withContext(Dispatchers.IO) {
-                                SlipstreamNative.restoreAnchor(
-                                    serverHost = lightWalletEndpoint.host,
-                                    serverPort = lightWalletEndpoint.port,
-                                    useTls = lightWalletEndpoint.isSecure,
-                                    networkId = zcashNetwork.id,
-                                    intent = intent,
-                                    birthdayHeight = requestedBirthday.value,
-                                    fallbackCheckpointHeight = fallbackCheckpoint,
-                                    torDir = engineTorDir
-                                )
-                            }
-                        WalletProvisioningPlan(
-                            startBirthday = BlockHeight.new(anchor.height),
-                            treeState =
-                                CheckpointTool
-                                    .loadNearest(applicationContext, zcashNetwork, requestedBirthday)
-                                    .treeState()
-                                    .encoded,
-                            recoverUntil = anchor.height
-                        )
-                    }
-
-                    0 -> {
-                        val anchor =
-                            withContext(Dispatchers.IO) {
-                                SlipstreamNative.restoreAnchor(
-                                    serverHost = lightWalletEndpoint.host,
-                                    serverPort = lightWalletEndpoint.port,
-                                    useTls = lightWalletEndpoint.isSecure,
-                                    networkId = zcashNetwork.id,
-                                    intent = intent,
-                                    birthdayHeight = 0L,
-                                    fallbackCheckpointHeight = fallbackCheckpoint,
-                                    torDir = engineTorDir
-                                )
-                            }
-                        WalletProvisioningPlan(
-                            startBirthday =
-                                anchor.height.takeIf { it > 0 }?.let(BlockHeight::new) ?: BlockHeight.new(
-                                    fallbackCheckpoint
-                                ),
-                            treeState =
-                                anchor.treestate ?: CheckpointTool
-                                    .loadLast(applicationContext, zcashNetwork)
-                                    .treeState()
-                                    .encoded,
-                            recoverUntil = null
-                        )
-                    }
-
-                    else -> {
-                        WalletProvisioningPlan(
-                            startBirthday = birthday ?: BlockHeight.new(fallbackCheckpoint),
-                            treeState =
-                                CheckpointTool
-                                    .loadNearest(
-                                        applicationContext,
-                                        zcashNetwork,
-                                        birthday ?: zcashNetwork.saplingActivationHeight
-                                    ).treeState()
-                                    .encoded,
-                            recoverUntil = null
-                        )
-                    }
+                    WalletInitMode.NewWallet, WalletInitMode.ExistingWallet -> birthday
                 }
-            val startBirthday = provisioning.startBirthday
 
             val dbFile = DataDbPath.dataDbFile(noBackupRoot, alias, zcashNetwork)
 
-            val fsBlockDbRoot = File(applicationContext.filesDir, "slipstream_unused_fsblockdb").apply { mkdirs() }
+            val fsBlockDbRoot =
+                File(
+                    applicationContext.filesDir,
+                    "slipstream_unused_fsblockdb"
+                ).apply { mkdirs() }
             val saplingParamsDir = File(zcashNoBackupDir, "sapling_params")
             val backend =
                 RustBackend.new(
@@ -1230,30 +1788,6 @@ class SlipstreamSynchronizer internal constructor(
                 )
             val typesafeBackend = TypesafeBackendImpl(backend)
 
-            /*
-             * Mirrors `DerivedDataDb.new`: unconditional [Backend.initDataDb], then
-             * [Backend.createAccount] gated on `setup != null && accounts.isEmpty()`.
-             */
-            when (backend.initDataDb(setup?.seed?.byteArray)) {
-                0 -> Unit
-                1 -> throw InitializeException.SeedRequired
-                2 -> throw InitializeException.SeedNotRelevant
-                -1 -> error("Rust backend only uses -1 as an error sentinel")
-                else -> error("Rust backend used a code that needs to be defined here")
-            }
-            if (shouldCreateAccount(hasSetup = setup != null, accountsAreEmpty = backend.getAccounts().isEmpty())) {
-                val accountSetup = requireNotNull(setup)
-                runCatchingCancellable {
-                    backend.createAccount(
-                        accountName = accountSetup.accountName,
-                        keySource = accountSetup.keySource,
-                        seed = accountSetup.seed.byteArray,
-                        treeState = provisioning.treeState,
-                        recoverUntil = provisioning.recoverUntil
-                    )
-                }.getOrElse { throw InitializeException.CreateAccountException(it) }
-            }
-
             val engine =
                 SlipstreamEngine(
                     dbFile.absolutePath,
@@ -1263,14 +1797,9 @@ class SlipstreamSynchronizer internal constructor(
                     CoroutineScope(SupervisorJob() + Dispatchers.Default)
                 )
 
-            val activityManager = applicationContext.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+            val activityManager =
+                applicationContext.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
             val memoryInfo = ActivityManager.MemoryInfo().also { activityManager.getMemoryInfo(it) }
-            engine.open(totalMemoryBytes = memoryInfo.totalMem)
-            /*
-             * `ufvk` stays non-null even though the account row already exists: `FFI_JNI_CONTRACT.md`
-             * section 3.5's `start(ufvk != null)` is a no-op when an account is already present.
-             */
-            engine.start(ufvk, startBirthday.value)
 
             /*
              * Tor is only needed for on-demand/background work, never on the cold-start critical
@@ -1285,14 +1814,18 @@ class SlipstreamSynchronizer internal constructor(
             val exchangeRateFetcher =
                 if (isExchangeRateEnabled) {
                     lazyTorClient?.let { holder ->
-                        UsdExchangeRateFetcher(isolatedTorClient = LazyTorClient { holder.getOrCreate().isolatedTorClient() })
+                        UsdExchangeRateFetcher(isolatedTorClient = LazyTorClient {
+                            holder.getOrCreate().isolatedTorClient()
+                        })
                     }
                 } else {
                     null
                 }
 
             val walletClientFactory =
-                WalletClientFactory(context = applicationContext, torClient = lazyTorClient.takeIf { isTorEnabled })
+                WalletClientFactory(
+                    context = applicationContext,
+                    torClient = lazyTorClient.takeIf { isTorEnabled })
             val walletClient = walletClientFactory.create(endpoint = lightWalletEndpoint)
             val fastestServerFetcher =
                 FastestServerFetcher(typesafeBackend, zcashNetwork, walletClientFactory, sdkFlags)
@@ -1335,9 +1868,50 @@ class SlipstreamSynchronizer internal constructor(
                             FirstClassByteArray(candidate.txId),
                             sdkFlags
                         )
-                        Unit
                     },
                     notifyTxChange = engine::notifyTxChange
+                )
+
+            /*
+             * The deferred tail's every JNI/assets touch, captured as a lambda: `restoreAnchor`
+             * behind [SlipstreamAnchorSource], the bundled-checkpoint height, the two
+             * [CheckpointTool] reads and the DbReady balance seed's summary read behind their own.
+             * `totalMemoryBytes` is a plain value - the
+             * `ActivityManager` binder call above is cheap enough to stay on this path.
+             */
+            val prepareInputs =
+                PrepareInputs(
+                    walletInitMode = walletInitMode,
+                    requestedBirthday = requestedBirthday,
+                    setup = setup,
+                    ufvk = ufvk,
+                    anchorSource = { intent, birthdayHeight, fallbackCheckpointHeight ->
+                        SlipstreamNative.restoreAnchor(
+                            serverHost = lightWalletEndpoint.host,
+                            serverPort = lightWalletEndpoint.port,
+                            useTls = lightWalletEndpoint.isSecure,
+                            networkId = zcashNetwork.id,
+                            intent = intent,
+                            birthdayHeight = birthdayHeight,
+                            fallbackCheckpointHeight = fallbackCheckpointHeight,
+                            torDir = engineTorDir
+                        )
+                    },
+                    fallbackCheckpointHeight = {
+                        newestBundledCheckpointHeight(applicationContext, zcashNetwork)
+                    },
+                    treeState = { height ->
+                        CheckpointTool
+                            .loadNearest(applicationContext, zcashNetwork, height)
+                            .treeState()
+                    },
+                    lastCheckpointTreeState = {
+                        CheckpointTool
+                            .loadLast(applicationContext, zcashNetwork)
+                            .treeState()
+                    },
+                    dbWalletSummary = { typesafeBackend.getWalletSummary() },
+                    totalMemoryBytes = memoryInfo.totalMem
                 )
 
             return SlipstreamSynchronizer(
@@ -1360,56 +1934,13 @@ class SlipstreamSynchronizer internal constructor(
                 spendService = spendService,
                 broadcasterImpl = broadcaster,
                 resubmissionTicker = resubmissionTicker,
-                startBirthday = startBirthday
+                /*
+                 * Provisional until the preparation tail resolves the anchor; see
+                 * [SlipstreamSynchronizer.latestBirthdayHeight].
+                 */
+                startBirthday = requestedBirthday ?: zcashNetwork.saplingActivationHeight,
+                prepareInputs = prepareInputs
             )
-        }
-
-        /** `@JvmStatic`-shaped twin of their `newBlocking` for Java callers (C2). */
-        @JvmStatic
-        fun newBlocking(
-            alias: String = ZcashSdk.DEFAULT_ALIAS,
-            birthday: BlockHeight?,
-            context: Context,
-            lightWalletEndpoint: LightWalletEndpoint,
-            setup: AccountCreateSetup?,
-            walletInitMode: WalletInitMode,
-            zcashNetwork: ZcashNetwork,
-            isTorEnabled: Boolean,
-            isExchangeRateEnabled: Boolean
-        ): CloseableSynchronizer =
-            runBlocking {
-                new(
-                    alias = alias,
-                    birthday = birthday,
-                    context = context,
-                    lightWalletEndpoint = lightWalletEndpoint,
-                    setup = setup,
-                    walletInitMode = walletInitMode,
-                    zcashNetwork = zcashNetwork,
-                    isTorEnabled = isTorEnabled,
-                    isExchangeRateEnabled = isExchangeRateEnabled
-                )
-            }
-
-        /**
-         * Deletes `data.sqlite3` + `-wal` + `-shm`; refuses while an instance is `Active`. No
-         * separate on-disk block cache directory to delete alongside it - every persisted fact
-         * Slipstream keeps lives inside `data.sqlite3` itself.
-         */
-        suspend fun erase(
-            appContext: Context,
-            network: ZcashNetwork,
-            alias: String = ZcashSdk.DEFAULT_ALIAS
-        ): Boolean {
-            val key = SlipstreamKey(network, alias)
-            check(!InstanceGuard.isActive(key)) { "Cannot erase while a Slipstream synchronizer for $key is active" }
-            return withContext(Dispatchers.IO) {
-                val dbFile =
-                    DataDbPath.dataDbFile(appContext.applicationContext.getNoBackupFilesDirSuspend(), alias, network)
-                val walFile = File("${dbFile.path}-wal")
-                val shmFile = File("${dbFile.path}-shm")
-                listOf(dbFile, walFile, shmFile).map { !it.exists() || it.delete() }.all { it }
-            }
         }
 
         private const val ENGINE_TOR_SUBDIR = "slipstream_tor"

--- a/sdk-lib/src/main/java/com/zodl/slipstream/internal/Provisioning.kt
+++ b/sdk-lib/src/main/java/com/zodl/slipstream/internal/Provisioning.kt
@@ -2,8 +2,13 @@ package com.zodl.slipstream.internal
 
 import android.content.Context
 import cash.z.ecc.android.sdk.WalletInitMode
+import cash.z.ecc.android.sdk.internal.model.TreeState
+import cash.z.ecc.android.sdk.internal.model.WalletSummary
+import cash.z.ecc.android.sdk.model.AccountCreateSetup
+import cash.z.ecc.android.sdk.model.BlockHeight
 import cash.z.ecc.android.sdk.model.ZcashNetwork
 import cash.z.ecc.android.sdk.tool.CheckpointTool
+import com.zodl.slipstream.model.SlipstreamRestoreAnchor
 
 /**
  * `FFI_JNI_CONTRACT.md` section 8: 1 = restore, 0 = new, null = no anchor call.
@@ -45,3 +50,55 @@ internal fun shouldCreateAccount(
     hasSetup: Boolean,
     accountsAreEmpty: Boolean
 ): Boolean = hasSetup && accountsAreEmpty
+
+/**
+ * The `restoreAnchor` native call ([com.zodl.slipstream.SlipstreamNative.restoreAnchor]) as an
+ * injectable collaborator, mirroring the iOS twin's `Initializer.slipstreamAnchorSource` closure.
+ * The endpoint, network id and engine Tor directory are captured by the implementation, so the
+ * deferred-preparation tail only supplies the three facts that vary per [WalletInitMode] intent.
+ * Being a seam is the point: it keeps the JNI binding out of the tail, so the tail is unit-testable
+ * without `mockStatic`.
+ */
+internal fun interface SlipstreamAnchorSource {
+    suspend operator fun invoke(
+        intent: Int,
+        birthdayHeight: Long,
+        fallbackCheckpointHeight: Long
+    ): SlipstreamRestoreAnchor
+}
+
+/**
+ * Everything `SlipstreamSynchronizer.Companion.newLocked` defers out of construction into the
+ * synchronizer's own preparation job: the heavy tail (anchor resolution, data-DB provisioning,
+ * `engine.open`/`engine.start`) that used to run before `new()` returned.
+ *
+ * Every JNI or assets touch the tail performs sits behind one of the lambdas here -
+ * [anchorSource] for `restoreAnchor`, [fallbackCheckpointHeight] for
+ * [newestBundledCheckpointHeight], [treeState]/[lastCheckpointTreeState] for
+ * [CheckpointTool], [dbWalletSummary] for the wallet DB's own summary read. [totalMemoryBytes] is a
+ * plain value rather than a lambda because the `ActivityManager` read that produces it is cheap
+ * enough to stay on the construction path.
+ *
+ * [requestedBirthday] is the caller's birthday, already validated cheap-side (non-null whenever
+ * [walletInitMode] is [WalletInitMode.RestoreWallet]), and [ufvk] the key derived cheap-side - a
+ * caller bug must still throw synchronously out of `new()` rather than becoming an asynchronous
+ * setup error.
+ *
+ * @property dbWalletSummary the balance seed the tail publishes at `DbReady`, read straight from the
+ * wallet database so an existing wallet renders its real balances in the same phase its account row
+ * surfaces. `null` means no summary is available yet - a fresh or never-scanned database - and skips
+ * the seed, leaving the host on its shimmer until the engine's first tick.
+ */
+@Suppress("LongParameterList")
+internal class PrepareInputs(
+    val walletInitMode: WalletInitMode,
+    val requestedBirthday: BlockHeight?,
+    val setup: AccountCreateSetup?,
+    val ufvk: String?,
+    val anchorSource: SlipstreamAnchorSource,
+    val fallbackCheckpointHeight: suspend () -> Long,
+    val treeState: suspend (BlockHeight?) -> TreeState,
+    val lastCheckpointTreeState: suspend () -> TreeState,
+    val dbWalletSummary: suspend () -> WalletSummary?,
+    val totalMemoryBytes: Long
+)

--- a/sdk-lib/src/test/java/com/zodl/slipstream/SlipstreamSynchronizerLifecycleTest.kt
+++ b/sdk-lib/src/test/java/com/zodl/slipstream/SlipstreamSynchronizerLifecycleTest.kt
@@ -2,15 +2,28 @@ package com.zodl.slipstream
 
 import android.content.Context
 import cash.z.ecc.android.sdk.Synchronizer
+import cash.z.ecc.android.sdk.WalletInitMode
 import cash.z.ecc.android.sdk.exception.InitializeException
 import cash.z.ecc.android.sdk.internal.Backend
 import cash.z.ecc.android.sdk.internal.FastestServerFetcher
+import cash.z.ecc.android.sdk.internal.model.JniAccount
+import cash.z.ecc.android.sdk.internal.model.JniAccountUsk
+import cash.z.ecc.android.sdk.internal.model.JniRewindResult
+import cash.z.ecc.android.sdk.internal.model.RecoveryProgress
+import cash.z.ecc.android.sdk.internal.model.ScanProgress
+import cash.z.ecc.android.sdk.internal.model.TreeState
+import cash.z.ecc.android.sdk.internal.model.WalletSummary
+import cash.z.ecc.android.sdk.model.Account
 import cash.z.ecc.android.sdk.model.AccountBalance
+import cash.z.ecc.android.sdk.model.AccountCreateSetup
 import cash.z.ecc.android.sdk.model.AccountUuid
 import cash.z.ecc.android.sdk.model.BlockHeight
+import cash.z.ecc.android.sdk.model.FirstClassByteArray
 import cash.z.ecc.android.sdk.model.PercentDecimal
 import cash.z.ecc.android.sdk.model.SdkFlags
 import cash.z.ecc.android.sdk.model.TransactionId
+import cash.z.ecc.android.sdk.model.WalletBalance
+import cash.z.ecc.android.sdk.model.Zatoshi
 import cash.z.ecc.android.sdk.model.ZcashNetwork
 import cash.z.ecc.android.sdk.util.WalletClientFactory
 import co.electriccoin.lightwallet.client.CombinedWalletClient
@@ -19,6 +32,8 @@ import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
 import co.electriccoin.lightwallet.client.model.RawTransactionUnsafe
 import co.electriccoin.lightwallet.client.model.Response
 import com.zodl.slipstream.internal.InstanceGuard
+import com.zodl.slipstream.internal.PrepareInputs
+import com.zodl.slipstream.internal.SlipstreamAnchorSource
 import com.zodl.slipstream.internal.SlipstreamEngine
 import com.zodl.slipstream.internal.SlipstreamKey
 import com.zodl.slipstream.internal.db.SlipstreamTransactionReader
@@ -26,13 +41,25 @@ import com.zodl.slipstream.internal.db.TransactionsController
 import com.zodl.slipstream.internal.spend.ResubmissionTicker
 import com.zodl.slipstream.internal.spend.SlipstreamBroadcaster
 import com.zodl.slipstream.internal.spend.SlipstreamSpendService
+import com.zodl.slipstream.model.SlipstreamRestoreAnchor
 import com.zodl.slipstream.model.SlipstreamSnapshot
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.Test
 import org.mockito.Mockito.after
 import org.mockito.Mockito.clearInvocations
@@ -44,6 +71,8 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -324,7 +353,8 @@ class SlipstreamSynchronizerLifecycleTest {
         runBlocking { `when`(backend.getAccounts()).thenThrow(RuntimeException("boom")) }
 
         assertFailsWith<InitializeException.GetAccountsException> {
-            runBlocking { synchronizer.accountsFlow.first() }
+            /* drop(1): the flow now leads with a null "not loaded yet" emission (readiness gate). */
+            runBlocking { synchronizer.accountsFlow.drop(1).first() }
         }
     }
 
@@ -335,7 +365,7 @@ class SlipstreamSynchronizerLifecycleTest {
         runBlocking { `when`(backend.getAccounts()).thenThrow(CancellationException("cancelled")) }
 
         assertFailsWith<CancellationException> {
-            runBlocking { synchronizer.accountsFlow.first() }
+            runBlocking { synchronizer.accountsFlow.drop(1).first() }
         }
     }
 
@@ -611,6 +641,833 @@ class SlipstreamSynchronizerLifecycleTest {
         }
     }
 
+    /* ── deferred preparation: the iOS-style constructor/prepare split ────────── */
+
+    @Test
+    fun construction_is_cheap_and_reports_initializing_while_preparing() {
+        val engine = mock(SlipstreamEngine::class.java)
+        val backend = mock(Backend::class.java)
+        val engineStatus = MutableStateFlow(Synchronizer.Status.INITIALIZING)
+        val key = newKey()
+        val anchorGate = CompletableDeferred<Unit>()
+        stubPrepareBackend(backend, null)
+        val synchronizer =
+            buildSynchronizer(
+                engine = engine,
+                backend = backend,
+                key = key,
+                engineStatusOverride = engineStatus,
+                prepareInputs = prepareInputs(anchorSource = gatedAnchor(anchorGate))
+            )
+        try {
+            runBlocking {
+                assertEquals(Synchronizer.Status.INITIALIZING, synchronizer.status.first())
+                verify(engine, after(SETTLE_MS).never()).open(TOTAL_MEMORY_BYTES)
+                verify(engine, never()).start(UFVK, ANCHOR_HEIGHT)
+                verify(engine, never()).startPolling()
+            }
+        } finally {
+            anchorGate.complete(Unit)
+            InstanceGuard.release(key)
+        }
+    }
+
+    /**
+     * The probe for "awaits the gate" is a WRITE ([SlipstreamSynchronizer.rewindToHeight]) rather
+     * than a read: reads are served from `DbReady`, which the tail now publishes before it ever
+     * touches the anchor - that early completion is asserted here too, and is the whole point of
+     * the phase.
+     */
+    @Test
+    fun gated_call_awaits_preparation_then_succeeds_after_the_tail_ran_in_order() {
+        val engine = mock(SlipstreamEngine::class.java)
+        val backend = mock(Backend::class.java)
+        val key = newKey()
+        val anchorGate = CompletableDeferred<Unit>()
+        val setup = AccountCreateSetup(ACCOUNT_NAME, KEY_SOURCE, FirstClassByteArray(ByteArray(SEED_BYTES)))
+        stubPrepareBackend(backend, setup.seed.byteArray)
+        val synchronizer =
+            buildSynchronizer(
+                engine = engine,
+                backend = backend,
+                key = key,
+                prepareInputs = prepareInputs(setup = setup, anchorSource = gatedAnchor(anchorGate))
+            )
+        try {
+            val accounts =
+                runBlocking {
+                    val early = withTimeout(TIMEOUT_MS) { synchronizer.getAccounts() }
+                    val pending =
+                        async(Dispatchers.Default) {
+                            synchronizer.rewindToHeight(BlockHeight.new(BELOW_BIRTHDAY_VALUE))
+                        }
+                    verify(engine, after(SETTLE_MS).never()).open(TOTAL_MEMORY_BYTES)
+                    assertTrue(pending.isActive)
+                    anchorGate.complete(Unit)
+                    withTimeout(TIMEOUT_MS) { pending.await() }
+                    early
+                }
+
+            assertEquals(emptyList(), accounts)
+            val order = inOrder(backend, engine)
+            runBlocking {
+                order.verify(backend, timeout(TIMEOUT_MS)).initDataDb(setup.seed.byteArray)
+                order.verify(backend, timeout(TIMEOUT_MS)).createAccount(
+                    ACCOUNT_NAME,
+                    KEY_SOURCE,
+                    setup.seed.byteArray,
+                    TREE_STATE,
+                    ANCHOR_HEIGHT
+                )
+                order.verify(engine, timeout(TIMEOUT_MS)).open(TOTAL_MEMORY_BYTES)
+                order.verify(engine, timeout(TIMEOUT_MS)).start(UFVK, ANCHOR_HEIGHT)
+                order.verify(engine, timeout(TIMEOUT_MS)).startPolling()
+            }
+        } finally {
+            InstanceGuard.release(key)
+        }
+    }
+
+    @Test
+    fun failed_preparation_disconnects_latches_the_setup_error_and_keeps_the_guard() {
+        val engine = mock(SlipstreamEngine::class.java)
+        val backend = mock(Backend::class.java)
+        val engineStatus = MutableStateFlow(Synchronizer.Status.INITIALIZING)
+        val key = newKey()
+        val anchorGate = CompletableDeferred<Unit>()
+        val failure = RuntimeException("anchor unreachable")
+        val earlyHandlerCalls = AtomicInteger(0)
+        val recorded = AtomicReference<Throwable?>()
+        /* Acquired as Companion.new would, so the "a failed preparation keeps the key" claim is real. */
+        runBlocking { InstanceGuard.acquire(key) }
+        stubPrepareBackend(backend, null)
+        val synchronizer =
+            buildSynchronizer(
+                engine = engine,
+                backend = backend,
+                key = key,
+                engineStatusOverride = engineStatus,
+                prepareInputs =
+                    prepareInputs(
+                        anchorSource =
+                            SlipstreamAnchorSource { _, _, _ ->
+                                anchorGate.await()
+                                throw failure
+                            }
+                    )
+            )
+        val earlyHandlerFired = CountDownLatch(1)
+        try {
+            synchronizer.onSetupErrorHandler = { t ->
+                recorded.set(t)
+                earlyHandlerCalls.incrementAndGet()
+                earlyHandlerFired.countDown()
+                false
+            }
+            anchorGate.complete(Unit)
+
+            assertTrue(earlyHandlerFired.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+            runBlocking {
+                withTimeout(TIMEOUT_MS) { synchronizer.status.first { it == Synchronizer.Status.DISCONNECTED } }
+            }
+            assertSameFailure(failure, recorded.get())
+            assertEquals(1, earlyHandlerCalls.get())
+
+            val thrown = assertFailsWith<SlipstreamNotReadyException> { runBlocking { synchronizer.getAccounts() } }
+            assertSameFailure(failure, thrown.cause)
+
+            val lateHandlerCalls = AtomicInteger(0)
+            synchronizer.onSetupErrorHandler = { lateHandlerCalls.incrementAndGet(); false }
+            assertEquals(1, lateHandlerCalls.get())
+
+            synchronizer.onSetupErrorHandler = null
+            assertEquals(1, lateHandlerCalls.get())
+            assertTrue(InstanceGuard.isActive(key))
+        } finally {
+            InstanceGuard.release(key)
+        }
+    }
+
+    @Test
+    fun close_during_preparation_cancels_it_without_opening_the_engine_or_erroring() {
+        val engine = mock(SlipstreamEngine::class.java)
+        val backend = mock(Backend::class.java)
+        val engineStatus = MutableStateFlow(Synchronizer.Status.INITIALIZING)
+        val key = newKey()
+        val handlerCalls = AtomicInteger(0)
+        runBlocking { InstanceGuard.acquire(key) }
+        stubPrepareBackend(backend, null)
+        val synchronizer =
+            buildSynchronizer(
+                engine = engine,
+                backend = backend,
+                key = key,
+                engineStatusOverride = engineStatus,
+                prepareInputs = prepareInputs(anchorSource = SlipstreamAnchorSource { _, _, _ -> awaitCancellation() })
+            )
+        try {
+            synchronizer.onSetupErrorHandler = { handlerCalls.incrementAndGet(); false }
+
+            synchronizer.close()
+
+            val thrown = assertFailsWith<SlipstreamNotReadyException> { runBlocking { synchronizer.getAccounts() } }
+            assertEquals(null, thrown.cause)
+            runBlocking {
+                verify(engine, timeout(TIMEOUT_MS)).shutdown()
+                verify(engine, never()).open(TOTAL_MEMORY_BYTES)
+            }
+            assertEquals(0, handlerCalls.get())
+            assertEquals(Synchronizer.Status.INITIALIZING, engineStatus.value)
+            /* The guard was released by the completed shutdown job, so a fresh acquire succeeds. */
+            runBlocking { InstanceGuard.acquire(key) }
+        } finally {
+            InstanceGuard.release(key)
+        }
+    }
+
+    @Test
+    fun sync_burst_while_preparing_returns_unavailable_without_suspending() {
+        val engine = mock(SlipstreamEngine::class.java)
+        val backend = mock(Backend::class.java)
+        val key = newKey()
+        val anchorGate = CompletableDeferred<Unit>()
+        stubPrepareBackend(backend, null)
+        val synchronizer =
+            buildSynchronizer(
+                engine = engine,
+                backend = backend,
+                key = key,
+                prepareInputs = prepareInputs(anchorSource = gatedAnchor(anchorGate))
+            )
+        try {
+            val result = runBlocking { synchronizer.syncBurst(timeout = ONE_SECOND) { false } }
+
+            assertEquals(Synchronizer.SyncBurstResult.UNAVAILABLE, result)
+            runBlocking {
+                verify(engine, after(SETTLE_MS).never()).start(null, ANCHOR_HEIGHT)
+                verify(engine, never()).startPolling()
+            }
+        } finally {
+            anchorGate.complete(Unit)
+            InstanceGuard.release(key)
+        }
+    }
+
+    @Test
+    fun on_foreground_during_preparation_is_queued_behind_the_gate() {
+        val engine = mock(SlipstreamEngine::class.java)
+        val backend = mock(Backend::class.java)
+        val key = newKey()
+        val anchorGate = CompletableDeferred<Unit>()
+        stubPrepareBackend(backend, null)
+        val synchronizer =
+            buildSynchronizer(
+                engine = engine,
+                backend = backend,
+                key = key,
+                prepareInputs = prepareInputs(anchorSource = gatedAnchor(anchorGate))
+            )
+        try {
+            `when`(engine.isRunning).thenReturn(true)
+
+            synchronizer.onForeground()
+            runBlocking { verify(engine, after(SETTLE_MS).never()).start(UFVK, ANCHOR_HEIGHT) }
+
+            anchorGate.complete(Unit)
+
+            runBlocking {
+                val order = inOrder(engine)
+                order.verify(engine, timeout(TIMEOUT_MS)).start(UFVK, ANCHOR_HEIGHT)
+                verify(engine, timeout(TIMEOUT_MS).times(2)).startPolling()
+                /* The queued block found a running engine, so it never restarted it keylessly. */
+                verify(engine, never()).start(null, ANCHOR_HEIGHT)
+            }
+        } finally {
+            InstanceGuard.release(key)
+        }
+    }
+
+    @Test
+    fun cold_flows_emit_from_db_ready_before_the_anchor_resolves() {
+        val engine = mock(SlipstreamEngine::class.java)
+        val backend = mock(Backend::class.java)
+        val key = newKey()
+        val anchorGate = CompletableDeferred<Unit>()
+        stubPrepareBackend(backend, null)
+        val synchronizer =
+            buildSynchronizer(
+                engine = engine,
+                backend = backend,
+                key = key,
+                prepareInputs = prepareInputs(anchorSource = gatedAnchor(anchorGate))
+            )
+        try {
+            runBlocking {
+                assertEquals(null, synchronizer.accountsFlow.first())
+                /* Both cold flows are served from the migrated DB while the anchor is still held. */
+                assertEquals(emptyList(), withTimeout(TIMEOUT_MS) { synchronizer.accountsFlow.drop(1).first() })
+                assertEquals(emptyList(), withTimeout(TIMEOUT_MS) { synchronizer.allTransactions.first() })
+                verify(engine, after(SETTLE_MS).never()).open(TOTAL_MEMORY_BYTES)
+
+                anchorGate.complete(Unit)
+
+                verify(engine, timeout(TIMEOUT_MS)).start(UFVK, ANCHOR_HEIGHT)
+                assertEquals(emptyList(), withTimeout(TIMEOUT_MS) { synchronizer.accountsFlow.drop(1).first() })
+                assertEquals(emptyList(), withTimeout(TIMEOUT_MS) { synchronizer.allTransactions.first() })
+            }
+        } finally {
+            InstanceGuard.release(key)
+        }
+    }
+
+    /**
+     * The regression harness for a preparation that fails AFTER `DbReady` was published: both cold
+     * flows are already subscribed and serving DB rows when the anchor throws, so they must
+     * COMPLETE rather than kill the host's eager collectors or strand them forever - while the
+     * relaxed suspend reads start throwing, `Failed` being terminal for them too.
+     */
+    @Test
+    fun cold_flows_complete_instead_of_failing_when_preparation_fails() {
+        val engine = mock(SlipstreamEngine::class.java)
+        val backend = mock(Backend::class.java)
+        val engineStatus = MutableStateFlow(Synchronizer.Status.INITIALIZING)
+        val key = newKey()
+        val anchorGate = CompletableDeferred<Unit>()
+        val emitted = CountDownLatch(2)
+        stubPrepareBackend(backend, null)
+        val synchronizer =
+            buildSynchronizer(
+                engine = engine,
+                backend = backend,
+                key = key,
+                engineStatusOverride = engineStatus,
+                prepareInputs =
+                    prepareInputs(
+                        anchorSource =
+                            SlipstreamAnchorSource { _, _, _ ->
+                                anchorGate.await()
+                                throw RuntimeException("anchor unreachable")
+                            }
+                    )
+            )
+        try {
+            runBlocking {
+                val accounts =
+                    async(Dispatchers.Default) {
+                        synchronizer.accountsFlow.onEach { if (it != null) emitted.countDown() }.toList()
+                    }
+                val transactions =
+                    async(Dispatchers.Default) {
+                        synchronizer.allTransactions.onEach { emitted.countDown() }.toList()
+                    }
+                assertTrue(emitted.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+
+                anchorGate.complete(Unit)
+
+                val accountEmissions = withTimeout(TIMEOUT_MS) { accounts.await() }
+                assertEquals(2, accountEmissions.size)
+                assertEquals(null, accountEmissions[0])
+                assertEquals(emptyList(), accountEmissions[1])
+
+                val transactionEmissions = withTimeout(TIMEOUT_MS) { transactions.await() }
+                assertEquals(1, transactionEmissions.size)
+                assertEquals(emptyList(), transactionEmissions[0])
+
+                assertFailsWith<SlipstreamNotReadyException> { synchronizer.getAccounts() }
+            }
+        } finally {
+            InstanceGuard.release(key)
+        }
+    }
+
+    @Test
+    fun status_is_not_masked_to_synced_when_a_pause_lands_on_a_failed_preparation() {
+        val engine = mock(SlipstreamEngine::class.java)
+        val backend = mock(Backend::class.java)
+        val engineStatus = MutableStateFlow(Synchronizer.Status.INITIALIZING)
+        val key = newKey()
+        stubPrepareBackend(backend, null)
+        val synchronizer =
+            buildSynchronizer(
+                engine = engine,
+                backend = backend,
+                key = key,
+                engineStatusOverride = engineStatus,
+                prepareInputs =
+                    prepareInputs(
+                        anchorSource = SlipstreamAnchorSource { _, _, _ -> throw RuntimeException("anchor unreachable") }
+                    )
+            )
+        try {
+            runBlocking {
+                withTimeout(TIMEOUT_MS) { synchronizer.status.first { it == Synchronizer.Status.DISCONNECTED } }
+                synchronizer.pause()
+                assertEquals(Synchronizer.Status.DISCONNECTED, synchronizer.status.first())
+            }
+        } finally {
+            InstanceGuard.release(key)
+        }
+    }
+
+    @Test
+    fun a_preparation_finishing_around_close_never_overwrites_the_closed_state() {
+        val engine = mock(SlipstreamEngine::class.java)
+        val backend = mock(Backend::class.java)
+        val key = newKey()
+        val anchorEntered = CountDownLatch(1)
+        val anchorGate = CompletableDeferred<Unit>()
+        val handlerCalls = AtomicInteger(0)
+        stubPrepareBackend(backend, null)
+        val synchronizer =
+            buildSynchronizer(
+                engine = engine,
+                backend = backend,
+                key = key,
+                prepareInputs =
+                    prepareInputs(
+                        anchorSource =
+                            SlipstreamAnchorSource { _, _, _ ->
+                                anchorEntered.countDown()
+                                anchorGate.await()
+                                SlipstreamRestoreAnchor(ANCHOR_HEIGHT, null)
+                            }
+                    )
+            )
+        try {
+            synchronizer.onSetupErrorHandler = { handlerCalls.incrementAndGet(); false }
+            assertTrue(anchorEntered.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+
+            synchronizer.close()
+            anchorGate.complete(Unit)
+
+            val thrown = assertFailsWith<SlipstreamNotReadyException> { runBlocking { synchronizer.getAccounts() } }
+            assertEquals(null, thrown.cause)
+            runBlocking { verify(engine, timeout(TIMEOUT_MS)).shutdown() }
+            assertEquals(0, handlerCalls.get())
+        } finally {
+            InstanceGuard.release(key)
+        }
+    }
+
+    @Test
+    fun rewind_below_the_resolved_birthday_is_coerced_up_to_it() {
+        val engine = mock(SlipstreamEngine::class.java)
+        val backend = mock(Backend::class.java)
+        val key = newKey()
+        val synchronizer = buildSynchronizer(engine = engine, backend = backend, key = key)
+        try {
+            runBlocking {
+                `when`(backend.rewindToHeight(STARTING_BIRTHDAY_VALUE))
+                    .thenReturn(JniRewindResult.Success(STARTING_BIRTHDAY_VALUE))
+            }
+
+            val rewound = runBlocking { synchronizer.rewindToNearestHeight(BlockHeight.new(BELOW_BIRTHDAY_VALUE)) }
+
+            assertEquals(BlockHeight.new(STARTING_BIRTHDAY_VALUE), rewound)
+            runBlocking {
+                verify(backend).rewindToHeight(STARTING_BIRTHDAY_VALUE)
+                verify(backend, never()).rewindToHeight(BELOW_BIRTHDAY_VALUE)
+            }
+        } finally {
+            InstanceGuard.release(key)
+        }
+    }
+
+    @Test
+    fun preparation_finishing_under_a_migration_pause_does_not_start_polling() {
+        val engine = mock(SlipstreamEngine::class.java)
+        val backend = mock(Backend::class.java)
+        val key = newKey()
+        val anchorGate = CompletableDeferred<Unit>()
+        stubPrepareBackend(backend, null)
+        val synchronizer =
+            buildSynchronizer(
+                engine = engine,
+                backend = backend,
+                key = key,
+                prepareInputs = prepareInputs(anchorSource = gatedAnchor(anchorGate))
+            )
+        try {
+            synchronizer.pause()
+            anchorGate.complete(Unit)
+
+            runBlocking {
+                verify(engine, timeout(TIMEOUT_MS)).start(UFVK, ANCHOR_HEIGHT)
+                /* The queued pause() block runs once preparation publishes Ready. */
+                verify(engine, timeout(TIMEOUT_MS)).stopPolling()
+                verify(engine, after(SETTLE_MS).never()).startPolling()
+            }
+        } finally {
+            InstanceGuard.release(key)
+        }
+    }
+
+    /* ── DbReady: DB-backed reads served before the tail's network anchor ─────── */
+
+    @Test
+    fun read_only_surfaces_are_served_at_db_ready_while_the_anchor_is_still_pending() {
+        val engine = mock(SlipstreamEngine::class.java)
+        val backend = mock(Backend::class.java)
+        val transactionsController = mock(TransactionsController::class.java)
+        val key = newKey()
+        val anchorGate = CompletableDeferred<Unit>()
+        val accountUuid = AccountUuid.new(ByteArray(ACCOUNT_UUID_BYTES))
+        stubPrepareBackend(backend, null)
+        runBlocking {
+            `when`(backend.getCurrentAddress(accountUuid.value)).thenReturn(UNIFIED_ADDRESS)
+            `when`(transactionsController.forAccount(accountUuid)).thenReturn(flowOf(emptyList()))
+        }
+        val synchronizer =
+            buildSynchronizer(
+                engine = engine,
+                backend = backend,
+                transactionsController = transactionsController,
+                key = key,
+                prepareInputs = prepareInputs(anchorSource = gatedAnchor(anchorGate))
+            )
+        try {
+            runBlocking {
+                assertEquals(emptyList(), withTimeout(TIMEOUT_MS) { synchronizer.getAccounts() })
+                assertEquals(
+                    emptyList(),
+                    withTimeout(TIMEOUT_MS) { synchronizer.getTransactions(accountUuid).first() }
+                )
+                assertEquals(
+                    UNIFIED_ADDRESS,
+                    withTimeout(TIMEOUT_MS) { synchronizer.getUnifiedAddress(Account.new(accountUuid)) }
+                )
+
+                /* A write stays gated on full readiness, so it is still suspended on the held anchor. */
+                val pending =
+                    async(Dispatchers.Default) {
+                        synchronizer.rewindToHeight(BlockHeight.new(BELOW_BIRTHDAY_VALUE))
+                    }
+                verify(engine, after(SETTLE_MS).never()).open(TOTAL_MEMORY_BYTES)
+                assertTrue(pending.isActive)
+
+                anchorGate.complete(Unit)
+                withTimeout(TIMEOUT_MS) { pending.await() }
+            }
+        } finally {
+            InstanceGuard.release(key)
+        }
+    }
+
+    /**
+     * The restore shape: the account row is written only once the anchor resolves, so the whole
+     * `DbReady` window reads an empty table. That read is suppressed rather than served - the host
+     * reads an empty list as "loaded, no accounts" - leaving the collector on the leading `null`
+     * until the tail's `createAccount` makes the rows real.
+     */
+    @Test
+    fun accounts_flow_refreshes_once_the_tail_creates_the_account_row() {
+        val engine = mock(SlipstreamEngine::class.java)
+        val backend = mock(Backend::class.java)
+        val key = newKey()
+        val anchorGate = CompletableDeferred<Unit>()
+        val created = AtomicBoolean(false)
+        val setup = AccountCreateSetup(ACCOUNT_NAME, KEY_SOURCE, FirstClassByteArray(ByteArray(SEED_BYTES)))
+        val accountUuid = AccountUuid.new(ByteArray(ACCOUNT_UUID_BYTES))
+        val jniAccount =
+            JniAccount(
+                accountName = ACCOUNT_NAME,
+                accountUuid = accountUuid.value,
+                hdAccountIndex = NULL_HD_ACCOUNT_INDEX,
+                keySource = KEY_SOURCE,
+                seedFingerprint = null,
+                ufvk = UFVK,
+                uivk = null
+            )
+        runBlocking {
+            `when`(backend.initDataDb(setup.seed.byteArray)).thenReturn(0)
+            `when`(backend.getAccounts()).thenAnswer { if (created.get()) listOf(jniAccount) else emptyList() }
+            `when`(
+                backend.createAccount(
+                    ACCOUNT_NAME,
+                    KEY_SOURCE,
+                    setup.seed.byteArray,
+                    TREE_STATE,
+                    ANCHOR_HEIGHT
+                )
+            ).thenAnswer {
+                created.set(true)
+                JniAccountUsk(accountUuid.value, ByteArray(USK_BYTES))
+            }
+        }
+        val synchronizer =
+            buildSynchronizer(
+                engine = engine,
+                backend = backend,
+                key = key,
+                prepareInputs = prepareInputs(setup = setup, anchorSource = gatedAnchor(anchorGate))
+            )
+        try {
+            runBlocking {
+                val emissions = Channel<List<Account>?>(Channel.UNLIMITED)
+                val collector =
+                    launch(Dispatchers.Default) {
+                        synchronizer.accountsFlow.collect { emissions.send(it) }
+                    }
+                try {
+                    assertEquals(null, withTimeout(TIMEOUT_MS) { emissions.receive() })
+                    /* The leading null is already consumed, so any element here would be the empty read. */
+                    assertEquals(null, withTimeoutOrNull(SETTLE_MS) { emissions.receive() })
+
+                    anchorGate.complete(Unit)
+
+                    val rows = withTimeout(TIMEOUT_MS) { emissions.receive() }
+                    assertEquals(accountUuid, rows?.single()?.accountUuid)
+                } finally {
+                    collector.cancel()
+                }
+            }
+        } finally {
+            InstanceGuard.release(key)
+        }
+    }
+
+    /**
+     * The host distinguishes "still loading" (`null`) from "loaded, and there are no accounts" (an
+     * empty list), so the restore window must never serve the latter: until the tail's
+     * `createAccount` runs, the collector stays on the leading `null` and the account UI keeps
+     * rendering as loading rather than as absent.
+     */
+    @Test
+    fun accounts_flow_stays_loading_instead_of_emitting_empty_while_creation_is_pending() {
+        val engine = mock(SlipstreamEngine::class.java)
+        val backend = mock(Backend::class.java)
+        val key = newKey()
+        val anchorGate = CompletableDeferred<Unit>()
+        val created = AtomicBoolean(false)
+        val setup = AccountCreateSetup(ACCOUNT_NAME, KEY_SOURCE, FirstClassByteArray(ByteArray(SEED_BYTES)))
+        val accountUuid = AccountUuid.new(ByteArray(ACCOUNT_UUID_BYTES))
+        val jniAccount =
+            JniAccount(
+                accountName = ACCOUNT_NAME,
+                accountUuid = accountUuid.value,
+                hdAccountIndex = NULL_HD_ACCOUNT_INDEX,
+                keySource = KEY_SOURCE,
+                seedFingerprint = null,
+                ufvk = UFVK,
+                uivk = null
+            )
+        runBlocking {
+            `when`(backend.initDataDb(setup.seed.byteArray)).thenReturn(0)
+            `when`(backend.getAccounts()).thenAnswer { if (created.get()) listOf(jniAccount) else emptyList() }
+            `when`(
+                backend.createAccount(
+                    ACCOUNT_NAME,
+                    KEY_SOURCE,
+                    setup.seed.byteArray,
+                    TREE_STATE,
+                    ANCHOR_HEIGHT
+                )
+            ).thenAnswer {
+                created.set(true)
+                JniAccountUsk(accountUuid.value, ByteArray(USK_BYTES))
+            }
+        }
+        val synchronizer =
+            buildSynchronizer(
+                engine = engine,
+                backend = backend,
+                key = key,
+                prepareInputs = prepareInputs(setup = setup, anchorSource = gatedAnchor(anchorGate))
+            )
+        try {
+            runBlocking {
+                val emissions = async(Dispatchers.Default) { synchronizer.accountsFlow.take(2).toList() }
+                /* Settles past DbReady with the anchor still held: a second emission would be the empty read. */
+                verify(engine, after(SETTLE_MS).never()).open(TOTAL_MEMORY_BYTES)
+                assertTrue(emissions.isActive)
+
+                anchorGate.complete(Unit)
+
+                val rows = withTimeout(TIMEOUT_MS) { emissions.await() }
+                assertEquals(2, rows.size)
+                assertEquals(null, rows[0])
+                assertEquals(accountUuid, rows[1]?.single()?.accountUuid)
+            }
+        } finally {
+            InstanceGuard.release(key)
+        }
+    }
+
+    /**
+     * The `DbReady` balance seed: what the wallet database already knows surfaces in the same phase
+     * the account row does, so an existing wallet never renders a hard zero while the tail is still
+     * blocked on its anchor.
+     */
+    @Test
+    fun balances_are_seeded_from_the_db_at_db_ready_before_the_anchor_resolves() {
+        val engine = mock(SlipstreamEngine::class.java)
+        val backend = mock(Backend::class.java)
+        val key = newKey()
+        val anchorGate = CompletableDeferred<Unit>()
+        val balances = MutableStateFlow<Map<AccountUuid, AccountBalance>?>(null)
+        val summary = dbSummary(AccountUuid.new(ByteArray(ACCOUNT_UUID_BYTES)))
+        stubPrepareBackend(backend, null)
+        val synchronizer =
+            buildSynchronizer(
+                engine = engine,
+                backend = backend,
+                key = key,
+                walletBalancesOverride = balances,
+                prepareInputs =
+                    prepareInputs(
+                        anchorSource = gatedAnchor(anchorGate),
+                        dbWalletSummary = { summary }
+                    )
+            )
+        try {
+            runBlocking {
+                assertEquals(
+                    summary.accountBalances,
+                    withTimeout(TIMEOUT_MS) { synchronizer.walletBalances.first { it != null } }
+                )
+                /* Still short of the anchor, so the seed is genuinely a DbReady-phase publish. */
+                verify(engine, after(SETTLE_MS).never()).open(TOTAL_MEMORY_BYTES)
+            }
+        } finally {
+            anchorGate.complete(Unit)
+            InstanceGuard.release(key)
+        }
+    }
+
+    /**
+     * The seed is an optimization, never a gate: a never-scanned database throws out of the summary
+     * read ("Target height not available"), and the tail must carry on to `Ready` with the balances
+     * left null - the shimmer, which is the correct render for a wallet with nothing scanned yet.
+     */
+    @Test
+    fun a_failing_db_balance_seed_is_swallowed_and_leaves_preparation_intact() {
+        val engine = mock(SlipstreamEngine::class.java)
+        val backend = mock(Backend::class.java)
+        val key = newKey()
+        val balances = MutableStateFlow<Map<AccountUuid, AccountBalance>?>(null)
+        val handlerCalls = AtomicInteger(0)
+        stubPrepareBackend(backend, null)
+        val synchronizer =
+            buildSynchronizer(
+                engine = engine,
+                backend = backend,
+                key = key,
+                walletBalancesOverride = balances,
+                prepareInputs = prepareInputs(dbWalletSummary = { error(SEED_FAILURE_MESSAGE) })
+            )
+        try {
+            synchronizer.onSetupErrorHandler = { handlerCalls.incrementAndGet(); false }
+            runBlocking {
+                verify(engine, timeout(TIMEOUT_MS)).startPolling()
+                assertEquals(null, balances.value)
+            }
+            assertEquals(0, handlerCalls.get())
+        } finally {
+            InstanceGuard.release(key)
+        }
+    }
+
+    /**
+     * The anchor is a blocking, engine-bounded network call, so a preparation that has already lost
+     * its `DbReady` compare-and-set to [SlipstreamSynchronizer.close] must never start one - the
+     * shutdown's own `cancelAndJoin` would have to wait it out for a result nothing will read.
+     */
+    @Test
+    fun close_during_the_data_db_step_bails_out_before_the_anchor_call() {
+        val engine = mock(SlipstreamEngine::class.java)
+        val backend = mock(Backend::class.java)
+        val key = newKey()
+        val initEntered = CountDownLatch(1)
+        val initProceed = CountDownLatch(1)
+        val anchorCalls = AtomicInteger(0)
+        runBlocking {
+            `when`(backend.getAccounts()).thenReturn(emptyList())
+            `when`(backend.initDataDb(null)).thenAnswer {
+                initEntered.countDown()
+                initProceed.await()
+                0
+            }
+        }
+        val synchronizer =
+            buildSynchronizer(
+                engine = engine,
+                backend = backend,
+                key = key,
+                prepareInputs =
+                    prepareInputs(
+                        anchorSource =
+                            SlipstreamAnchorSource { _, _, _ ->
+                                anchorCalls.incrementAndGet()
+                                SlipstreamRestoreAnchor(ANCHOR_HEIGHT, null)
+                            }
+                    )
+            )
+        try {
+            assertTrue(initEntered.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+
+            synchronizer.close()
+            initProceed.countDown()
+
+            runBlocking {
+                verify(engine, timeout(TIMEOUT_MS)).shutdown()
+                verify(engine, never()).open(TOTAL_MEMORY_BYTES)
+            }
+            assertEquals(0, anchorCalls.get())
+        } finally {
+            InstanceGuard.release(key)
+        }
+    }
+
+    /**
+     * kotlinx's stack-trace recovery hands the preparation job a COPY of any exception that crossed
+     * the tail's `withContext(Dispatchers.IO)` boundary, so identity comparison is not available -
+     * assert on the type and message instead.
+     */
+    private fun assertSameFailure(
+        expected: Throwable,
+        actual: Throwable?
+    ) {
+        assertEquals(expected::class, actual?.let { it::class })
+        assertEquals(expected.message, actual?.message)
+    }
+
+    private fun gatedAnchor(gate: CompletableDeferred<Unit>) =
+        SlipstreamAnchorSource { _, _, _ ->
+            gate.await()
+            SlipstreamRestoreAnchor(ANCHOR_HEIGHT, null)
+        }
+
+    /**
+     * Mockito answers `null` for unstubbed suspend calls (their erased return type is `Object`),
+     * which the preparation tail would unbox into a crash - stub the two reads it performs.
+     */
+    private fun stubPrepareBackend(
+        backend: Backend,
+        seed: ByteArray?
+    ) {
+        runBlocking {
+            `when`(backend.initDataDb(seed)).thenReturn(0)
+            `when`(backend.getAccounts()).thenReturn(emptyList())
+        }
+    }
+
+    /**
+     * The wallet database's own summary, shaped as `TypesafeBackendImpl.getWalletSummary` returns
+     * it. Only [WalletSummary.accountBalances] feeds the `DbReady` seed; the heights and progress
+     * fields are plausible filler, deliberately not seeded anywhere.
+     */
+    private fun dbSummary(accountUuid: AccountUuid) =
+        WalletSummary(
+            accountBalances = mapOf(accountUuid to SEEDED_ACCOUNT_BALANCE),
+            chainTipHeight = BlockHeight.new(ANCHOR_HEIGHT),
+            fullyScannedHeight = BlockHeight.new(ANCHOR_HEIGHT),
+            scanProgress = ScanProgress(1, 1),
+            recoveryProgress = RecoveryProgress(1, 1),
+            nextSaplingSubtreeIndex = 0u,
+            nextOrchardSubtreeIndex = 0u,
+            nextIronwoodSubtreeIndex = 0u
+        )
+
     private fun newKey() = SlipstreamKey(ZcashNetwork.Testnet, "alias_${System.nanoTime()}")
 
     @Suppress("LongParameterList")
@@ -650,14 +1507,17 @@ class SlipstreamSynchronizerLifecycleTest {
         key: SlipstreamKey = newKey(),
         startBirthday: BlockHeight = BlockHeight.new(STARTING_BIRTHDAY_VALUE),
         engineStatusOverride: MutableStateFlow<Synchronizer.Status>? = null,
-        lastSnapshotOverride: MutableStateFlow<SlipstreamSnapshot?>? = null
+        lastSnapshotOverride: MutableStateFlow<SlipstreamSnapshot?>? = null,
+        walletBalancesOverride: MutableStateFlow<Map<AccountUuid, AccountBalance>?>? = null,
+        prepareInputs: PrepareInputs? = null
     ): SlipstreamSynchronizer {
         `when`(engine.status).thenReturn(engineStatusOverride ?: MutableStateFlow(Synchronizer.Status.SYNCED))
         `when`(engine.progress).thenReturn(MutableStateFlow(PercentDecimal.ZERO_PERCENT))
         `when`(engine.areFundsSpendable).thenReturn(MutableStateFlow(false))
         `when`(engine.networkHeight).thenReturn(MutableStateFlow<BlockHeight?>(null))
         `when`(engine.fullyScannedHeight).thenReturn(MutableStateFlow<BlockHeight?>(null))
-        `when`(engine.walletBalances).thenReturn(MutableStateFlow<Map<AccountUuid, AccountBalance>?>(null))
+        `when`(engine.walletBalances)
+            .thenReturn(walletBalancesOverride ?: MutableStateFlow<Map<AccountUuid, AccountBalance>?>(null))
         `when`(engine.lastSnapshot).thenReturn(lastSnapshotOverride ?: MutableStateFlow<SlipstreamSnapshot?>(null))
         `when`(transactionsController.allTransactions).thenReturn(flowOf(emptyList()))
 
@@ -681,9 +1541,42 @@ class SlipstreamSynchronizerLifecycleTest {
             spendService = mock(SlipstreamSpendService::class.java),
             broadcasterImpl = mock(SlipstreamBroadcaster::class.java),
             resubmissionTicker = mock(ResubmissionTicker::class.java),
-            startBirthday = startBirthday
+            startBirthday = startBirthday,
+            prepareInputs = prepareInputs
         )
     }
+
+    /**
+     * A [PrepareInputs] whose every JNI/assets seam is a stub, so the deferred-preparation tail can
+     * be driven from a test without `SlipstreamNative` or `CheckpointTool`. Defaults describe a
+     * [WalletInitMode.RestoreWallet] provisioning (intent 1 - the only intent that resolves an
+     * anchor from a birthday), with no [AccountCreateSetup] so no account row is written.
+     */
+    @Suppress("LongParameterList")
+    private fun prepareInputs(
+        walletInitMode: WalletInitMode = WalletInitMode.RestoreWallet,
+        requestedBirthday: BlockHeight? = BlockHeight.new(REQUESTED_BIRTHDAY_VALUE),
+        setup: AccountCreateSetup? = null,
+        ufvk: String? = UFVK,
+        anchorSource: SlipstreamAnchorSource =
+            SlipstreamAnchorSource { _, _, _ -> SlipstreamRestoreAnchor(ANCHOR_HEIGHT, null) },
+        fallbackCheckpointHeight: suspend () -> Long = { FALLBACK_CHECKPOINT },
+        treeState: suspend (BlockHeight?) -> TreeState = { TreeState(TREE_STATE) },
+        lastCheckpointTreeState: suspend () -> TreeState = { TreeState(TREE_STATE) },
+        dbWalletSummary: suspend () -> WalletSummary? = { null },
+        totalMemoryBytes: Long = TOTAL_MEMORY_BYTES
+    ) = PrepareInputs(
+        walletInitMode = walletInitMode,
+        requestedBirthday = requestedBirthday,
+        setup = setup,
+        ufvk = ufvk,
+        anchorSource = anchorSource,
+        fallbackCheckpointHeight = fallbackCheckpointHeight,
+        treeState = treeState,
+        lastCheckpointTreeState = lastCheckpointTreeState,
+        dbWalletSummary = dbWalletSummary,
+        totalMemoryBytes = totalMemoryBytes
+    )
 
     companion object {
         private const val TIMEOUT_MS = 2_000L
@@ -691,6 +1584,41 @@ class SlipstreamSynchronizerLifecycleTest {
         private const val LATCH_TIMEOUT_SECONDS = 2L
         private const val STARTING_BIRTHDAY_VALUE = 2_000_000L
         private const val ACCOUNT_UUID_BYTES = 16
+
+        /** Deferred-preparation fixtures: the anchor resolves ABOVE the requested birthday. */
+        private const val REQUESTED_BIRTHDAY_VALUE = 2_100_000L
+        private const val ANCHOR_HEIGHT = 2_200_000L
+        private const val FALLBACK_CHECKPOINT = 1_900_000L
+        private const val TOTAL_MEMORY_BYTES = 4_000_000_000L
+        private const val UFVK = "uview1testkey"
+        private const val ACCOUNT_NAME = "test account"
+        private const val KEY_SOURCE = "test key source"
+        private const val SEED_BYTES = 32
+        private const val BELOW_BIRTHDAY_VALUE = 1_000_000L
+        private const val UNIFIED_ADDRESS = "utest1address"
+
+        /** [JniAccount] represents a NULL ZIP 32 account index across JNI as `-1`. */
+        private const val NULL_HD_ACCOUNT_INDEX = -1L
+        private const val USK_BYTES = 8
+        private val TREE_STATE = byteArrayOf(1, 2, 3, 4)
+
+        /** What a never-scanned database answers the summary read with, per the Rust backend. */
+        private const val SEED_FAILURE_MESSAGE = "Target height not available"
+
+        /** Non-zero throughout, so a hard-zero balance can never be mistaken for the seed. */
+        private val SEEDED_POOL_BALANCE =
+            WalletBalance(
+                available = Zatoshi(100_000L),
+                changePending = Zatoshi(2_000L),
+                valuePending = Zatoshi(300L)
+            )
+        private val SEEDED_ACCOUNT_BALANCE =
+            AccountBalance(
+                sapling = SEEDED_POOL_BALANCE,
+                orchard = SEEDED_POOL_BALANCE,
+                ironwood = SEEDED_POOL_BALANCE,
+                unshielded = Zatoshi(40L)
+            )
 
         private val TICK = 20.milliseconds
         private val HALF_SECOND = 500.milliseconds


### PR DESCRIPTION
## Why

Today `SlipstreamSynchronizer.new()` performs the entire heavy construction before returning — `restoreAnchor` (a blocking network fetch; on a cold-Tor restore that's bootstrap + up to ~45 s of bounded circuit attempts) → `initDataDb` → `createAccount` → `engine.open` → `engine.start`. `WalletCoordinator` calls it inside a `callbackFlow`, so for that whole window the app's `synchronizer` StateFlow is null (unexplained shimmer, the MOB-1634 failure class), and any construction throw kills the flow and leaves it null **forever** with zero UI feedback. It is also why a Tor-enabled restore shows a long dead window while a Tor-off restore doesn't.

## Design

Mirrors the iOS SDK's `prepare()` / `Initializer.slipstreamAnchorSource` split **behind the unchanged Android API**: `new()` returns in milliseconds with `status = INITIALIZING`; the tail runs in an internal prepare job guarded by a four-state machine (`Preparing → DbReady → Ready`, terminal `Failed`/`Closed`, CAS-only transitions so `close()` always wins races).

> **Design-review flag (@nuttycom):** this deliberately deviates from the upstream `Synchronizer.new` contract of returning a fully-ready instance. Engine/DB operations now await readiness internally; failures surface through `onSetupErrorHandler` instead of a throw from `new()`. The iOS `prepare()` precedent is the model; flagging explicitly since the "new() returns ready" posture was previously load-bearing.

## The changes

1. **Deferred prepare + readiness gates** (`SlipstreamSynchronizer.kt`): every engine/DB-touching operation awaits `Ready` (`awaitReady()` throwing / `awaitPrepared()` boolean); lifecycle blocks (`onForeground`/`onBackground`/`pause`/`resume`) queue behind the gate inside `launchGuarded`; `syncBurst` probes synchronously and returns `UNAVAILABLE` while preparing; `close()` cancels-and-joins the prepare job before any engine teardown step.
2. **DbReady read phase**: the tail is reordered iOS-style — `initDataDb` **before** the network anchor — and read-only surfaces (`getAccounts`, address getters, transactions/memos/outputs/recipients, transparent balance, `debugQuery`, plus the `accountsFlow`/`allTransactions` cold flows) relax to `awaitDbReady()`. An existing wallet serves accounts and transactions as soon as migrations finish, before any network round-trip; the rewind targets are coerced to `>= startBirthday` to keep `WalletCoordinator.rescanBlockchain()` safe against the provisional birthday.
3. **Failure surfacing**: a failed prepare forces engine status `DISCONNECTED` and latches the error into `onSetupErrorHandler` (with late-attach replay, since the host attaches handlers only after the first emission). Cold flows complete instead of killing the host's eager collectors.
4. **Typed provisioning**: the treestate plumbing carries `TreeState` end-to-end and unwraps `.encoded` exactly once, at the `createAccount` JNI boundary.
5. **Truthful-from-DbReady balances**: `engine.walletBalances` is seeded from `TypesafeBackend.getWalletSummary()` at DbReady (best-effort; the first engine tick overwrites with its stale-tip masking) — closes the zero-balance flash on relaunch.
6. **No transient "no accounts" state**: `accountsFlow` suppresses empty emissions while the tail's `createAccount` is still pending, so a restore's anchor window renders as *loading*, not *absent*; `accountsVersion` (StateFlow counter, replacing the replaying SharedFlow) drives re-reads from `createAccount`/`importAccountByUfvk`/`deleteAccount`.

## App-side counterpart

Landed on `zashi-android` `feature/ironwood-slipstream` as [Handle deferred slipstream preparation on home messages and migration worker (`95e93f4d3`)](https://github.com/Electric-Coin-Company/zashi-android/commit/95e93f4d3): setup-error banner precedence, Restoring-banner narration during INITIALIZING, and MigrationWorker INITIALIZING-awareness.

## Testing

- `SlipstreamSynchronizerLifecycleTest`: **44/44 green** — covers cheap construction, gate ordering (initDataDb → createAccount → open → start → startPolling), the close/prepare CAS race, prepare-failure latch + DISCONNECTED, flow survival on Failed-after-DbReady, syncBurst probing, foreground queuing, migration-pause interaction, rewind coercion, the balance seed, and the empty-accounts suppression. The suppression and seed tests are negative-controlled (removing the fix line fails exactly those tests).
- Known pre-existing failure left untouched: `SlipstreamHostReadModelsTest.transaction_row_constructor_matches_rust_jni_signature` (zip318 reflection pin vs `2d1192a5`).
- Whole-stack compile: `zashi-android` `assembleZcashmainnetStoreDebug` and `assembleZcashmainnetInternalRelease` (R8) both green against this branch via the included build.

## Manual verification status

- RIM build (`zcashmainnetInternalRelease`, v3.8.1) passed the merged-lib integrity checks (RustBackend/SlipstreamNative/MigrationRustBackend families, 16 KB alignment, single native lib per ABI) and is deployed to a physical Pixel 9.
- Pending device matrix: existing-wallet relaunch (instant accounts/balances, no 0.000 flash), restore with Tor on/off (loading → account+banner together), airplane-mode restore (setup-error banner), close-during-prepare (wallet switch mid-restore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)