### PR TITLE
Use semantic types at the API boundary instead of bytes and strings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `OrchardMigrationSdk` external-signing APIs now carry PCZTs as `Pczt` instead of raw
+  `ByteArray`, including `KeystoneBatchSignedPczts` and `UnsignedPreparationPczt`; callers must
+  wrap signer output in `Pczt` and use `Pczt.toByteArray()` when sending it to external devices.
+- `TransferResult.Success.txId` is now `TransactionId` instead of `String`; callers that need the
+  display encoding must use `TransactionId.txIdString()`.
+
+### Fixed
+- `ImportAccountCheckpointsNotReadyException` and Slipstream account-loading logs no longer expose
+  backend exception details that could contain sensitive wallet input.
+
 ## [3.0.0] - 2026-08-08
 
 ### Added

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
@@ -2,7 +2,9 @@
 
 package cash.z.ecc.android.sdk
 
+import cash.z.ecc.android.sdk.model.Pczt
 import cash.z.ecc.android.sdk.model.Proposal
+import cash.z.ecc.android.sdk.model.TransactionId
 import cash.z.ecc.android.sdk.model.UnifiedSpendingKey
 import kotlinx.coroutines.flow.Flow
 import kotlin.time.Duration
@@ -186,8 +188,8 @@ data class KeystoneBatchDecodeResult(
  * their transfer ids) to [OrchardMigrationSdk.storeSignedSchedulePczts].
  */
 data class KeystoneBatchSignedPczts(
-    val splitSignedPczt: ByteArray?,
-    val transferSignedPczts: List<ByteArray>
+    val splitSignedPczt: Pczt?,
+    val transferSignedPczts: List<Pczt>
 )
 
 /**
@@ -400,7 +402,7 @@ data class UnsignedPreparationPczt(
     val id: Long,
     val layer: Int,
     val index: Int,
-    val pcztBytes: ByteArray,
+    val pczt: Pczt,
 )
 
 /**
@@ -491,7 +493,7 @@ sealed class AttentionReason {
  */
 sealed class TransferResult {
     data class Success(
-        val txId: String
+        val txId: TransactionId
     ) : TransferResult()
 
     /**
@@ -635,14 +637,14 @@ interface OrchardMigrationSdk {
      * [storeSignedNoteSplitPczt]. Throws if [proposal]'s plan has been superseded by a later
      * propose/prepare call (see [NoteSplitProposal.proposalHandle]).
      */
-    suspend fun createUnsignedNoteSplitPczt(proposal: NoteSplitProposal): ByteArray
+    suspend fun createUnsignedNoteSplitPczt(proposal: NoteSplitProposal): Pczt
 
     /**
      * Accepts the externally-signed note-split PCZT, finalizes it, and broadcasts it — the
      * back half of [createUnsignedNoteSplitPczt], mirroring [submitNoteSplit]'s composition
      * (extract → broadcast via the existing submission path → record result) exactly.
      */
-    suspend fun storeSignedNoteSplitPczt(signedPczt: ByteArray, options: NetworkPrivacyOptions): TransferResult
+    suspend fun storeSignedNoteSplitPczt(signedPczt: Pczt, options: NetworkPrivacyOptions): TransferResult
 
     /**
      * Builds one unsigned PCZT per transfer of `schedule` for an external signer — the
@@ -654,7 +656,7 @@ interface OrchardMigrationSdk {
      * placeholder-witness scheme [signAndStoreMigrationSchedule] does — callers do not need to
      * wait for the note-split to confirm on-chain before calling this either.
      */
-    suspend fun createUnsignedTransferPczts(schedule: MigrationSchedule): List<Pair<Long, ByteArray>>
+    suspend fun createUnsignedTransferPczts(schedule: MigrationSchedule): List<Pair<Long, Pczt>>
 
     /**
      * Every PREPARATION transaction's unsigned, ZIP32-annotated PCZT — the WHOLE note-split tree.
@@ -674,7 +676,7 @@ interface OrchardMigrationSdk {
      * role): [finalizeReadyTransfers] later completes any transfer that was staged awaiting proof,
      * exactly as it already does for the software-signing path.
      */
-    suspend fun storeSignedSchedulePczts(signed: List<Pair<Long, ByteArray>>)
+    suspend fun storeSignedSchedulePczts(signed: List<Pair<Long, Pczt>>)
 
     /**
      * Builds the animated multi-part QR frames for one combined Keystone batch-signing request
@@ -687,8 +689,8 @@ interface OrchardMigrationSdk {
      */
     suspend fun buildKeystoneSignBatchQrParts(
         requestId: ByteArray,
-        splitUnsignedPczt: ByteArray?,
-        transferUnsignedPczts: List<ByteArray>,
+        splitUnsignedPczt: Pczt?,
+        transferUnsignedPczts: List<Pczt>,
         maxFragmentLen: Int
     ): List<String>
 
@@ -713,8 +715,8 @@ interface OrchardMigrationSdk {
      * bytes for each, ready for [storeSignedNoteSplitPczt]/[storeSignedSchedulePczts].
      */
     suspend fun applyKeystoneBatchSignatures(
-        splitUnsignedPczt: ByteArray?,
-        transferUnsignedPczts: List<ByteArray>,
+        splitUnsignedPczt: Pczt?,
+        transferUnsignedPczts: List<Pczt>,
         batchSignResponse: ByteArray
     ): KeystoneBatchSignedPczts
 
@@ -993,7 +995,7 @@ interface OrchardMigrationSdk {
      * engine's `apply_signature` — the state-machine contract for the Keystone flow. Returns
      * whether the state changed.
      */
-    suspend fun applySignature(transferId: Long, signedPczt: ByteArray): Boolean
+    suspend fun applySignature(transferId: Long, signedPczt: Pczt): Boolean
 
     /**
      * The engine's Keystone signing-round budget ([KeystoneSigningRoundBudget]) — how many TOTAL

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/exception/Exceptions.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/exception/Exceptions.kt
@@ -323,7 +323,7 @@ sealed class InitializeException(
     ) : InitializeException(
             "Failed to import new account based on UFVK because its checkpoints are not yet " +
                 "in sync across shielded pools. This is usually transient and resolves once " +
-                "more blocks are scanned; retry the import later. Cause: ${cause?.message}",
+                "more blocks are scanned; retry the import later.",
             cause
         )
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
@@ -59,8 +59,10 @@ import cash.z.ecc.android.sdk.internal.storage.preference.keys.EncryptedPreferen
 import cash.z.ecc.android.sdk.internal.transaction.submitTransaction
 import cash.z.ecc.android.sdk.model.AccountUuid
 import cash.z.ecc.android.sdk.model.FirstClassByteArray
+import cash.z.ecc.android.sdk.model.Pczt
 import cash.z.ecc.android.sdk.model.Proposal
 import cash.z.ecc.android.sdk.model.SdkFlags
+import cash.z.ecc.android.sdk.model.TransactionId
 import cash.z.ecc.android.sdk.model.TransactionSubmitResult
 import cash.z.ecc.android.sdk.model.UnifiedSpendingKey
 import cash.z.ecc.android.sdk.model.ZcashNetwork
@@ -401,23 +403,23 @@ internal class OrchardMigrationSdkImpl(
 
     // ── External signer (Keystone hardware wallet) ──────────────────────────
 
-    override suspend fun createUnsignedNoteSplitPczt(proposal: NoteSplitProposal): ByteArray =
+    override suspend fun createUnsignedNoteSplitPczt(proposal: NoteSplitProposal): Pczt =
         logged("createUnsignedNoteSplitPczt") {
             val dbDataPath = dbDataPath()
             val account = account ?: noAccountAvailable()
-            migrationBackend.createUnsignedNoteSplitPczt(dbDataPath, network, account, proposal.proposalHandle)
+            Pczt(migrationBackend.createUnsignedNoteSplitPczt(dbDataPath, network, account, proposal.proposalHandle))
         }
 
     /** Phase-split for the same reason as [submitNoteSplit]. */
     override suspend fun storeSignedNoteSplitPczt(
-        signedPczt: ByteArray,
+        signedPczt: Pczt,
         options: NetworkPrivacyOptions
     ): TransferResult {
         val prepared =
             logged("storeSignedNoteSplitPczt.prepare") {
                 val dbDataPath = dbDataPath()
                 val account = account ?: noAccountAvailable()
-                val stored = migrationBackend.storeSignedNoteSplitPczt(dbDataPath, network, account, signedPczt)
+                val stored = migrationBackend.storeSignedNoteSplitPczt(dbDataPath, network, account, signedPczt.toByteArray())
                 PreparedBroadcast(
                     dbDataPath = dbDataPath,
                     account = account,
@@ -432,13 +434,13 @@ internal class OrchardMigrationSdkImpl(
         return recordSubmitOutcome("storeSignedNoteSplitPczt", prepared, submitResult, minedHeight)
     }
 
-    override suspend fun createUnsignedTransferPczts(schedule: MigrationSchedule): List<Pair<Long, ByteArray>> =
+    override suspend fun createUnsignedTransferPczts(schedule: MigrationSchedule): List<Pair<Long, Pczt>> =
         logged("createUnsignedTransferPczts") {
             val dbDataPath = dbDataPath()
             val account = account ?: noAccountAvailable()
             migrationBackend
                 .createUnsignedTransferPczts(dbDataPath, network, account, schedule.proposalHandle)
-                .map { it.id to it.pcztBytes }
+                .map { it.id to Pczt(it.pcztBytes) }
         }
 
     override suspend fun createUnsignedPreparationPczts(schedule: MigrationSchedule): List<UnsignedPreparationPczt> =
@@ -447,10 +449,10 @@ internal class OrchardMigrationSdkImpl(
             val account = account ?: noAccountAvailable()
             migrationBackend
                 .createUnsignedPreparationPczts(dbDataPath, network, account, schedule.proposalHandle)
-                .map { UnsignedPreparationPczt(id = it.id, layer = it.layer, index = it.index, pcztBytes = it.pcztBytes) }
+                .map { UnsignedPreparationPczt(id = it.id, layer = it.layer, index = it.index, pczt = Pczt(it.pcztBytes)) }
         }
 
-    override suspend fun storeSignedSchedulePczts(signed: List<Pair<Long, ByteArray>>) =
+    override suspend fun storeSignedSchedulePczts(signed: List<Pair<Long, Pczt>>) =
         logged("storeSignedSchedulePczts") {
             val dbDataPath = dbDataPath()
             val account = account ?: noAccountAvailable()
@@ -459,22 +461,22 @@ internal class OrchardMigrationSdkImpl(
                 network,
                 account,
                 LongArray(signed.size) { signed[it].first },
-                Array(signed.size) { signed[it].second },
+                Array(signed.size) { signed[it].second.toByteArray() },
             )
         }
 
     override suspend fun buildKeystoneSignBatchQrParts(
         requestId: ByteArray,
-        splitUnsignedPczt: ByteArray?,
-        transferUnsignedPczts: List<ByteArray>,
+        splitUnsignedPczt: Pczt?,
+        transferUnsignedPczts: List<Pczt>,
         maxFragmentLen: Int
     ): List<String> =
         loggedRead("buildKeystoneSignBatchQrParts") {
             migrationBackend
                 .buildKeystoneSignBatchQrParts(
                     requestId,
-                    splitUnsignedPczt,
-                    transferUnsignedPczts.toTypedArray(),
+                    splitUnsignedPczt?.toByteArray(),
+                    transferUnsignedPczts.map(Pczt::toByteArray).toTypedArray(),
                     maxFragmentLen,
                 ).toList()
         }
@@ -493,15 +495,15 @@ internal class OrchardMigrationSdkImpl(
         }
 
     override suspend fun applyKeystoneBatchSignatures(
-        splitUnsignedPczt: ByteArray?,
-        transferUnsignedPczts: List<ByteArray>,
+        splitUnsignedPczt: Pczt?,
+        transferUnsignedPczts: List<Pczt>,
         batchSignResponse: ByteArray
     ): KeystoneBatchSignedPczts =
         loggedRead("applyKeystoneBatchSignatures") {
             migrationBackend
                 .applyKeystoneBatchSignatures(
-                    splitUnsignedPczt,
-                    transferUnsignedPczts.toTypedArray(),
+                    splitUnsignedPczt?.toByteArray(),
+                    transferUnsignedPczts.map(Pczt::toByteArray).toTypedArray(),
                     batchSignResponse,
                 ).toPublic()
         }
@@ -733,7 +735,7 @@ internal class OrchardMigrationSdkImpl(
                 // already MINED, i.e. already public/on-chain, so the post-broadcast de-correlation
                 // buffer has no privacy value left to protect on this recovery path — arming
                 // `now + buffer` would just needlessly block sync for no privacy benefit.
-                TransferAttemptOutcome.Executed(TransferResult.Success(attempt.prepared.txid.toHexReversed()))
+                TransferAttemptOutcome.Executed(TransferResult.Success(TransactionId.new(attempt.prepared.txid)))
             }
         }
     }
@@ -1098,11 +1100,11 @@ internal class OrchardMigrationSdkImpl(
                 ?.map { row -> MigrationSyncWakeup(height = row[0], covers = row.drop(1)) }
         }
 
-    override suspend fun applySignature(transferId: Long, signedPczt: ByteArray): Boolean =
+    override suspend fun applySignature(transferId: Long, signedPczt: Pczt): Boolean =
         logged("applySignature") {
             val dbDataPath = dbDataPath()
             val account = account ?: noAccountAvailable()
-            migrationBackend.applySignature(dbDataPath, network, account, transferId, signedPczt)
+            migrationBackend.applySignature(dbDataPath, network, account, transferId, signedPczt.toByteArray())
         }
 
     override suspend fun keystoneSigningRoundBudget(): KeystoneSigningRoundBudget =
@@ -1462,7 +1464,7 @@ private fun mapSubmitResult(
     when (result) {
         is TransactionSubmitResult.Success -> {
             MappedTransferResult(
-                transferResult = TransferResult.Success(result.txIdString()),
+                transferResult = TransferResult.Success(TransactionId.new(result.txId)),
                 tag = 0,
                 retryable = false,
                 txIdBytes = result.txId.byteArray,
@@ -1484,7 +1486,7 @@ private fun mapSubmitResult(
                 // as Success (tag=0) so the pre-signed plan is not terminally failed.
                 classifyNonGrpcFailure(result.description, minedHeight) -> {
                     MappedTransferResult(
-                        TransferResult.Success(preparedTxid.toHexReversed()),
+                        TransferResult.Success(TransactionId.new(preparedTxid)),
                         tag = 0,
                         retryable = false,
                         txIdBytes = preparedTxid,
@@ -1722,8 +1724,8 @@ private fun JniKeystoneBatchDecodeResult.toPublic(): KeystoneBatchDecodeResult =
 
 private fun JniKeystoneBatchSignedPczts.toPublic(): KeystoneBatchSignedPczts =
     KeystoneBatchSignedPczts(
-        splitSignedPczt = splitSignedPczt,
-        transferSignedPczts = transferSignedPczts.toList(),
+        splitSignedPczt = splitSignedPczt?.let(::Pczt),
+        transferSignedPczts = transferSignedPczts.map(::Pczt),
     )
 
 private fun JniMigrationState.toPublic(): MigrationState =

--- a/sdk-lib/src/main/java/com/zodl/slipstream/SlipstreamSynchronizer.kt
+++ b/sdk-lib/src/main/java/com/zodl/slipstream/SlipstreamSynchronizer.kt
@@ -798,7 +798,7 @@ class SlipstreamSynchronizer internal constructor(
     override suspend fun getAccounts(): List<Account> {
         awaitDbReady()
         return runCatchingCancellable { backend.getAccounts().map(Account::new) }
-            .onFailure { Twig.error(it) { "Get wallet accounts failed." } }
+            .onFailure { Twig.error { "Get wallet accounts failed." } }
             .getOrElse { throw InitializeException.GetAccountsException(it) }
     }
 

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImplTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImplTest.kt
@@ -415,7 +415,7 @@ class OrchardMigrationSdkImplTest {
             check(outcome is TransferAttemptOutcome.Executed) { "expected Executed, got $outcome" }
             val result = outcome.result
             check(result is TransferResult.Success) { "expected Success, got $result" }
-            assertEquals(prepared.txid.toHexReversed(), result.txId)
+            assertEquals(prepared.txid.toHexReversed(), result.txId.txIdString())
         }
 
     /**


### PR DESCRIPTION
This replaces some byte arrays and strings with our preexisting semantic API types.