### PR TITLE
MOB-1669: snapshot spendable-note read on first use in migration Backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Migration Keystone batch signing no longer stalls for seconds when building the first note-split
+  PCZT of a run: spendable-note selection is now cached for the lifetime of one migration call
+  instead of being re-queried from the wallet database on every note the plan spends (MOB-1669).
+
 ## [3.0.1] - 2026-08-08
 
 ### Changed

--- a/backend-lib/src/main/rust/migration_engine.rs
+++ b/backend-lib/src/main/rust/migration_engine.rs
@@ -66,6 +66,16 @@ pub struct Backend<'a, W> {
     /// transaction's outputs (needing `params`) and stamps the sent-transaction time (needing the
     /// clock). Both are unused by the read/write-state methods.
     store: PoolMigrations<&'a mut Connection, Network, SystemClock>,
+    /// The spendable-note snapshot every `resolve_wallet_note`/`spendable_orchard_note_values`
+    /// read is served from, filled on first use — see `spendable_orchard` (MOB-1669, 2026-08-10:
+    /// this used to re-run `select_unspent_notes` from scratch on EVERY call, confirmed live as
+    /// the ~7s-per-call cost behind "Android took 3.5 minutes to generate 3 batched QRs" — a note
+    /// split with N wallet-sourced inputs paid that full query cost N times over). Mirrors
+    /// upstream `zcash_pool_migration::wallet::WalletMigration`'s own field of the same purpose
+    /// (`wallet.rs`): the engine addresses a note by its index into this sequence, so every read
+    /// through one `Backend` instance must see the same set — a fresh `Backend` (one per JNI call)
+    /// observes wallet changes by construction, not by invalidating this cache.
+    spendable: std::cell::RefCell<Option<Vec<SpendableNote>>>,
 }
 
 impl<'a, W> Backend<'a, W>
@@ -90,6 +100,7 @@ where
             account,
             usk,
             store,
+            spendable: std::cell::RefCell::new(None),
         })
     }
 
@@ -122,32 +133,41 @@ where
     /// The account's spendable Orchard notes as `(note, tree position, value)`, sorted by tree
     /// position so an index is stable across calls within one JNI invocation (matches
     /// `WalletMigration`'s own ordering contract, which the engine relies on).
-    fn spendable_orchard(&self) -> Result<Vec<SpendableNote>, EngineError> {
-        let target = self.selection_target()?;
-        // Exclude notes locked by another in-flight proposal (e.g. a concurrent foreground send)
-        // rather than ignoring locks — migration actually spends these notes, so racing a locked
-        // one would double-spend against whatever proposal is holding it.
-        let received = self
-            .wallet
-            .select_unspent_notes(
-                self.account,
-                &[ShieldedPool::Orchard],
-                target,
-                &[],
-                LockFilter::Policy(&LockedInputPolicy::Exclude),
-            )
-            .map_err(|e| anyhow::anyhow!("selecting spendable Orchard notes failed: {e}"))?;
-        let mut notes: Vec<SpendableNote> = received
-            .orchard()
-            .iter()
-            .map(|rn| {
-                let note = *rn.note();
-                let value = note.value().inner();
-                (note, rn.note_commitment_tree_position(), value)
-            })
-            .collect();
-        notes.sort_by_key(|(_, pos, _)| *pos);
-        Ok(notes)
+    ///
+    /// Snapshotted on the FIRST read within this `Backend` instance's lifetime — see the
+    /// `spendable` field's doc comment. Every subsequent call within the same instance is served
+    /// from the cache instead of re-running `select_unspent_notes`.
+    fn spendable_orchard(&self) -> Result<std::cell::Ref<'_, [SpendableNote]>, EngineError> {
+        if self.spendable.borrow().is_none() {
+            let target = self.selection_target()?;
+            // Exclude notes locked by another in-flight proposal (e.g. a concurrent foreground
+            // send) rather than ignoring locks — migration actually spends these notes, so racing
+            // a locked one would double-spend against whatever proposal is holding it.
+            let received = self
+                .wallet
+                .select_unspent_notes(
+                    self.account,
+                    &[ShieldedPool::Orchard],
+                    target,
+                    &[],
+                    LockFilter::Policy(&LockedInputPolicy::Exclude),
+                )
+                .map_err(|e| anyhow::anyhow!("selecting spendable Orchard notes failed: {e}"))?;
+            let mut notes: Vec<SpendableNote> = received
+                .orchard()
+                .iter()
+                .map(|rn| {
+                    let note = *rn.note();
+                    let value = note.value().inner();
+                    (note, rn.note_commitment_tree_position(), value)
+                })
+                .collect();
+            notes.sort_by_key(|(_, pos, _)| *pos);
+            *self.spendable.borrow_mut() = Some(notes);
+        }
+        Ok(std::cell::Ref::map(self.spendable.borrow(), |cached| {
+            cached.as_deref().expect("filled above")
+        }))
     }
 }
 
@@ -161,9 +181,9 @@ where
 
     fn spendable_orchard_note_values(&self) -> Result<Vec<Zatoshis>, Self::Error> {
         self.spendable_orchard()?
-            .into_iter()
+            .iter()
             .enumerate()
-            .map(|(i, (_, _, value))| {
+            .map(|(i, &(_, _, value))| {
                 Zatoshis::from_u64(value)
                     .map_err(|_| anyhow::anyhow!("spendable note {i} has an invalid value"))
             })


### PR DESCRIPTION
## Summary
`Backend::resolve_wallet_note` (via `spendable_orchard`) re-ran `select_unspent_notes` — a real SQLite query enumerating and sorting every spendable Orchard note for the account — from scratch on every single call, with no caching. It's called once per wallet-sourced spend input while a preparation tree is built, so a note split needing N wallet inputs paid that full query cost N times over.

Confirmed live on a physical Pixel: `createUnsignedNoteSplitPczt` dropped from ~7.1-7.3s to ~845ms (an ~8.4x improvement) — this was the dominant cause of a QA report ("Android took 3.5 minutes to generate 3 batched QRs" during Keystone migration signing, vs. iOS "instant" on the same flow).

Fix mirrors `zcash_pool_migration`'s own upstream `WalletMigration` adapter, which already snapshots spendable notes on first read within one adapter instance's lifetime — the exact registry `0.1.0-rc.7` version this crate already depends on, no dependency bump needed. See `spec/2026-08-10-migration-engine-walletmigration-adapter-plan.md` for why wholesale-adopting `WalletMigration` itself (to literally mirror iOS's architecture) is a separate, deferred, higher-risk change — iOS pins an unmerged upstream `librustzcash` revision with a breaking constructor signature change that doesn't fit ~39 of our 51 `Backend::new` call sites (Keystone/hardware-wallet and read-only flows, which hold no local spending key).

## Test plan
- [x] `cargo test --features slipstream` — 62/62 passing
- [x] `cargo clippy --tests --all-features -- -W clippy::all` — clean (no new findings)
- [x] `cargo fmt --all -- --check` — clean
- [x] Live-verified on a physical Pixel (mainnet internal debug): `createUnsignedNoteSplitPczt` timing confirmed dropping from ~7.1-7.3s to ~845ms
- [ ] Dedicated cache-behavior regression test (proving the snapshot holds across a mid-lifetime wallet mutation) is a tracked fast-follow — no existing lightweight `InputSource`/wallet test double exists in this codebase to build one on cheaply; every existing test touching `Backend` requires a real `MIGRATION_TEST_WALLET_DB`