### PR TITLE
migration: reuse librustzcash helpers instead of hand-rolling them

### DIFF
--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -76,13 +76,10 @@ pub(crate) fn propose_orchard_to_ironwood(
         .chain_height()
         .map_err(|e| anyhow!("Error reading the chain tip: {}", e))?
         .ok_or_else(|| anyhow!("Wallet has not yet scanned any blocks."))?;
-    match network.activation_height(NetworkUpgrade::Nu6_3) {
-        Some(h) if chain_tip >= h => (),
-        _ => {
-            return Err(anyhow!(
-                "Ironwood (NU6.3) is not active yet; there is nothing to migrate to."
-            ));
-        }
+    if !network.is_nu_active(NetworkUpgrade::Nu6_3, chain_tip) {
+        return Err(anyhow!(
+            "Ironwood (NU6.3) is not active yet; there is nothing to migrate to."
+        ));
     }
 
     let orchard_fvk = db_data

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -13,8 +13,8 @@
 
 use anyhow::anyhow;
 use rand::rngs::OsRng;
-use zcash_address::{ToAddress, ZcashAddress, unified, unified::Encoding as _};
 use zcash_client_backend::{
+    address::Receiver,
     data_api::{
         Account as _, InputSource, MaxSpendMode, WalletRead,
         wallet::{
@@ -93,14 +93,16 @@ pub(crate) fn propose_orchard_to_ironwood(
 
     // The internal scope is the account's own change address, so the funds
     // stay with the account rather than being exposed as an external payment.
+    //
+    // [`Receiver::to_zcash_address`] wraps a bare Orchard address as the
+    // single-receiver unified address this call needs. It performs the same
+    // three steps (raw address bytes, one-item `unified::Address`,
+    // `from_unified`) that this function used to spell out by hand. The
+    // hand-rolled form also propagated a `try_from_items` error that cannot
+    // occur: a unified address may always hold one Orchard receiver, which is
+    // why upstream asserts it instead.
     let receiver = orchard_fvk.address_at(0u32, orchard::keys::Scope::Internal);
-    let recipient = ZcashAddress::from_unified(
-        network.network_type(),
-        unified::Address::try_from_items(vec![unified::Receiver::Orchard(
-            receiver.to_raw_address_bytes(),
-        )])
-        .map_err(|e| anyhow!("Unable to construct the migration recipient: {}", e))?,
-    );
+    let recipient = Receiver::Orchard(receiver).to_zcash_address(network.network_type());
 
     // Orchard only. Sapling and transparent funds are deliberately left where
     // they are: this migrates one pool, it is not a sweep of the wallet.


### PR DESCRIPTION
Two spots in `propose_orchard_to_ironwood` reimplemented logic librustzcash
already exposes publicly. Both are replaced with the upstream call. No
behaviour change; net -1 line, and one import line dropped.

## 1. NU6.3 activation guard -> `Parameters::is_nu_active`

The guard matched on `activation_height` by hand:

```rust
match network.activation_height(NetworkUpgrade::Nu6_3) {
    Some(h) if chain_tip >= h => (),
    _ => return Err(...),
}
```

`zcash_protocol::consensus::Parameters::is_nu_active` (consensus.rs:409) is a
public trait method whose default body is
`self.activation_height(nu).is_some_and(|h| h <= height)`. That agrees with the
old match on every input, including the unset-activation case, where both treat
the upgrade as inactive.

## 2. Recipient construction -> `Receiver::to_zcash_address`

The recipient was assembled from raw parts: address bytes, a one-item
`unified::Address`, then `ZcashAddress::from_unified`.

`zcash_keys::address::Receiver::to_zcash_address` (address.rs:274, re-exported
from `zcash_client_backend::address`) performs exactly those three steps in its
`Receiver::Orchard` arm. The one difference is error handling: upstream
`expect`s the `try_from_items` result because a unified address may always hold
a single Orchard receiver, whereas the local code propagated an `anyhow` error
for that case. That error arm was unreachable, so nothing is lost.

## Not changed, and why

- `orchard_fvk.address_at(0, Scope::Internal)` has no upstream equivalent that
  returns the internal-scope Orchard receiver at diversifier 0.
  `get_next_available_address` and `get_last_generated_address_matching` return
  external-scope unified addresses, and
  `reserve_next_n_internal_addresses` is transparent-only.
- `chain_height()` and `get_account().ufvk().orchard()` are already direct
  upstream calls.

## Testing

Run against the librustzcash revision this branch pins
(`f641579aa1c2ec2124953527284f9152d27f075a`):

- `cargo check --all-targets` - clean, no errors or warnings
- `cargo test` - 4 passed, 0 failed (this branch has no tests covering
  `migration.rs`; the crate's only unit tests are in `utils::exception`)
- `make check-format-rust` - passes
- `make lint-rust` - passes with no output

🤖 Generated with [Claude Code](https://claude.com/claude-code)