### PR TITLE
Use zcash_voting 2.0.0-rc.5 from crates.io

### DIFF
--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -1206,7 +1206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d308ebe4b10924331bd079044b418da7b227d724d3e2408567a47ad7c3da2a0"
 dependencies = [
  "derive-deftly-macros",
- "heck 0.4.1",
+ "heck 0.5.0",
 ]
 
 [[package]]
@@ -1215,7 +1215,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "indexmap 2.14.0",
  "itertools 0.15.0",
  "proc-macro-crate",
@@ -1342,7 +1342,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1592,7 +1592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2635,7 +2635,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2984,7 +2984,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3788,7 +3788,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -4261,7 +4261,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4801,7 +4801,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -5009,7 +5009,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6961,7 +6961,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -1206,7 +1206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d308ebe4b10924331bd079044b418da7b227d724d3e2408567a47ad7c3da2a0"
 dependencies = [
  "derive-deftly-macros",
- "heck 0.5.0",
+ "heck 0.4.1",
 ]
 
 [[package]]
@@ -1215,7 +1215,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "indexmap 2.14.0",
  "itertools 0.15.0",
  "proc-macro-crate",
@@ -1342,7 +1342,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1592,7 +1592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2635,7 +2635,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2984,7 +2984,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3788,7 +3788,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -4261,7 +4261,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4801,7 +4801,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -5009,7 +5009,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6694,7 +6694,8 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vote-commitment-tree"
 version = "0.4.0-rc.2"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=60f468a42ade1b021439b2d0bdd238044703ea3f#60f468a42ade1b021439b2d0bdd238044703ea3f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3e4675e494f06faa7a5e571c69ec9e74142a2d222384696ba3d313a938b11e"
 dependencies = [
  "anyhow",
  "ff",
@@ -6710,7 +6711,8 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.6.0-rc.2"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=60f468a42ade1b021439b2d0bdd238044703ea3f#60f468a42ade1b021439b2d0bdd238044703ea3f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9bf6de4d2870aff92b3388df3572d186b1bf64fda3cee623e220d3874f7665"
 dependencies = [
  "base64",
  "ff",
@@ -6959,7 +6961,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7809,8 +7811,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/valargroup/zcash_voting.git?rev=60f468a42ade1b021439b2d0bdd238044703ea3f#60f468a42ade1b021439b2d0bdd238044703ea3f"
+version = "2.0.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb38f2178857e07f0d832c701ee0fb5b752660a12ccc89df3efcae6a5ee8c42"
 dependencies = [
  "anyhow",
  "base64",

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -136,11 +136,11 @@ xz2 = { version = "0.1", features = ["static"] }
 # https://github.com/valargroup/voting-circuits/blob/v0.8.0/voting-circuits/src/share_reveal/circuit.rs
 #
 # To re-enable: uncomment these three, add `unstable-voting-circuits` back to the
-# orchard dependency above, uncomment the `zcash_voting` entry in `[patch.crates-io]`
-# below (the 1.0 sources this tree is written against are the git rev, not the published
-# crate), and build with `--cfg zcash_voting`. `incrementalmerkletree` above stays
-# uncommented either way -- the migration engine uses it too.
-zcash_voting = { version = "2.0.0-rc.4" }
+# orchard dependency above, and build with `--cfg zcash_voting`. The 2.0 sources this
+# tree is written against are a published crates.io release, so no `[patch.crates-io]`
+# entry is needed. `incrementalmerkletree` above stays uncommented either way -- the
+# migration engine uses it too.
+zcash_voting = { version = "2.0.0-rc.5" }
 
 # The delegation-submission signing recipe (voting/delegation.rs) derives the account
 # SpendAuth key locally and needs the same Pallas scalar/field types zcash_voting and
@@ -212,8 +212,6 @@ crate-type = ["staticlib", "cdylib"]
 [workspace]
 
 [patch.crates-io]
-zcash_voting = { git = "https://github.com/valargroup/zcash_voting.git", rev = "60f468a42ade1b021439b2d0bdd238044703ea3f" }
-
 # DO NOT ALTER THIS COMMENT
 #
 # This section is left in place to ensure that development against in-progress

--- a/backend-lib/src/main/rust/voting/delegation.rs
+++ b/backend-lib/src/main/rust/voting/delegation.rs
@@ -988,6 +988,7 @@ mod tests {
             vote_round_id: "round-1".to_string(),
             spend_auth_sig,
             sighash,
+            tx1_effects: vec![8; voting::tx1::TX1_EFFECTS_LEN],
         }
     }
 }


### PR DESCRIPTION
Bumps the shielded-voting dependency from `2.0.0-rc.4` to `2.0.0-rc.5` and
removes the `[patch.crates-io]` git pin.

## Changes

- `zcash_voting` `2.0.0-rc.4` -> `2.0.0-rc.5`.
- Dropped the `[patch.crates-io]` entry pointing at the valargroup git
  remote. rc.5 is a published crates.io release, so the git revision the
  patch existed to supply is no longer needed. `zcash_voting`,
  `vote-commitment-tree` and `vote-commitment-tree-client` now all resolve
  from the registry in `Cargo.lock`.
- Updated the stale re-enable comment in `Cargo.toml`, which told the
  reader to uncomment a patch entry that no longer exists.
- Second commit: added the missing `tx1_effects` field to the test-only
  `DelegationSubmissionData` fixture. That constructor was not updated when
  the production JNI path adopted `tx1_effects`, so the test target failed
  to build with E0063 before this change.

## Notes

rc.5 changes no API this tree depends on. `DelegationSubmissionData`
already carried `tx1_effects` in rc.4, so the only build break was the
pre-existing test fixture above.

## Testing

- `RUSTFLAGS="--cfg zcash_voting" cargo check --all-targets` is clean.
- `RUSTFLAGS="--cfg zcash_voting" cargo test voting::` passes, 8/8
  (including the three delegation tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)