### PR TITLE
MOB-1584: Surface created transactions in allTransactions at store time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- A newly created transaction now becomes visible in `Synchronizer.allTransactions` on the next
+  engine tick (~2 s) instead of only after its network broadcast round-trip resolves: the
+  Slipstream broadcaster pokes the engine's transaction-change signal at store time in both
+  `createProposedTransactions` and `createTransactionFromPczt`, in addition to the existing
+  submit-time poke. Under a degraded network the submit-time-only poke left a sent transaction
+  invisible in the Activity list for the whole multi-endpoint submit window (MOB-1584).
 - Migration Keystone batch signing no longer stalls for seconds when building the first note-split
   PCZT of a run: spendable-note selection is now cached for the lifetime of one migration call
   instead of being re-queried from the wallet database on every note the plan spends (MOB-1669).

--- a/sdk-lib/src/main/java/com/zodl/slipstream/internal/spend/SlipstreamBroadcaster.kt
+++ b/sdk-lib/src/main/java/com/zodl/slipstream/internal/spend/SlipstreamBroadcaster.kt
@@ -30,6 +30,12 @@ import java.io.File
  * this implementation DOES poke [SlipstreamEngine.notifyTxChange] on every `submit` - a gap the
  * Swift adapter has that this one deliberately does not copy, since the engine is the only
  * `allTransactions` signal on Android (there is no separate event stream to fall back on).
+ *
+ * The same poke fires store-first at the end of both create methods (MOB-1584): a stored
+ * transaction must become visible in `allTransactions` on the next engine tick, not only after
+ * its network broadcast round-trip resolves - under a degraded network the submit-time-only poke
+ * left a created transaction invisible for the whole multi-endpoint submit window (up to its 30 s
+ * global timeout), which testers reported as the Activity list showing a send minutes late.
  */
 internal class SlipstreamBroadcaster(
     private val backend: Backend,
@@ -46,7 +52,9 @@ internal class SlipstreamBroadcaster(
     ): List<CreatedTransaction> {
         SaplingParams.ensureDownloaded(saplingParamsDir)
         val txIds = backend.createProposedTransactions(proposal.toUnsafe(), usk.copyBytes())
-        return txIds.map { txId -> storeAsAwaitingSubmission(FirstClassByteArray(txId)) }
+        val created = txIds.map { txId -> storeAsAwaitingSubmission(FirstClassByteArray(txId)) }
+        engine.notifyTxChange()
+        return created
     }
 
     override suspend fun createTransactionFromPczt(
@@ -54,7 +62,9 @@ internal class SlipstreamBroadcaster(
         pcztWithSignatures: Pczt
     ): List<CreatedTransaction> {
         val txId = backend.extractAndStoreTxFromPczt(pcztWithProofs.toByteArray(), pcztWithSignatures.toByteArray())
-        return listOf(storeAsAwaitingSubmission(FirstClassByteArray(txId)))
+        val created = listOf(storeAsAwaitingSubmission(FirstClassByteArray(txId)))
+        engine.notifyTxChange()
+        return created
     }
 
     override suspend fun submit(


### PR DESCRIPTION
Fixes the Android side of [MOB-1584](https://linear.app/zodl/issue/MOB-1584/transaction-show-up-late-on-activity) (transactions show up late on Activity).

## Root cause

On the app's real send path (`ProposalDataSource` → `synchronizer.broadcaster`), `SlipstreamBroadcaster.createProposedTransactions()` stores the created transaction but never pokes `SlipstreamEngine.notifyTxChange()`; the only poke fires in `submit()`, **after** the network broadcast round-trip resolves. Since the engine's `txSetVersion` counter is the sole `allTransactions` refresh signal (PollGate, D11), the stored transaction stays invisible in the Activity list for the whole multi-endpoint submit window — up to its 30 s global timeout per attempt on a degraded network, which testers perceived as the sent transaction appearing minutes late. (The store-first path in `SlipstreamSpendService` does poke before broadcast, but is not used by the app's ordinary sends.)

Measured on an emulator with instrumentation (testnet, healthy network): store → visible = broadcast round-trip (2.0 s) + up to one 2 s engine tick; with this fix the store-time poke makes the row visible on the next tick regardless of broadcast progress.

## Fix

Fire `engine.notifyTxChange()` at the end of both `createProposedTransactions` and `createTransactionFromPczt` (store-first, matching the S-SPEND rule), keeping the existing submit-time poke. Class KDoc and CHANGELOG updated.

## Verification

- `:sdk-lib:compileDebugKotlin` green on this branch.
- On-device timeline (instrumented build of the pre-fix code) confirming the mechanism: store at 16:53:47.1 with no poke → submit returns 16:53:49.2 → poke → next tick requery at 16:53:50.9 shows the new row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)