### PR TITLE
MOB-1664: restore DB-backed height fallback for transaction status

### DIFF
--- a/sdk-lib/src/main/java/com/zodl/slipstream/SlipstreamSynchronizer.kt
+++ b/sdk-lib/src/main/java/com/zodl/slipstream/SlipstreamSynchronizer.kt
@@ -1858,7 +1858,7 @@ class SlipstreamSynchronizer internal constructor(
                 FastestServerFetcher(typesafeBackend, zcashNetwork, walletClientFactory, sdkFlags)
 
             val transactionReader = SlipstreamTransactionReader(dbFile)
-            val transactionsController = TransactionsController(transactionReader, engine)
+            val transactionsController = TransactionsController(transactionReader, engine, typesafeBackend)
 
             val spendService =
                 SlipstreamSpendService(

--- a/sdk-lib/src/main/java/com/zodl/slipstream/internal/db/TransactionsController.kt
+++ b/sdk-lib/src/main/java/com/zodl/slipstream/internal/db/TransactionsController.kt
@@ -1,5 +1,6 @@
 package com.zodl.slipstream.internal.db
 
+import cash.z.ecc.android.sdk.internal.TypesafeBackend
 import cash.z.ecc.android.sdk.model.AccountUuid
 import cash.z.ecc.android.sdk.model.BlockHeight
 import cash.z.ecc.android.sdk.model.TransactionOverview
@@ -28,6 +29,7 @@ import kotlinx.coroutines.flow.onStart
 internal class TransactionsController(
     private val reader: SlipstreamTransactionReader,
     private val engine: SlipstreamEngine,
+    private val typesafeBackend: TypesafeBackend,
 ) {
     @OptIn(ExperimentalCoroutinesApi::class)
     val allTransactions =
@@ -49,9 +51,27 @@ internal class TransactionsController(
 
     private fun isRecovering(): Boolean = engine.lastSnapshot.value?.isRecovering ?: false
 
-    private fun latestHeight(): BlockHeight? =
-        engine.lastSnapshot.value
-            ?.chainTip
-            ?.takeIf { it > 0 }
-            ?.let(BlockHeight::new)
+    /**
+     * MOB-1664: [SlipstreamEngine.lastSnapshot] is per-engine-instance state that starts back at
+     * `null` every time the synchronizer is rebuilt (e.g. an automatic server switch tears down
+     * and reconstructs the whole engine via `WalletCoordinator`'s `flatMapLatest`) - unlike the
+     * legacy `SdkSynchronizer.getTransactions()`, which always had `backend.getMaxScannedHeight()`
+     * as a DB-backed fallback for exactly this gap. That fallback was lost when this path was
+     * ported; restoring it here (rather than trying to seed the new engine instance from the old
+     * one's last-known height) keeps every account's confirmation math tied to its own DB file,
+     * so it can't leak state across a network/account switch and stays reorg-safe (a reorged-out
+     * tx's `minedHeight` is cleared in the DB, so `computeTransactionState` still won't report it
+     * Confirmed even once `latestHeight` resolves again).
+     */
+    private suspend fun latestHeight(): BlockHeight? =
+        resolveLiveChainTip(engine.lastSnapshot.value?.chainTip) ?: typesafeBackend.getMaxScannedHeight()
 }
+
+/**
+ * MOB-1664: the live-height half of [TransactionsController.latestHeight]'s decision, pulled out
+ * as a pure function so the "is this snapshot's chainTip trustworthy" check is directly testable
+ * without a live [SlipstreamEngine]/native handle. Returns `null` for a fresh engine instance
+ * (chainTip absent) or a degraded snapshot (chainTip <= 0), signalling the caller to fall back to
+ * the DB-backed scanned height instead of treating the raw reading as ground truth.
+ */
+internal fun resolveLiveChainTip(chainTip: Long?): BlockHeight? = chainTip?.takeIf { it > 0 }?.let(BlockHeight::new)

--- a/sdk-lib/src/test/java/com/zodl/slipstream/internal/db/TransactionsControllerTest.kt
+++ b/sdk-lib/src/test/java/com/zodl/slipstream/internal/db/TransactionsControllerTest.kt
@@ -1,0 +1,35 @@
+package com.zodl.slipstream.internal.db
+
+import cash.z.ecc.android.sdk.model.BlockHeight
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * MOB-1664: a fresh [com.zodl.slipstream.internal.SlipstreamEngine] instance (e.g. right after an
+ * automatic server switch rebuilds the whole synchronizer) reports `chainTip == null`, and a
+ * mid-tick degraded snapshot can report `chainTip <= 0`. Neither is trustworthy; both must be
+ * treated as "unknown" so [TransactionsController.latestHeight] falls back to the DB-backed
+ * scanned height instead of letting every transaction's confirmation math momentarily flash back
+ * to Pending.
+ */
+class TransactionsControllerTest {
+    @Test
+    fun `null chainTip is treated as unknown`() = assertNull(resolveLiveChainTip(null))
+
+    @Test
+    fun `zero chainTip is treated as unknown`() = assertNull(resolveLiveChainTip(0L))
+
+    @Test
+    fun `negative chainTip is treated as unknown`() = assertNull(resolveLiveChainTip(-1L))
+
+    @Test
+    fun `positive chainTip resolves to a real BlockHeight`() {
+        assertEquals(BlockHeight.new(3_440_531L), resolveLiveChainTip(3_440_531L))
+    }
+
+    @Test
+    fun `chainTip of exactly one resolves`() {
+        assertEquals(BlockHeight.new(1L), resolveLiveChainTip(1L))
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes [MOB-1664](https://linear.app/zodl/issue/MOB-1664/inaccurate-transaction-statuses-on-automatic-server-switch): receive transactions briefly flash "Receiving..." (Pending) then correct back to "Received" (Confirmed), reported as happening repeatedly and randomly, correlated with automatic server switches and "Wallet disconnected" states.
- Root cause: `TransactionsController.latestHeight()` only read the live `SlipstreamEngine.lastSnapshot`'s `chainTip`, which is per-engine-instance state that resets to `null` every time the synchronizer is rebuilt (e.g. an automatic server switch tears down and reconstructs the whole `SlipstreamSynchronizer` via `WalletCoordinator`'s `flatMapLatest`). During that gap, `computeTransactionState()` falls straight to `Pending` for every transaction regardless of how deeply confirmed it actually is.
- The legacy `SdkSynchronizer.getTransactions()` always had a DB-backed fallback (`backend.getMaxScannedHeight()`) for exactly this gap; it was dropped when this path was ported to the Slipstream engine. Restored it via the already-constructed `TypesafeBackend` rather than seeding new engine instances from old ones' last-known height, since the DB fallback can't leak state across a network/account switch and stays reorg-safe (a reorged-out tx's `minedHeight` is cleared in the DB, so `computeTransactionState` still won't report it Confirmed once `latestHeight` resolves again).

## Test plan
- [x] New unit tests (`TransactionsControllerTest`) covering the live/fallback decision boundary (null, zero, negative, positive chainTip)
- [x] Full `sdk-lib` unit test suite: 244/244 green
- [x] Live-verified on an emulator against mainnet with a real wallet: added temporary diagnostic logging, confirmed the exact previously-null moment (both at cold app launch and after a manual server switch) now resolves via the DB fallback to a value matching what the live engine reports moments later — no discontinuity, no visible flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)