### PR TITLE
MOB-1665: migration liveness + expired-transaction timestamp fixes

### DIFF
--- a/sdk-lib/src/main/java/com/zodl/slipstream/internal/db/TransactionOverviewCursor.kt
+++ b/sdk-lib/src/main/java/com/zodl/slipstream/internal/db/TransactionOverviewCursor.kt
@@ -20,6 +20,7 @@ import kotlin.math.absoluteValue
 internal object TransactionOverviewCursor {
     /** Zcash's protocol-target block interval; used only as a fallback timestamp estimator below. */
     private const val SECONDS_PER_BLOCK = 75L
+    private const val MILLIS_PER_SECOND = 1000L
 
     /**
      * Pure row mapper - [row] is already-constructed by the native, so this is fully
@@ -34,7 +35,7 @@ internal object TransactionOverviewCursor {
     fun fromRow(
         row: SlipstreamTransactionRow,
         latestHeight: BlockHeight?,
-        nowEpochSeconds: Long = System.currentTimeMillis() / 1000
+        nowEpochSeconds: Long = System.currentTimeMillis() / MILLIS_PER_SECOND
     ): TransactionOverview {
         val minedBlockHeight = row.minedHeight?.let(BlockHeight::new)
         val expiryBlockHeight = row.expiryHeight?.takeIf { it != 0L }?.let(BlockHeight::new)

--- a/sdk-lib/src/main/java/com/zodl/slipstream/internal/db/TransactionOverviewCursor.kt
+++ b/sdk-lib/src/main/java/com/zodl/slipstream/internal/db/TransactionOverviewCursor.kt
@@ -4,6 +4,7 @@ import cash.z.ecc.android.sdk.model.BlockHeight
 import cash.z.ecc.android.sdk.model.FirstClassByteArray
 import cash.z.ecc.android.sdk.model.TransactionId
 import cash.z.ecc.android.sdk.model.TransactionOverview
+import cash.z.ecc.android.sdk.model.TransactionState
 import cash.z.ecc.android.sdk.model.Zatoshi
 import cash.z.ecc.android.sdk.model.Zip318Kind
 import com.zodl.slipstream.model.SlipstreamTransactionRow
@@ -17,9 +18,14 @@ import kotlin.math.absoluteValue
  * the internal `DbTransactionOverview` type), built instead over the public 17-field constructor.
  */
 internal object TransactionOverviewCursor {
+    /** Zcash's protocol-target block interval; used only as a fallback timestamp estimator below. */
+    private const val SECONDS_PER_BLOCK = 75L
+
     /**
      * Pure row mapper - [row] is already-constructed by the native, so this is fully
      * JVM-unit-testable without an `android.database.Cursor` (`SDK_ADAPTER_PLAN.md` law 5).
+     * [nowEpochSeconds] is a parameter rather than an internal `System.currentTimeMillis()` read
+     * specifically to preserve that purity/determinism for tests.
      *
      * @param latestHeight the engine snapshot's `chainTip` at query time (the adapter's twin of
      *   the upstream SDK folding `processor.networkHeight` into the flow,
@@ -27,11 +33,41 @@ internal object TransactionOverviewCursor {
      */
     fun fromRow(
         row: SlipstreamTransactionRow,
-        latestHeight: BlockHeight?
+        latestHeight: BlockHeight?,
+        nowEpochSeconds: Long = System.currentTimeMillis() / 1000
     ): TransactionOverview {
         val minedBlockHeight = row.minedHeight?.let(BlockHeight::new)
         val expiryBlockHeight = row.expiryHeight?.takeIf { it != 0L }?.let(BlockHeight::new)
         val isSent = row.accountBalanceDelta < 0
+
+        val transactionState =
+            computeTransactionState(
+                latestHeight = latestHeight,
+                minedHeight = minedBlockHeight,
+                expiryHeight = expiryBlockHeight,
+                isExpiredUnmined = row.isExpiredUnmined?.let { it != 0L }
+            )
+
+        // MOB-1665: the legacy SdkSynchronizer path backfilled a real historical timestamp for
+        // an Expired transaction with no blockTimeEpochSeconds (upstream
+        // TransactionOverview.checkAndFillInTime, looking up the block at expiryHeight) - this
+        // read path never picked up an equivalent, so an expired transaction with a null block
+        // time fell through to the UI's `?: endOfDay` sort fallback (GetActivitiesUseCase.kt) and
+        // sorted as if it happened at the end of TODAY, no matter how long ago it actually
+        // expired (confirmed live: a ~9-month-old failed transaction surfaced at the top of the
+        // activity list). This read path has no equivalent block-time-by-height lookup to port,
+        // so estimate instead from the block-height gap to the known chain tip - accurate enough
+        // for what this value is actually used for (an approximate "how long ago" ordering key),
+        // not a claimed-precise instant.
+        val estimatedBlockTime =
+            row.blockTime ?: run {
+                if (transactionState != TransactionState.Expired || expiryBlockHeight == null || latestHeight == null) {
+                    null
+                } else {
+                    val blocksSinceExpiry = latestHeight.value - expiryBlockHeight.value
+                    (nowEpochSeconds - blocksSinceExpiry * SECONDS_PER_BLOCK).takeIf { it > 0 }
+                }
+            }
 
         return TransactionOverview(
             txId = TransactionId.new(row.txId),
@@ -48,14 +84,8 @@ internal object TransactionOverviewCursor {
             receivedNoteCount = row.receivedNoteCount,
             sentNoteCount = row.sentNoteCount,
             memoCount = row.memoCount,
-            blockTimeEpochSeconds = row.blockTime,
-            transactionState =
-                computeTransactionState(
-                    latestHeight = latestHeight,
-                    minedHeight = minedBlockHeight,
-                    expiryHeight = expiryBlockHeight,
-                    isExpiredUnmined = row.isExpiredUnmined?.let { it != 0L }
-                ),
+            blockTimeEpochSeconds = estimatedBlockTime,
+            transactionState = transactionState,
             isShielding = row.isShielding,
             // NOT PROJECTED by this read path. `host_read.rs`'s `listTransactions` SQL selects a
             // fixed column list that does not include `spent_note_count`, `pool_crossing_value` or

--- a/sdk-lib/src/test/java/com/zodl/slipstream/internal/db/TransactionOverviewCursorTest.kt
+++ b/sdk-lib/src/test/java/com/zodl/slipstream/internal/db/TransactionOverviewCursorTest.kt
@@ -183,6 +183,112 @@ class TransactionOverviewCursorTest {
         assertEquals(cash.z.ecc.android.sdk.model.Zip318Kind.TRANSFER, overview.zip318Kind)
     }
 
+    /**
+     * MOB-1665: an Expired transaction with no real block_time (never mined, so nothing in the
+     * `blocks` table joins to it) used to reach the UI as a null timestamp, sorting as if it
+     * happened at the end of today (GetActivitiesUseCase.kt's `?: endOfDay` fallback) no matter
+     * how long ago it actually expired. Estimated from the block-height gap to the known chain
+     * tip instead, at the fixed 75s/block protocol target.
+     */
+    @Test
+    fun expired_transaction_with_no_block_time_gets_an_estimated_timestamp() {
+        val overview =
+            TransactionOverviewCursor.fromRow(
+                row =
+                    SlipstreamTransactionRow(
+                        txId = ByteArray(32) { 7 },
+                        minedHeight = null,
+                        expiryHeight = 100,
+                        txIndex = null,
+                        raw = null,
+                        accountBalanceDelta = -1,
+                        totalSpent = 1,
+                        totalReceived = 0,
+                        feePaid = null,
+                        hasChange = false,
+                        sentNoteCount = 1,
+                        receivedNoteCount = 0,
+                        memoCount = 0,
+                        blockTime = null,
+                        isShielding = false,
+                        isExpiredUnmined = 0L,
+                        zip318Kind = 0
+                    ),
+                latestHeight = BlockHeight.new(200),
+                nowEpochSeconds = 1_800_000_000L
+            )
+
+        assertEquals(TransactionState.Expired, overview.transactionState)
+        // 100 blocks past expiry, at 75s/block = 7_500s ago.
+        assertEquals(1_800_000_000L - 7_500L, overview.blockTimeEpochSeconds)
+    }
+
+    /** A real block_time on the row is always used verbatim — the estimate is a fallback only. */
+    @Test
+    fun expired_transaction_with_a_real_block_time_keeps_it_unestimated() {
+        val overview =
+            TransactionOverviewCursor.fromRow(
+                row =
+                    SlipstreamTransactionRow(
+                        txId = ByteArray(32) { 8 },
+                        minedHeight = null,
+                        expiryHeight = 100,
+                        txIndex = null,
+                        raw = null,
+                        accountBalanceDelta = -1,
+                        totalSpent = 1,
+                        totalReceived = 0,
+                        feePaid = null,
+                        hasChange = false,
+                        sentNoteCount = 1,
+                        receivedNoteCount = 0,
+                        memoCount = 0,
+                        blockTime = 1_650_000_000L,
+                        isShielding = false,
+                        isExpiredUnmined = 0L,
+                        zip318Kind = 0
+                    ),
+                latestHeight = BlockHeight.new(200),
+                nowEpochSeconds = 1_800_000_000L
+            )
+
+        assertEquals(TransactionState.Expired, overview.transactionState)
+        assertEquals(1_650_000_000L, overview.blockTimeEpochSeconds)
+    }
+
+    /** A non-expired (Pending) transaction with no block_time is left null — no estimate applies. */
+    @Test
+    fun pending_transaction_with_no_block_time_is_not_estimated() {
+        val overview =
+            TransactionOverviewCursor.fromRow(
+                row =
+                    SlipstreamTransactionRow(
+                        txId = ByteArray(32) { 9 },
+                        minedHeight = null,
+                        expiryHeight = 300,
+                        txIndex = null,
+                        raw = null,
+                        accountBalanceDelta = -1,
+                        totalSpent = 1,
+                        totalReceived = 0,
+                        feePaid = null,
+                        hasChange = false,
+                        sentNoteCount = 1,
+                        receivedNoteCount = 0,
+                        memoCount = 0,
+                        blockTime = null,
+                        isShielding = false,
+                        isExpiredUnmined = 0L,
+                        zip318Kind = 0
+                    ),
+                latestHeight = BlockHeight.new(200),
+                nowEpochSeconds = 1_800_000_000L
+            )
+
+        assertEquals(TransactionState.Pending, overview.transactionState)
+        assertNull(overview.blockTimeEpochSeconds)
+    }
+
     /** Same shape, `PREPARATION` (note-split) kind — the other migration branch case. */
     @Test
     fun migration_preparation_pending_row_maps_to_pending_state_with_preparation_kind() {


### PR DESCRIPTION
## Summary
- Fixes [MOB-1665](https://linear.app/zodl/issue/MOB-1665/migration-stuck-with-pending-transactions-on-grapheneos): a real user's migration got stuck (5 pending transfers, one "Ready now" that never sent, no manual way to retry). Root-caused to `MigrationLiveDriver`'s loop dying silently on any transient failure and nothing on the Progress screen restarting it — see companion app-side PR for that fix.
- **This PR**: estimates a timestamp for Expired transactions with no `block_time` (`TransactionOverviewCursor.kt`). The legacy `SdkSynchronizer` path backfilled a real historical timestamp for exactly this case (`TransactionOverview.checkAndFillInTime`, looking up the block at `expiryHeight`); the Slipstream read path never picked up an equivalent, so an expired transaction with a null block time reached the UI as null and sorted as if it happened at the end of *today* (the app's `?: endOfDay` sort fallback). Confirmed live: a ~9-month-old failed transaction surfaced at the top of a user's activity list.
- No equivalent block-time-by-height lookup exists on this read path, so this estimates from the block-height gap to the known chain tip at the fixed 75s/block protocol target — accurate enough for what the value is actually used for (an approximate "how long ago" ordering key), not a claimed-precise instant.

## Test plan
- [x] 3 new unit tests (`TransactionOverviewCursorTest`): expired+no-block-time gets an estimate, expired+real-block-time keeps it unestimated, non-expired+no-block-time stays null
- [x] Full `sdk-lib` unit test suite: 247/247 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)