### PR TITLE
TEMPORARY: pin librustzcash to 59ed8930 and adapt to its API

### DIFF
--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -1545,8 +1545,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1582,8 +1581,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3245,6 +3243,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3257,8 +3261,7 @@ dependencies = [
 [[package]]
 name = "pczt"
 version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aead0b7ecb4363d8560ac76687c02ef896292fb836c1c68f3a4d99443f32e1a0"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -7205,8 +7208,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
  "bech32",
  "bs58",
@@ -7219,8 +7221,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49636f1d22b0511b2a117548cc9dcf569440a3589b06bf6df422c6b738f6231"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
  "arti-client",
  "base64",
@@ -7287,8 +7288,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7a9511b23d123fabf23b797e9d750dabe69bd31ebcfd2de9423e0f5c0a3c73"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
  "bip32",
  "bitflags",
@@ -7302,6 +7302,7 @@ dependencies = [
  "maybe-rayon",
  "nonempty",
  "orchard",
+ "pastey",
  "pczt",
  "prost 0.14.4",
  "rand 0.8.7",
@@ -7347,8 +7348,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def800f128e459eedebc900f36f408eaf0687634128dcf64ecfeaeebc3e16c14"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
  "bech32",
  "bip32",
@@ -7390,9 +7390,9 @@ dependencies = [
 [[package]]
 name = "zcash_pool_migration"
 version = "0.1.0-rc.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb981e23ad66171cfad0bd4e0ed481f771d317ff7f14148a4fd49e85f0a1307"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
+ "blake2b_simd",
  "corez",
  "getset",
  "incrementalmerkletree",
@@ -7411,8 +7411,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ca4de11896f704ffe6319c2cd7bc8fc6ab31a55cec80d26def15c009d83678"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7442,8 +7441,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea125021aaa749e966989c7f7aaa18afe2f89474573f5f0dfac8b98083a6d095"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7464,8 +7462,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043686451284bcb72e40ffa18e2cdcea3108e8468e3d021062c0b32c4a060c98"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
  "corez",
  "document-features",
@@ -7503,8 +7500,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "547c012778bae17f58007731af074d638aa146ab0ecfc120adebf23d049aff6c"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
  "bip32",
  "bs58",
@@ -7597,8 +7593,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb464491970d9b61889e4f2b7b00fb9f471a33692e5c0de3122fdc575d8067ab"
+source = "git+https://github.com/zcash/librustzcash?rev=59ed8930b8c6d96ce7c0c44a756d480f7311be8a#59ed8930b8c6d96ce7c0c44a756d480f7311be8a"
 dependencies = [
  "base64",
  "nom",

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -209,14 +209,14 @@ slipstream-core = { git = "https://github.com/zodl-inc/slipstream.git", rev = "a
 # zcash_voting = { git = "https://github.com/valargroup/zcash_voting.git", rev = "7d39d02b297f0ce23751f2638bf403285e34e675" }
 
 ## Uncomment and modify the following block to use librustzcash crates at a pinned revision.
-#pczt = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-#zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-#zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-#zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-#zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-#zcash_pool_migration = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-#zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-#zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-#zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-#zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-#zip321 = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
+pczt = { git = "https://github.com/zcash/librustzcash", rev = "59ed8930b8c6d96ce7c0c44a756d480f7311be8a" }
+zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "59ed8930b8c6d96ce7c0c44a756d480f7311be8a" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "59ed8930b8c6d96ce7c0c44a756d480f7311be8a" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "59ed8930b8c6d96ce7c0c44a756d480f7311be8a" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "59ed8930b8c6d96ce7c0c44a756d480f7311be8a" }
+zcash_pool_migration = { git = "https://github.com/zcash/librustzcash", rev = "59ed8930b8c6d96ce7c0c44a756d480f7311be8a" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "59ed8930b8c6d96ce7c0c44a756d480f7311be8a" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "59ed8930b8c6d96ce7c0c44a756d480f7311be8a" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "59ed8930b8c6d96ce7c0c44a756d480f7311be8a" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "59ed8930b8c6d96ce7c0c44a756d480f7311be8a" }
+zip321 = { git = "https://github.com/zcash/librustzcash", rev = "59ed8930b8c6d96ce7c0c44a756d480f7311be8a" }

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -45,6 +45,7 @@ use rand::rngs::OsRng;
 use rusqlite::Connection;
 use std::ptr;
 
+use zcash_client_backend::data_api::locking::LockError;
 use zcash_client_backend::data_api::wallet::input_selection::LockFilter;
 use zcash_client_backend::data_api::{InputSource, NullifierQuery, OutputLockStore, WalletRead};
 use zcash_client_backend::keys::UnifiedSpendingKey;
@@ -1221,16 +1222,25 @@ fn try_prove(
 ///   ready transfer with it. As of rc.6 the primary cure for a late dependency is upstream —
 ///   `engine::prove_transfer` re-draws the boundary at prove time — so this classification is now a
 ///   defence-in-depth backstop for any residual tree-query miss, not the sole recovery path.
+/// - `Lock(LockFailure(..))` — a note this transaction spends is already reserved by a different
+///   owner, i.e. another flow (typically a user payment proposed while this transaction was being
+///   proved) has committed to spending it. The conflict resolves either way without this batch's
+///   help: the other flow may release its lock or let it expire, after which a later attempt
+///   proves; or its transaction mines, after which the next attempt reports `UnknownSpentNote`,
+///   already transient here. Neither outcome is reached any sooner by taking down every other
+///   ready transfer in the batch.
 ///
-/// A non-transient prover error (e.g. `IronwoodTreeUnavailable`) is NOT swallowed here — it still
+/// A non-transient prover error (e.g. `IronwoodTreeUnavailable`, or `Lock(Storage(..))` — a
+/// genuine lock-store write failure rather than a conflict) is NOT swallowed here — it still
 /// surfaces so a real failure is not silently dropped.
-fn is_transient_prove_error<TE, NE, RE>(err: &WalletProveError<TE, NE, RE>) -> bool {
+fn is_transient_prove_error<TE, NE, RE, LE>(err: &WalletProveError<TE, NE, RE, LE>) -> bool {
     matches!(
         err,
         WalletProveError::UnknownSpentNote(_)
             | WalletProveError::AnchorNotFound(_)
             | WalletProveError::WitnessNotFound(_)
             | WalletProveError::Tree(_)
+            | WalletProveError::Lock(LockError::LockFailure(_))
     )
 }
 
@@ -5010,11 +5020,15 @@ mod next_due_transfer_tests {
             as_of: scanned,
         };
         let mut st = state.clone();
+        // Seeded: the RNG only feeds the overdue re-spread's anchor-boundary redraws, and these
+        // traces assert on the step CHOICE, which must not vary run to run.
+        let mut rng = <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(7);
         let step = advance_migration(
             &mut store,
             &mut st,
             DuenessTargets::new(scanned, BlockHeight::from_u32(estimated)),
             &AdvanceConfig::new(SETTLE_DEPTH),
+            &mut rng,
         )
         .expect("in-memory store never errors");
         match step {
@@ -5980,9 +5994,10 @@ mod late_dependency_anchor_tests {
     #[test]
     fn commitment_tree_not_contained_is_transient() {
         // Reconstruct the EXACT live error value: Query(NotContained(Address{level:0, index:242174})).
-        let tree_err: WalletProveError<(), (), ()> = WalletProveError::Tree(ShardTreeError::Query(
-            QueryError::NotContained(Address::from_parts(Level::from(0u8), 242_174)),
-        ));
+        let tree_err: WalletProveError<(), (), (), ()> =
+            WalletProveError::Tree(ShardTreeError::Query(QueryError::NotContained(
+                Address::from_parts(Level::from(0u8), 242_174),
+            )));
         assert!(
             is_transient_prove_error(&tree_err),
             "a commitment-tree query miss (NotContained) is transient: the funding note is not yet \
@@ -5994,14 +6009,14 @@ mod late_dependency_anchor_tests {
     /// The three witness/anchor-resolution errors that were ALREADY transient must stay transient.
     #[test]
     fn witness_and_anchor_errors_stay_transient() {
-        let unknown: WalletProveError<(), (), ()> = WalletProveError::UnknownSpentNote(
+        let unknown: WalletProveError<(), (), (), ()> = WalletProveError::UnknownSpentNote(
             orchard::note::Nullifier::from_bytes(&[0u8; 32])
                 .into_option()
                 .expect("valid nullifier bytes"),
         );
-        let anchor: WalletProveError<(), (), ()> =
+        let anchor: WalletProveError<(), (), (), ()> =
             WalletProveError::AnchorNotFound(BlockHeight::from_u32(ANCHOR));
-        let witness: WalletProveError<(), (), ()> =
+        let witness: WalletProveError<(), (), (), ()> =
             WalletProveError::WitnessNotFound(BlockHeight::from_u32(ANCHOR));
         assert!(is_transient_prove_error(&unknown));
         assert!(is_transient_prove_error(&anchor));
@@ -6012,10 +6027,41 @@ mod late_dependency_anchor_tests {
     /// transient — it should still surface, so we don't silently swallow real failures.
     #[test]
     fn ironwood_tree_unavailable_is_not_transient() {
-        let err: WalletProveError<(), (), ()> = WalletProveError::IronwoodTreeUnavailable;
+        let err: WalletProveError<(), (), (), ()> = WalletProveError::IronwoodTreeUnavailable;
         assert!(
             !is_transient_prove_error(&err),
             "a genuinely unrecoverable prover error must not be swallowed as transient"
+        );
+    }
+
+    /// A lock CONFLICT — another flow reserved a note this transaction spends — is transient: it
+    /// resolves without this batch's help, either by the other flow releasing/expiring its lock
+    /// (a later attempt then proves) or by its transaction mining (the next attempt then reports
+    /// `UnknownSpentNote`, itself transient). Propagating it would roll back every other ready
+    /// transfer in the batch to no purpose.
+    #[test]
+    fn lock_conflict_is_transient() {
+        let conflict: WalletProveError<(), (), (), ()> =
+            WalletProveError::Lock(LockError::LockFailure(OutputRef::new(
+                zcash_protocol::TxId::from_bytes([9u8; 32]),
+                PoolType::ORCHARD,
+                0,
+            )));
+        assert!(
+            is_transient_prove_error(&conflict),
+            "a note reserved by a competing flow must defer (Ok(false)), never take down the \
+             whole prove batch"
+        );
+    }
+
+    /// A lock-store WRITE failure is not a conflict and does not self-resolve; it must surface.
+    #[test]
+    fn lock_storage_failure_is_not_transient() {
+        let broken: WalletProveError<(), (), (), ()> =
+            WalletProveError::Lock(LockError::Storage(()));
+        assert!(
+            !is_transient_prove_error(&broken),
+            "a genuine lock-store failure must not be swallowed as a conflict"
         );
     }
 }
@@ -6329,11 +6375,15 @@ mod state_machine_trace_tests {
         fn advance(&self, target: BlockHeight) -> AdvanceStep {
             let mut store = NoOpPoolMigrationStore;
             let mut state = self.build();
+            // Seeded: the RNG only feeds the overdue re-spread's anchor-boundary redraws, and
+            // these traces assert on the step SEQUENCE, which must not vary run to run.
+            let mut rng = <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(7);
             advance_migration(
                 &mut store,
                 &mut state,
                 DuenessTargets::at(target),
                 &AdvanceConfig::new(ReorgSettleDepth::new(10)),
+                &mut rng,
             )
             .expect("advance_migration over the no-op store")
         }
@@ -6545,12 +6595,14 @@ mod state_machine_trace_tests {
         let (steps, _) = d.drain(4_224_660);
         assert_eq!(
             steps,
-            // Again id order among the simultaneously due, not schedule order.
+            // Schedule order among the simultaneously due, NOT id order: the engine offers the
+            // candidate that has been ready longest — earliest scheduled height, ties by id.
+            // Here 13@4224640, 10@4224646, 12@4224649, 6@4224655, 14@4224656.
             vec![
-                broadcast(6),
+                broadcast(13),
                 broadcast(10),
                 broadcast(12),
-                broadcast(13),
+                broadcast(6),
                 broadcast(14)
             ]
         );
@@ -6827,7 +6879,11 @@ fn advance_step(
 ) -> anyhow::Result<(i64, i64)> {
     let targets = DuenessTargets::new(scanned_target, estimated_target);
     let config = AdvanceConfig::new(SETTLE_DEPTH);
-    let step = advance_migration(backend, state, targets, &config)
+    // Supplies the re-spread's anchor-boundary redraws (`scheduling::redraw_anchor_boundary`) when
+    // a step is found overdue past its shift tolerance. Those draws are privacy-bearing — they set
+    // the age an anchor is broadcast at — so this is the same `OsRng` the other engine entry
+    // points (`engine::prove_transfer`, the builders) are given, never a seeded one.
+    let step = advance_migration(backend, state, targets, &config, &mut OsRng)
         .map_err(|e| anyhow!("Error advancing migration: {:?}", e))?;
     Ok(match step {
         AdvanceStep::Prove { id, .. } => (STEP_PROVE, i64::from(u32::from(id))),


### PR DESCRIPTION
Adopts `librustzcash` revision `59ed8930b8c6d96ce7c0c44a756d480f7311be8a` and fixes the resulting compilation errors.

Depends on https://github.com/zcash/librustzcash/pull/2929 and the associated PR stack.

## Why a pin

The `zcash_pool_migration` changes this adapts to are not in any published crate — the locking work (`WalletProveError`'s fourth type parameter, `MigrationProver::lock_spent_notes`) is filed under the `0.1.0-rc.4` heading in the upstream CHANGELOG, but published rc.4 through rc.6 all carry the three-parameter enum. This pins a specific revision rather than a branch, so the build stays reproducible while the upstream branch moves.

**The pin must not outlive the upstream release that carries these changes.** Replace it with the released version numbers before merging; the source adaptation stays.

## What changed upstream

Three API changes, all in `zcash_pool_migration`:

**`wallet::WalletProveError` gains a fourth type parameter** (the lock store's error) and a `Lock(LockError<LE>)` variant, reporting a note another flow has already reserved.

`is_transient_prove_error` classifies a lock **conflict** as transient. It resolves without the prove batch's help either way: the competing flow releases or expires its lock, after which a later attempt proves; or its transaction mines, after which the next attempt reports `UnknownSpentNote`, already transient here. Propagating it would crash `finalizeReadyTransfers` and roll back every other ready transfer in the batch to no purpose. A lock-store **write failure** is not a conflict, does not self-resolve, and still surfaces. Both arms are covered by new unit tests.

**`satisfiability::advance_migration` takes a `CryptoRng`**, for the anchor-boundary redraws it now performs when re-spreading a broadcast schedule the wallet slept through. The JNI path passes `OsRng` — those draws set the age an anchor is broadcast at, so they are privacy-bearing and must come from the same source the other engine entry points are given. The trace tests pass a seeded `StdRng`, since they assert on step choice and must not vary run to run.

**`state::AdvanceStep` selection now offers the candidate that has been ready longest** rather than the first one in storage order. This flipped one assertion in `live_plan_happy_trace_completes_with_late_but_in_margin_prep`: the tail now broadcasts in schedule order (13@4224640, 10@4224646, 12@4224649, 6@4224655, 14@4224656) rather than id order. The new order is exactly the scheduled-height order, so the expectation and its now-inverted comment were updated rather than worked around.

## Verification

All at exit 0:

- `cargo check --workspace --all-targets` (default, `android-test-fixtures`, and `--all-features`)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — 49 passed, 0 failed, 13 ignored

## Noted, not fixed

`migration.rs`'s terminal-status encoder ends in `_ => unreachable!("is_terminal() only returns true for Complete/Failed")`. That premise is false and was already false before this bump: `Superseded` has always been terminal, and this revision adds `Cancelled`. Nothing in this crate calls `mark_superseded`/`mark_cancelled`, so it is unreachable in practice — but only by our own restraint, not by the type. Fixing it means deciding what a cancelled or superseded migration looks like on the Kotlin `MigrationState` surface, which needs a counterpart on that side, so it is left out of this PR.

---

Filed with Claude Code assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
