### PR TITLE
deploy-snapshot: free runner disk space (fix 3.0.2 snapshot deploy)

### DIFF
--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -72,6 +72,23 @@ jobs:
           # No job here pushes or otherwise re-uses the checkout credential, so keep it
           # out of .git/config where it would be picked up by artifact uploads.
           persist-credentials: false
+      - name: Free runner disk space
+        # This job builds every demo-app variant plus the 4-ABI Rust backend on one
+        # runner; the ~14 GB free on ubuntu-latest is not enough, and the overflow
+        # surfaces as a cause-less packageZcash* IncrementalSplitterRunnable failure.
+        # Drop preinstalled toolchains this build never uses (~12 GB).
+        timeout-minutes: 3
+        shell: bash
+        run: |
+          df -h /
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/share/swift \
+            /usr/local/.ghcup \
+            /usr/local/share/boost \
+            /usr/local/share/powershell \
+            "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}/CodeQL"
+          df -h /
       - name: Setup
         id: setup
         timeout-minutes: 50


### PR DESCRIPTION
## Development

Second review PR for the 3.0.2 release (same pattern as #2150 + #2151 for 3.0.1).

Both `deploy-snapshot` attempts on `release/v3.0.2` ([run 31417816399](https://github.com/zcash/zcash-android-wallet-sdk/actions/runs/31417816399)) failed in the setup `./gradlew assemble` warm-up with a cause-less `:demo-app:packageZcash* > IncrementalSplitterRunnable` failure — the canonical disk-full signature (AGP swallows the IOException when the APK zip write fails). Evidence it's the runner, not the tree:

- the failing variant moved between attempts (`mainnetRelease` → `mainnetDebug`) at the same ~31 min mark,
- attempt 2 ran with **zero** cache hits and failed identically, ruling out a poisoned cache,
- per-job PR CI builds each of these variants fine on the same tree — only this job assembles all six demo-app variants **plus** the 4-ABI Rust backend on one runner,
- the tree grew since 3.0.1's successful deploys (#2153 folded the v2.8.x line in).

The fix is the standard free-disk step: drop ~12 GB of preinstalled toolchains this build never uses (dotnet, swift, ghcup, boost, powershell, CodeQL), with `df -h` before/after so the effect is visible in the log.

The publish itself (`publishToMavenCentral`) never ran, so nothing was partially deployed; `3.0.2-SNAPSHOT` is still absent from the snapshot repository.