### PR TITLE
Fix spendable balance pinned at zero after Orchard→Ironwood migration (MOB-1667)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,24 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migration Keystone batch signing no longer stalls for seconds when building the first note-split
   PCZT of a run: spendable-note selection is now cached for the lifetime of one migration call
   instead of being re-queried from the wallet database on every note the plan spends (MOB-1669).
+- Spendable balance no longer stays pinned at zero indefinitely (with a correct total balance and a
+  `SYNCED` status) after an Orchard→Ironwood migration (MOB-1667). Three defects chained into that
+  state, and all three are fixed:
+  - the `readyToBroadcast` leg of the migration sync block had no time bound, unlike the other two
+    legs. Its escape - the plan's stale-plan expiry - is evaluated against the scanned tip, which
+    only advances while sync runs, so a migration driver that never ran again (a background worker
+    killed by an aggressive OEM scheduler) paused sync forever. It is now capped at three privacy
+    sync buffers of continuous readiness, re-armed by every live transfer attempt;
+  - `Synchronizer.pause()` stopped the engine's poll loop, which performs only local reads and
+    never gated the network session it was supposed to decorrelate; the pause therefore froze the
+    balances, heights and status the host renders - and forced `status` to `SYNCED` while they were
+    frozen. Pausing now suppresses `syncBurst` and transaction resubmission only, keeps polling, and
+    reports the engine's real status. `resume()` restarts an engine a preceding `onBackground()`
+    stopped instead of polling a dead session;
+  - the stale-tip spendable mask now fails open after 15 minutes of consecutive stale ticks. It
+    could otherwise never lift, because the engine's `tipFresh` flag latches only when a full
+    network prologue completes. Showing spendable against an unverified tip cannot lose funds - a
+    spend built on a stale tip fails at propose or broadcast.
 
 ## [3.0.1] - 2026-08-08
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
@@ -1336,14 +1336,14 @@ interface CloseableSynchronizer :
     Synchronizer,
     Closeable {
     /**
-     * Pauses block-scanning without tearing the synchronizer down: the engine's poll loop stops
-     * (no new network sync — used to decorrelate wallet sync from a migration broadcast) but the
-     * instance and all its StateFlows (status, balances, heights) stay alive and readable. While
-     * paused, [status] reports [Synchronizer.Status.SYNCED]. Idempotent.
+     * Closes the migration privacy gate without tearing the synchronizer down — used to decorrelate
+     * host-initiated sync traffic from a migration broadcast. [syncBurst] refuses to run and no
+     * transaction is resubmitted while paused; the instance, its poll loop and all its StateFlows
+     * (status, balances, heights) stay alive, live and truthful. Idempotent.
      */
     fun pause()
 
-    /** Resumes block-scanning after [pause]. Idempotent. */
+    /** Reopens the gate after [pause], restarting a stopped engine when foregrounded. Idempotent. */
     fun resume()
 }
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
@@ -918,6 +918,7 @@ internal class OrchardMigrationSdkImpl(
         options: NetworkPrivacyOptions,
         useEstimatedTip: Boolean,
     ): TransferAttemptOutcome {
+        reStampSyncBlockReadySince()
         val preparation =
             logged("executeNextPendingTransfer.prepare") {
                 prepareNextPendingTransfer(options, useEstimatedTip)
@@ -1189,6 +1190,8 @@ internal class OrchardMigrationSdkImpl(
                 }
             }
         val nowEpochSeconds = Clock.System.now().epochSeconds
+        val readyToBroadcastWithinCap =
+            boundedReadyToBroadcast(preferenceProvider, readyToBroadcast, nowEpochSeconds)
         val resumeAtEpochSeconds =
             preferenceProvider.getString(EncryptedPreferenceKeys.MIGRATION_SYNC_RESUME_AT.key)?.toLongOrNull()
         val bufferActive = resumeAtEpochSeconds != null && resumeAtEpochSeconds > nowEpochSeconds
@@ -1196,7 +1199,71 @@ internal class OrchardMigrationSdkImpl(
             preferenceProvider.getString(EncryptedPreferenceKeys.MIGRATION_BROADCAST_IN_FLIGHT_UNTIL.key)?.toLongOrNull()
                 ?: 0L
         val broadcastInFlight = isBroadcastInFlight(nowEpochSeconds, inFlightUntilEpochSeconds)
-        return readyToBroadcast || bufferActive || broadcastInFlight
+        return readyToBroadcastWithinCap || bufferActive || broadcastInFlight
+    }
+
+    /**
+     * Caps how long a `STEP_BROADCAST` readiness alone may keep sync blocked, using the
+     * [EncryptedPreferenceKeys.MIGRATION_SYNC_BLOCK_READY_SINCE] stamp.
+     *
+     * The other two legs of [isSyncBlockedNow] self-expire; this one cannot. A transfer stays ready
+     * to broadcast until some driver broadcasts it, and the plan's own stale-plan expiry is
+     * evaluated against the SCANNED tip — which only advances while sync runs, i.e. exactly what
+     * this block stops. A driver that never runs again (a killed background worker, as on the
+     * aggressive OEM schedulers behind MOB-1667) therefore pauses sync forever, and a permanently
+     * paused sync never refreshes the tip.
+     *
+     * [MIGRATION_SYNC_BLOCK_READY_SINCE][EncryptedPreferenceKeys.MIGRATION_SYNC_BLOCK_READY_SINCE]
+     * is cleared as soon as readiness goes away and re-armed by every live
+     * [executeNextPendingTransfer] attempt, so a working driver keeps the block indefinitely and
+     * only a dead one lets the cap elapse.
+     */
+    private suspend fun boundedReadyToBroadcast(
+        preferenceProvider: PreferenceProvider,
+        readyToBroadcast: Boolean,
+        nowEpochSeconds: Long,
+    ): Boolean {
+        val key = EncryptedPreferenceKeys.MIGRATION_SYNC_BLOCK_READY_SINCE.key
+        val stamp = preferenceProvider.getString(key)
+        val readySinceEpochSeconds = stamp?.toLongOrNull()
+        return when {
+            !readyToBroadcast -> {
+                /*
+                 * Written only when there is something to clear: this poll runs every
+                 * SYNC_BLOCK_TICK, and a write wakes every preference observer.
+                 */
+                if (!stamp.isNullOrEmpty()) preferenceProvider.putString(key, "")
+                false
+            }
+
+            readySinceEpochSeconds == null -> {
+                preferenceProvider.putString(key, nowEpochSeconds.toString())
+                true
+            }
+
+            else -> {
+                isReadyToBroadcastBlockWithinCap(
+                    nowEpochSeconds = nowEpochSeconds,
+                    readySinceEpochSeconds = readySinceEpochSeconds,
+                    capSeconds =
+                        privacySyncBufferDuration().inWholeSeconds * READY_TO_BROADCAST_BLOCK_CAP_MULTIPLIER,
+                )
+            }
+        }
+    }
+
+    /**
+     * Re-arms [EncryptedPreferenceKeys.MIGRATION_SYNC_BLOCK_READY_SINCE] at the start of every
+     * transfer attempt, so [boundedReadyToBroadcast]'s cap measures "how long has a ready transfer
+     * gone untouched by any driver", not "how long has it been ready". A driver that keeps
+     * attempting keeps sync blocked for as long as it needs.
+     */
+    private suspend fun reStampSyncBlockReadySince() {
+        val nowEpochSeconds = Clock.System.now().epochSeconds
+        preferenceProviderHolder().putString(
+            EncryptedPreferenceKeys.MIGRATION_SYNC_BLOCK_READY_SINCE.key,
+            nowEpochSeconds.toString(),
+        )
     }
 
     private suspend fun isReadyToBroadcast(
@@ -1326,6 +1393,16 @@ internal class OrchardMigrationSdkImpl(
         // preferences immediately before calling broadcast(); cleared (written as "0") right after
         // recordTransferResult(). A stale mark from a crash self-expires within this window.
         const val BROADCAST_IN_FLIGHT_WINDOW_SECONDS = 120L
+
+        /**
+         * How many privacy sync buffers a bare `STEP_BROADCAST` readiness may keep sync blocked
+         * before [boundedReadyToBroadcast] gives up on the driver (30 min on mainnet, 9 on
+         * testnet). Three buffers because the live driver's longest legitimate wait around a forced
+         * broadcast is one buffer, so a working driver never approaches the cap — while a dead one
+         * (MOB-1667: a background worker the OS never runs again) would otherwise block sync
+         * forever, and with sync stopped the plan's scanned-tip-based expiry can never fire either.
+         */
+        const val READY_TO_BROADCAST_BLOCK_CAP_MULTIPLIER = 3L
 
         // Separate from Files.TOR_SUBDIR (the main Synchronizer's shared Tor directory) — a
         // distinct on-disk Tor client/circuit state for migration broadcasts, per NetworkPrivacyOptions.useTor
@@ -1607,6 +1684,22 @@ internal fun isBroadcastInFlight(
     nowEpochSeconds: Long,
     inFlightUntilEpochSeconds: Long,
 ): Boolean = inFlightUntilEpochSeconds > nowEpochSeconds
+
+/**
+ * Returns `true` while a transfer that has been continuously ready to broadcast since
+ * [readySinceEpochSeconds] may still block sync, i.e. while less than [capSeconds] has elapsed.
+ *
+ * The cap is [OrchardMigrationSdkImpl.READY_TO_BROADCAST_BLOCK_CAP_MULTIPLIER] privacy sync
+ * buffers; see [OrchardMigrationSdkImpl.boundedReadyToBroadcast] for why this leg needs a bound at
+ * all when the other two expire by themselves. A stamp in the future (a clock that moved backwards)
+ * reads as not-yet-elapsed, which keeps the block rather than dropping it — the conservative
+ * direction. Top-level and `internal` so it is unit-testable as a pure function.
+ */
+internal fun isReadyToBroadcastBlockWithinCap(
+    nowEpochSeconds: Long,
+    readySinceEpochSeconds: Long,
+    capSeconds: Long,
+): Boolean = nowEpochSeconds - readySinceEpochSeconds < capSeconds
 
 /**
  * Task 1 (spec §2a) entry-guard predicate: `true` iff a broadcast is still marked in-flight AND the

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
@@ -1257,6 +1257,11 @@ internal class OrchardMigrationSdkImpl(
      * transfer attempt, so [boundedReadyToBroadcast]'s cap measures "how long has a ready transfer
      * gone untouched by any driver", not "how long has it been ready". A driver that keeps
      * attempting keeps sync blocked for as long as it needs.
+     *
+     * So the cap deliberately bounds only a driver that STOPPED RUNNING (a killed worker, an
+     * abandoned foreground flow) - never a live-but-perpetually-failing one, which re-arms the stamp
+     * on every attempt and keeps the block alive by design. Each individual attempt is still bounded
+     * by the in-flight and privacy-buffer legs of [boundedReadyToBroadcast].
      */
     private suspend fun reStampSyncBlockReadySince() {
         val nowEpochSeconds = Clock.System.now().epochSeconds

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/storage/preference/keys/EncryptedPreferenceKeys.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/storage/preference/keys/EncryptedPreferenceKeys.kt
@@ -36,4 +36,21 @@ internal object EncryptedPreferenceKeys {
             key = PreferenceKey("migration_broadcast_in_flight_until"),
             defaultValue = ""
         )
+
+    /**
+     * Epoch-seconds stamp: when [isSyncBlockedNow] first saw a transfer ready to broadcast without
+     * interruption. Unlike the other two migration keys, the readiness this bounds cannot expire on
+     * its own — a transfer stays `STEP_BROADCAST`-ready until a driver actually broadcasts it, and
+     * the plan's own staleness is measured against the SCANNED tip, which cannot advance while the
+     * sync this blocks is paused. The stamp turns that unbounded state into a capped one: cleared
+     * whenever readiness goes away, re-armed by every live
+     * [OrchardMigrationSdkImpl.executeNextPendingTransfer] attempt, and expired after
+     * [OrchardMigrationSdkImpl.READY_TO_BROADCAST_BLOCK_CAP_MULTIPLIER] privacy buffers, so only a
+     * dead migration driver ever reaches the cap.
+     */
+    val MIGRATION_SYNC_BLOCK_READY_SINCE =
+        StringPreferenceDefault(
+            key = PreferenceKey("migration_sync_block_ready_since"),
+            defaultValue = ""
+        )
 }

--- a/sdk-lib/src/main/java/com/zodl/slipstream/SlipstreamSynchronizer.kt
+++ b/sdk-lib/src/main/java/com/zodl/slipstream/SlipstreamSynchronizer.kt
@@ -1508,13 +1508,6 @@ class SlipstreamSynchronizer internal constructor(
                 lazyTorClient?.ifCreated { it.setDormant(TorDormantMode.SOFT) }
             }
 
-            // Mirror pause(): the privacy gate closed mid-burst (typically because the burst reached
-            // the target and hasOverdueTransfers flipped, so WalletCoordinator paused us). Keep the
-            // engine warm but stop polling, per the keep-alive sync-block design.
-            migrationPaused.value -> {
-                engine.stopPolling()
-            }
-
             // Mirror onForeground(): a live foreground wallet — leave it running and polling.
             else -> {
                 engine.startPolling()

--- a/sdk-lib/src/main/java/com/zodl/slipstream/SlipstreamSynchronizer.kt
+++ b/sdk-lib/src/main/java/com/zodl/slipstream/SlipstreamSynchronizer.kt
@@ -118,7 +118,6 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
@@ -267,7 +266,7 @@ class SlipstreamSynchronizer internal constructor(
 
     /**
      * The deferred-preparation gate every engine- or database-backed member awaits (see
-     * [awaitReady]/[awaitPrepared]). Declared before [status] because that combine reads it eagerly.
+     * [awaitReady]/[awaitPrepared]).
      */
     private val prepareState =
         MutableStateFlow(
@@ -303,14 +302,12 @@ class SlipstreamSynchronizer internal constructor(
     private val burstActive = AtomicBoolean(false)
 
     /**
-     * The `paused -> SYNCED` mask applies only once preparation is [PrepareState.Ready]: [pause]
-     * sets [migrationPaused] regardless of readiness, so an unmasked combine would report a failed
-     * preparation (which forces `DISCONNECTED`) as SYNCED for as long as the pause lasts.
+     * The engine's own status, unmasked. A migration [pause] used to force `SYNCED` here, because
+     * it also stopped the poll loop and the last observed status would otherwise have been frozen
+     * mid-sync for the whole pause. [pause] now keeps polling, so the engine status stays live and
+     * truthful throughout.
      */
-    override val status: Flow<Synchronizer.Status> =
-        combine(engine.status, migrationPaused, prepareState) { status, paused, prepare ->
-            if (paused && prepare is PrepareState.Ready) Synchronizer.Status.SYNCED else status
-        }
+    override val status: Flow<Synchronizer.Status> = engine.status
     override val progress: Flow<PercentDecimal> = engine.progress
     override val areFundsSpendable: Flow<Boolean> = engine.areFundsSpendable
     override val networkHeight = engine.networkHeight
@@ -493,10 +490,18 @@ class SlipstreamSynchronizer internal constructor(
     init {
         engine.onTick =
             { snap ->
-                resubmissionTicker.onTick(
-                    isSynced = engine.status.value == Synchronizer.Status.SYNCED,
-                    chainTip = snap.chainTip
-                )
+                /*
+                 * The one network-active consumer of the tick cadence, and therefore the only part
+                 * of the poll loop a migration [pause] has to suppress - resubmitting a transaction
+                 * is exactly the traffic the pause decorrelates from a migration broadcast. The
+                 * reads the tick itself performs are local JNI calls and keep running.
+                 */
+                if (!migrationPaused.value) {
+                    resubmissionTicker.onTick(
+                        isSynced = engine.status.value == Synchronizer.Status.SYNCED,
+                        chainTip = snap.chainTip
+                    )
+                }
             }
         val inputs = prepareInputs
         if (inputs == null) {
@@ -669,10 +674,9 @@ class SlipstreamSynchronizer internal constructor(
      * 5 s `busy_timeout`, and [backend] reads serialize on the single-threaded `zc-io` dispatcher
      * regardless.
      *
-     * The final [SlipstreamEngine.startPolling] is skipped while [migrationPaused] holds, mirroring
-     * [onForeground]: a migration privacy pause that landed mid-preparation would otherwise get a
-     * stray polling tick, since [pause]'s own queued `stopPolling` block only runs once
-     * [PrepareState.Ready] is published.
+     * The final [SlipstreamEngine.startPolling] is unconditional, including under a migration
+     * [pause]: polling only performs local JNI reads, and a pause that suppressed them left the
+     * balances and status frozen at whatever the last tick saw.
      */
     private suspend fun prepare(inputs: PrepareInputs) {
         val fallbackCheckpoint = inputs.fallbackCheckpointHeight()
@@ -743,7 +747,7 @@ class SlipstreamSynchronizer internal constructor(
          * section 3.5's `start(ufvk != null)` is a no-op when an account is already present.
          */
         engine.start(inputs.ufvk, provisioning.startBirthday.value)
-        if (!migrationPaused.value) engine.startPolling()
+        engine.startPolling()
     }
 
     /** The `when(intent)` block of the original `newLocked`, verbatim but behind [PrepareInputs]' lambdas. */
@@ -1402,20 +1406,37 @@ class SlipstreamSynchronizer internal constructor(
         }
     }
 
+    /**
+     * Closes the migration privacy gate without touching the poll loop. The loop only reads the
+     * engine's local state over JNI (`snapshot`/`drainEvents`/`walletSummary`), so it produces no
+     * network traffic to decorrelate from a migration broadcast; what it does produce is the
+     * balances, progress and status the host renders. Stopping it froze all of those for as long as
+     * the pause lasted, which - with an unbounded sync block, see
+     * [cash.z.ecc.android.sdk.OrchardMigrationSdk.isSyncBlocked] - could be forever (MOB-1667).
+     *
+     * What the pause does gate is [syncBurst] and the resubmission ticker (see `init`); the engine's
+     * own network session was never gated here at all.
+     */
     override fun pause() {
         if (closed.get()) return
         migrationPaused.update { true }
-        launchGuarded("pause") {
-            if (!awaitPrepared()) return@launchGuarded
-            engine.stopPolling()
-        }
     }
 
+    /**
+     * Reopens the gate and restarts an engine that is stopped, mirroring [onForeground]'s
+     * [SlipstreamEngine.isRunning] guard: a pause that spanned a background/foreground cycle leaves
+     * the engine stopped by [onBackground], and polling a stopped engine forever is what the
+     * unguarded restart used to do. A backgrounded wallet is left stopped - the next [onForeground]
+     * restarts it.
+     */
     override fun resume() {
         if (closed.get()) return
         migrationPaused.update { false }
         launchGuarded("resume") {
             if (!awaitPrepared()) return@launchGuarded
+            if (inForeground.get() && !engine.isRunning) {
+                engine.start(ufvk = null, birthday = startBirthday.value)
+            }
             engine.startPolling()
         }
     }
@@ -1505,10 +1526,10 @@ class SlipstreamSynchronizer internal constructor(
      * [SlipstreamEngine.start] unconditionally aborts any in-flight pass and reruns its bounded
      * quiescence drain, so restarting an already-running engine on every foreground would churn
      * useful work instead of resuming it. [SlipstreamEngine.isRunning] guards against that - skip
-     * the native restart when the engine is already live. [SlipstreamEngine.startPolling] stays
-     * unconditional; it is already an idempotent cancel-and-relaunch, but is skipped while paused
-     * so a foreground event does not undo an in-flight migration sync-block. A no-op once [close]
-     * has already run - post-close lifecycle calls are no-ops.
+     * the native restart when the engine is already live. [SlipstreamEngine.startPolling] is
+     * unconditional - it is an idempotent cancel-and-relaunch, and a migration [pause] no longer
+     * suppresses polling at all. A no-op once [close] has already run - post-close lifecycle calls
+     * are no-ops.
      */
     override fun onForeground() {
         if (closed.get()) return
@@ -1521,9 +1542,7 @@ class SlipstreamSynchronizer internal constructor(
             if (!engine.isRunning) {
                 engine.start(ufvk = null, birthday = startBirthday.value)
             }
-            if (!migrationPaused.value) {
-                engine.startPolling()
-            }
+            engine.startPolling()
         }
     }
 

--- a/sdk-lib/src/main/java/com/zodl/slipstream/SlipstreamSynchronizer.kt
+++ b/sdk-lib/src/main/java/com/zodl/slipstream/SlipstreamSynchronizer.kt
@@ -1426,17 +1426,21 @@ class SlipstreamSynchronizer internal constructor(
      * Reopens the gate and restarts an engine that is stopped, mirroring [onForeground]'s
      * [SlipstreamEngine.isRunning] guard: a pause that spanned a background/foreground cycle leaves
      * the engine stopped by [onBackground], and polling a stopped engine forever is what the
-     * unguarded restart used to do. A backgrounded wallet is left stopped - the next [onForeground]
-     * restarts it.
+     * unguarded restart used to do.
+     *
+     * A backgrounded wallet keeps BOTH the engine and the poll loop stopped - only the pause flag is
+     * cleared, mirroring [restoreAfterBurst]. Nothing here is lifecycle-driven: the host toggles the
+     * pause off whatever gates the migration, so a resume can land at any time while backgrounded,
+     * and restarting the 2 s poll loop against an engine [onBackground] stopped would burn battery
+     * to read a dead session. The next [onForeground] restarts both.
      */
     override fun resume() {
         if (closed.get()) return
         migrationPaused.update { false }
         launchGuarded("resume") {
             if (!awaitPrepared()) return@launchGuarded
-            if (inForeground.get() && !engine.isRunning) {
-                engine.start(ufvk = null, birthday = startBirthday.value)
-            }
+            if (!inForeground.get()) return@launchGuarded
+            if (!engine.isRunning) engine.start(ufvk = null, birthday = startBirthday.value)
             engine.startPolling()
         }
     }

--- a/sdk-lib/src/main/java/com/zodl/slipstream/internal/EngineMapping.kt
+++ b/sdk-lib/src/main/java/com/zodl/slipstream/internal/EngineMapping.kt
@@ -54,6 +54,29 @@ private fun SlipstreamPoolBalance.maskIfStale(mask: Boolean): SlipstreamPoolBala
     }
 
 /**
+ * How many consecutive stale-tip ticks the mask tolerates before it fails open - 450 ticks at the
+ * 2 s poll interval, i.e. 15 minutes.
+ */
+internal const val STALE_MASK_FAIL_OPEN_TICKS = 450
+
+/**
+ * The tip freshness [toAccountBalances] should mask against, given the engine's own `tipFresh` and
+ * how many consecutive ticks have reported a stale tip.
+ *
+ * `tipFresh` only latches once the engine's serial network prologue completes, so any condition
+ * that keeps the prologue from finishing (a wedged sync, a dead network session, MOB-1667's
+ * permanent migration pause) pins spendable at zero indefinitely while the total balance stays
+ * correct - the wallet looks funded but nothing can be spent, forever. Past
+ * [STALE_MASK_FAIL_OPEN_TICKS] live ticks the mask therefore fails open: showing spendable against
+ * an unverified tip cannot lose funds (a spend built on a stale tip fails at propose or broadcast),
+ * whereas hiding it indefinitely bricks the wallet.
+ */
+internal fun effectiveTipFresh(
+    tipFresh: Boolean,
+    consecutiveStaleTicks: Int
+): Boolean = tipFresh || consecutiveStaleTicks >= STALE_MASK_FAIL_OPEN_TICKS
+
+/**
  * Maps the engine's phase-resolving summary to the SDK's public balance model. `ironwood` is
  * read straight from the engine's own `SlipstreamAccountBalance.ironwood` field, which the JNI
  * layer populates from the linked librustzcash summary (`balance.ironwood_balance()`), so migrated

--- a/sdk-lib/src/main/java/com/zodl/slipstream/internal/SlipstreamEngine.kt
+++ b/sdk-lib/src/main/java/com/zodl/slipstream/internal/SlipstreamEngine.kt
@@ -49,6 +49,13 @@ internal class SlipstreamEngine(
     private var running = false
 
     /**
+     * Consecutive ticks whose snapshot reported a stale tip; feeds [effectiveTipFresh]'s fail-open.
+     * Counted in ticks rather than wall-clock time on purpose - it must measure how long the mask
+     * has been applied to LIVE observations, and no tick means no observation to mask.
+     */
+    private var staleTipTicks = 0
+
+    /**
      * Mirrors the iOS twin's `isRunning` member (`SlipstreamSynchronizer.swift`): true from a
      * successful [start] until the next [stop], including the internal retry [dispatchState] issues
      * on error-episode recovery. Lets a caller (`SlipstreamSynchronizer.onForeground`) tell an
@@ -198,9 +205,14 @@ internal class SlipstreamEngine(
                 allowZeroConfShielding = ALLOW_ZERO_CONF
             )
         summary?.let {
-            walletBalances.value = it.toAccountBalances(isRecovering = snap.isRecovering, tipFresh = snap.tipFresh)
+            walletBalances.value =
+                it.toAccountBalances(
+                    isRecovering = snap.isRecovering,
+                    tipFresh = effectiveTipFresh(snap.tipFresh, staleTipTicks)
+                )
             fullyScannedHeight.value = it.fullyScannedHeight.takeIf { height -> height > 0 }?.let(BlockHeight::new)
         }
+        staleTipTicks = if (snap.tipFresh) 0 else staleTipTicks + 1
 
         if (snap.chainTip > 0) networkHeight.value = BlockHeight.new(snap.chainTip)
         progress.value = permilleToPercentDecimal(snap.progressPermille)

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImplTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImplTest.kt
@@ -52,6 +52,7 @@ import org.mockito.Mockito.`when`
 import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Clock
@@ -72,6 +73,15 @@ class OrchardMigrationSdkImplTest {
 
         /** How long each fake send holds the broadcast mutex in the serialization test. */
         val BROADCAST_HOLD = 200.milliseconds
+
+        /**
+         * How far in the past a seeded `MIGRATION_SYNC_BLOCK_READY_SINCE` stamp is placed to count
+         * as expired: comfortably past the testnet cap of three 3-minute privacy buffers (540 s).
+         */
+        const val EXPIRED_READY_SINCE_AGE_SECONDS = 600L
+
+        /** Slack allowed when asserting that a freshly written epoch-seconds stamp is "now". */
+        const val STAMP_TOLERANCE_SECONDS = 60L
     }
 
     @Test
@@ -672,6 +682,230 @@ class OrchardMigrationSdkImplTest {
                 )
 
             assertTrue(sdk.isSyncBlocked().first())
+        }
+
+    // ── MOB-1667: the readyToBroadcast leg of isSyncBlocked is time-bounded ──
+
+    /**
+     * Boundary cases of the pure predicate behind the cap: the window is half-open, so an elapsed
+     * time strictly below the cap still blocks and an exactly-elapsed one no longer does. A stamp
+     * in the future (clock moved backwards) keeps the block.
+     */
+    @Test
+    fun `readyToBroadcast block cap expires exactly at the cap and never before`() {
+        assertTrue(
+            isReadyToBroadcastBlockWithinCap(
+                nowEpochSeconds = 1_000L,
+                readySinceEpochSeconds = 1_000L,
+                capSeconds = 540L
+            )
+        )
+        assertTrue(
+            isReadyToBroadcastBlockWithinCap(
+                nowEpochSeconds = 1_539L,
+                readySinceEpochSeconds = 1_000L,
+                capSeconds = 540L
+            )
+        )
+        assertFalse(
+            isReadyToBroadcastBlockWithinCap(
+                nowEpochSeconds = 1_540L,
+                readySinceEpochSeconds = 1_000L,
+                capSeconds = 540L
+            )
+        )
+        assertTrue(
+            isReadyToBroadcastBlockWithinCap(
+                nowEpochSeconds = 1_000L,
+                readySinceEpochSeconds = 2_000L,
+                capSeconds = 540L
+            )
+        )
+    }
+
+    /** The first evaluation of a broadcast-ready plan blocks sync AND records when it first did. */
+    @Test
+    fun isSyncBlocked_arms_the_ready_since_stamp_on_the_first_broadcast_ready_evaluation() =
+        runBlocking {
+            val account = AccountUuid.new(ByteArray(16) { it.toByte() })
+            val prefs = FakePreferenceProvider()
+            val fakeBackend = FakeTypesafeMigrationBackend(nextStepResult = longArrayOf(2L, 5L)) // STEP_BROADCAST
+            val sdk =
+                OrchardMigrationSdkImpl(
+                    context = fakeAndroidContext(),
+                    network = ZcashNetwork.Testnet,
+                    alias = "OrchardMigrationSdkImplTest",
+                    account = account,
+                    migrationBackend = fakeBackend,
+                    defaultSubmitEndpoint = LightWalletEndpoint("localhost", 9067, true),
+                    preferenceProviderHolder = FakePreferenceHolder(prefs),
+                )
+
+            assertTrue(sdk.isSyncBlocked().first())
+
+            val stamp = prefs.getString(EncryptedPreferenceKeys.MIGRATION_SYNC_BLOCK_READY_SINCE.key)?.toLongOrNull()
+            assertNotNull(stamp)
+            assertTrue(
+                stamp >= Clock.System.now().epochSeconds - STAMP_TOLERANCE_SECONDS,
+                "the stamp must record the moment readiness was first seen"
+            )
+        }
+
+    /**
+     * MOB-1667's deadlock: a migration driver that never runs again leaves the plan permanently
+     * `STEP_BROADCAST`-ready, and the plan's own expiry is evaluated against the scanned tip, which
+     * cannot advance while this very block keeps sync paused. Past the cap, sync must resume.
+     */
+    @Test
+    fun isSyncBlocked_emits_false_once_the_ready_since_stamp_is_older_than_the_cap() =
+        runBlocking {
+            val account = AccountUuid.new(ByteArray(16) { it.toByte() })
+            val expiredStamp = (Clock.System.now().epochSeconds - EXPIRED_READY_SINCE_AGE_SECONDS).toString()
+            val fakeBackend = FakeTypesafeMigrationBackend(nextStepResult = longArrayOf(2L, 5L)) // STEP_BROADCAST
+            val sdk =
+                OrchardMigrationSdkImpl(
+                    context = fakeAndroidContext(),
+                    network = ZcashNetwork.Testnet,
+                    alias = "OrchardMigrationSdkImplTest",
+                    account = account,
+                    migrationBackend = fakeBackend,
+                    defaultSubmitEndpoint = LightWalletEndpoint("localhost", 9067, true),
+                    preferenceProviderHolder =
+                        FakePreferenceHolder(
+                            FakePreferenceProvider(
+                                mapOf(EncryptedPreferenceKeys.MIGRATION_SYNC_BLOCK_READY_SINCE.key to expiredStamp)
+                            )
+                        ),
+                )
+
+            assertFalse(sdk.isSyncBlocked().first())
+        }
+
+    /** The cap bounds only its own leg — an in-flight broadcast still blocks sync unconditionally. */
+    @Test
+    fun isSyncBlocked_stays_true_past_the_cap_while_a_broadcast_is_in_flight() =
+        runBlocking {
+            val account = AccountUuid.new(ByteArray(16) { it.toByte() })
+            val now = Clock.System.now().epochSeconds
+            val fakeBackend = FakeTypesafeMigrationBackend(nextStepResult = longArrayOf(2L, 5L)) // STEP_BROADCAST
+            val sdk =
+                OrchardMigrationSdkImpl(
+                    context = fakeAndroidContext(),
+                    network = ZcashNetwork.Testnet,
+                    alias = "OrchardMigrationSdkImplTest",
+                    account = account,
+                    migrationBackend = fakeBackend,
+                    defaultSubmitEndpoint = LightWalletEndpoint("localhost", 9067, true),
+                    preferenceProviderHolder =
+                        FakePreferenceHolder(
+                            FakePreferenceProvider(
+                                mapOf(
+                                    EncryptedPreferenceKeys.MIGRATION_SYNC_BLOCK_READY_SINCE.key to
+                                        (now - EXPIRED_READY_SINCE_AGE_SECONDS).toString(),
+                                    EncryptedPreferenceKeys.MIGRATION_BROADCAST_IN_FLIGHT_UNTIL.key to
+                                        (now + 60).toString(),
+                                )
+                            )
+                        ),
+                )
+
+            assertTrue(sdk.isSyncBlocked().first())
+        }
+
+    /** Readiness going away clears the stamp, so a later readiness starts its own fresh window. */
+    @Test
+    fun isSyncBlocked_clears_the_ready_since_stamp_when_the_step_is_no_longer_broadcast() =
+        runBlocking {
+            val account = AccountUuid.new(ByteArray(16) { it.toByte() })
+            val nowEpochSeconds = Clock.System.now().epochSeconds
+            val prefs =
+                FakePreferenceProvider(
+                    mapOf(EncryptedPreferenceKeys.MIGRATION_SYNC_BLOCK_READY_SINCE.key to nowEpochSeconds.toString())
+                )
+            val fakeBackend = FakeTypesafeMigrationBackend(nextStepResult = longArrayOf(0L, -1L)) // STEP_WAITING
+            val sdk =
+                OrchardMigrationSdkImpl(
+                    context = fakeAndroidContext(),
+                    network = ZcashNetwork.Testnet,
+                    alias = "OrchardMigrationSdkImplTest",
+                    account = account,
+                    migrationBackend = fakeBackend,
+                    defaultSubmitEndpoint = LightWalletEndpoint("localhost", 9067, true),
+                    preferenceProviderHolder = FakePreferenceHolder(prefs),
+                )
+
+            assertFalse(sdk.isSyncBlocked().first())
+
+            assertNull(prefs.getString(EncryptedPreferenceKeys.MIGRATION_SYNC_BLOCK_READY_SINCE.key)?.toLongOrNull())
+        }
+
+    /**
+     * A live driver re-arms the window on every attempt, so the cap measures how long a ready
+     * transfer has gone untouched — not how long it has been ready.
+     */
+    @Test
+    fun executeNextPendingTransfer_re_stamps_the_ready_since_window() =
+        runBlocking {
+            val account = AccountUuid.new(ByteArray(16) { it.toByte() })
+            val expiredStamp = (Clock.System.now().epochSeconds - EXPIRED_READY_SINCE_AGE_SECONDS).toString()
+            val prefs =
+                FakePreferenceProvider(
+                    mapOf(EncryptedPreferenceKeys.MIGRATION_SYNC_BLOCK_READY_SINCE.key to expiredStamp)
+                )
+            val sdk =
+                OrchardMigrationSdkImpl(
+                    context = fakeAndroidContext(),
+                    network = ZcashNetwork.Testnet,
+                    alias = "OrchardMigrationSdkImplTest",
+                    account = account,
+                    migrationBackend = FakeTypesafeMigrationBackend(),
+                    defaultSubmitEndpoint = LightWalletEndpoint("localhost", 9067, true),
+                    preferenceProviderHolder = FakePreferenceHolder(prefs),
+                )
+
+            val outcome =
+                sdk.executeNextPendingTransfer(
+                    options = NetworkPrivacyOptions(useTor = false),
+                    useEstimatedTip = false,
+                )
+
+            assertEquals(TransferAttemptOutcome.NothingDue, outcome)
+            val stamp = prefs.getString(EncryptedPreferenceKeys.MIGRATION_SYNC_BLOCK_READY_SINCE.key)?.toLongOrNull()
+            assertNotNull(stamp)
+            assertTrue(
+                stamp >= Clock.System.now().epochSeconds - STAMP_TOLERANCE_SECONDS,
+                "every attempt must re-arm the window, even one that finds nothing due"
+            )
+        }
+
+    /**
+     * The window is persisted, not per-instance: a fresh [OrchardMigrationSdkImpl] (one is
+     * constructed per call site — see that class's doc) must keep counting from the stamp the
+     * previous one armed rather than restarting the cap on every construction.
+     */
+    @Test
+    fun the_ready_since_stamp_survives_a_fresh_sdk_instance() =
+        runBlocking {
+            val account = AccountUuid.new(ByteArray(16) { it.toByte() })
+            val prefs = FakePreferenceProvider()
+
+            fun newSdk() =
+                OrchardMigrationSdkImpl(
+                    context = fakeAndroidContext(),
+                    network = ZcashNetwork.Testnet,
+                    alias = "OrchardMigrationSdkImplTest",
+                    account = account,
+                    migrationBackend = FakeTypesafeMigrationBackend(nextStepResult = longArrayOf(2L, 5L)),
+                    defaultSubmitEndpoint = LightWalletEndpoint("localhost", 9067, true),
+                    preferenceProviderHolder = FakePreferenceHolder(prefs),
+                )
+
+            assertTrue(newSdk().isSyncBlocked().first())
+            val armed = prefs.getString(EncryptedPreferenceKeys.MIGRATION_SYNC_BLOCK_READY_SINCE.key)
+
+            assertTrue(newSdk().isSyncBlocked().first())
+
+            assertEquals(armed, prefs.getString(EncryptedPreferenceKeys.MIGRATION_SYNC_BLOCK_READY_SINCE.key))
         }
 
     // ── mark_superseded write-through (Task 7): nextStep's Replan branch ─────

--- a/sdk-lib/src/test/java/com/zodl/slipstream/SlipstreamSynchronizerLifecycleTest.kt
+++ b/sdk-lib/src/test/java/com/zodl/slipstream/SlipstreamSynchronizerLifecycleTest.kt
@@ -563,6 +563,43 @@ class SlipstreamSynchronizerLifecycleTest {
         }
     }
 
+    /**
+     * MOB-1667 follow-through: a migration pause landing mid-burst must not leave the poll loop
+     * stopped when the burst ends — [SlipstreamSynchronizer.pause] no longer suppresses polling,
+     * and `restoreAfterBurst` mirrors that. Expects two `startPolling` calls: the burst's own at
+     * start, and the foreground restore at the end.
+     */
+    @Test
+    fun sync_burst_ending_under_a_pause_keeps_polling_in_the_foreground() {
+        val engine = mock(SlipstreamEngine::class.java)
+        val key = newKey()
+        val synchronizer = buildSynchronizer(engine = engine, key = key)
+        try {
+            `when`(engine.isRunning).thenReturn(true)
+            clearInvocations(engine)
+            synchronizer.onForeground()
+            runBlocking { verify(engine, timeout(TIMEOUT_MS)).startPolling() }
+            clearInvocations(engine)
+
+            val result =
+                runBlocking {
+                    synchronizer.syncBurst(timeout = TWO_SECONDS, targetCheckInterval = TICK) {
+                        synchronizer.pause()
+                        true
+                    }
+                }
+
+            assertEquals(Synchronizer.SyncBurstResult.TARGET_REACHED, result)
+            runBlocking<Unit> {
+                verify(engine, timeout(TIMEOUT_MS).times(2)).startPolling()
+                verify(engine, never()).stopPolling()
+                verify(engine, never()).stop()
+            }
+        } finally {
+            InstanceGuard.release(key)
+        }
+    }
+
     @Test
     fun sync_burst_after_close_returns_unavailable() {
         val engine = mock(SlipstreamEngine::class.java)

--- a/sdk-lib/src/test/java/com/zodl/slipstream/SlipstreamSynchronizerLifecycleTest.kt
+++ b/sdk-lib/src/test/java/com/zodl/slipstream/SlipstreamSynchronizerLifecycleTest.kt
@@ -61,6 +61,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.Test
+import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.after
 import org.mockito.Mockito.clearInvocations
 import org.mockito.Mockito.inOrder
@@ -376,19 +377,51 @@ class SlipstreamSynchronizerLifecycleTest {
         }
     }
 
+    /**
+     * MOB-1667: polling is local JNI reads only, so a migration pause must leave it running — the
+     * host keeps seeing live balances, heights and status for however long the pause lasts.
+     */
     @Test
-    fun pause_stops_polling_without_tearing_the_engine_down() {
+    fun pause_keeps_polling_and_leaves_the_engine_alone() {
         val engine = mock(SlipstreamEngine::class.java)
         val key = newKey()
         val synchronizer = buildSynchronizer(engine = engine, key = key)
         try {
+            clearInvocations(engine) // drop the init() startPolling
             synchronizer.pause()
 
             runBlocking {
-                verify(engine, timeout(TIMEOUT_MS)).stopPolling()
-                verify(engine, after(SETTLE_MS).never()).stop()
-                verify(engine, after(SETTLE_MS).never()).free()
-                verify(engine, after(SETTLE_MS).never()).shutdown()
+                verify(engine, after(SETTLE_MS).never()).stopPolling()
+                verify(engine, never()).stop()
+                verify(engine, never()).free()
+                verify(engine, never()).shutdown()
+            }
+        } finally {
+            InstanceGuard.release(key)
+        }
+    }
+
+    /**
+     * The tick's one network-active consumer is the part a pause does suppress — resubmitting a
+     * transaction is exactly the traffic a migration broadcast must stay decorrelated from.
+     */
+    @Test
+    fun pause_suppresses_the_resubmission_tick_and_resume_restores_it() {
+        val engine = mock(SlipstreamEngine::class.java)
+        val ticker = mock(ResubmissionTicker::class.java)
+        val key = newKey()
+        val synchronizer = buildSynchronizer(engine = engine, key = key, resubmissionTicker = ticker)
+        try {
+            val onTick = captureOnTick(engine)
+
+            runBlocking {
+                synchronizer.pause()
+                onTick(snapshot(state = 1))
+                verify(ticker, never()).onTick(isSynced = true, chainTip = 0L)
+
+                synchronizer.resume()
+                onTick(snapshot(state = 1))
+                verify(ticker).onTick(isSynced = true, chainTip = 0L)
             }
         } finally {
             InstanceGuard.release(key)
@@ -401,6 +434,7 @@ class SlipstreamSynchronizerLifecycleTest {
         val key = newKey()
         val synchronizer = buildSynchronizer(engine = engine, key = key)
         try {
+            `when`(engine.isRunning).thenReturn(true)
             synchronizer.pause()
             clearInvocations(engine)
 
@@ -412,20 +446,76 @@ class SlipstreamSynchronizerLifecycleTest {
         }
     }
 
+    /**
+     * A pause that spans a background/foreground cycle leaves the engine stopped by
+     * [SlipstreamSynchronizer.onBackground]; resuming must restart it rather than poll a dead
+     * session forever.
+     */
     @Test
-    fun status_reports_synced_while_paused_then_reverts_after_resume() {
+    fun resume_restarts_a_stopped_engine_when_foregrounded() {
+        val engine = mock(SlipstreamEngine::class.java)
+        val key = newKey()
+        val synchronizer = buildSynchronizer(engine = engine, key = key)
+        try {
+            `when`(engine.isRunning).thenReturn(true)
+            clearInvocations(engine) // drop the init() startPolling
+            synchronizer.onForeground()
+            runBlocking { verify(engine, timeout(TIMEOUT_MS)).startPolling() }
+            synchronizer.pause()
+            `when`(engine.isRunning).thenReturn(false)
+            clearInvocations(engine)
+
+            synchronizer.resume()
+
+            runBlocking {
+                verify(engine, timeout(TIMEOUT_MS)).start(null, STARTING_BIRTHDAY_VALUE)
+                verify(engine, timeout(TIMEOUT_MS)).startPolling()
+            }
+        } finally {
+            InstanceGuard.release(key)
+        }
+    }
+
+    /** Backgrounded, the engine stays stopped — the next foreground event is what restarts it. */
+    @Test
+    fun resume_while_backgrounded_leaves_a_stopped_engine_stopped() {
+        val engine = mock(SlipstreamEngine::class.java)
+        val key = newKey()
+        val synchronizer = buildSynchronizer(engine = engine, key = key)
+        try {
+            `when`(engine.isRunning).thenReturn(false)
+            synchronizer.pause()
+            clearInvocations(engine)
+
+            synchronizer.resume()
+
+            runBlocking {
+                verify(engine, timeout(TIMEOUT_MS)).startPolling()
+                verify(engine, never()).start(null, STARTING_BIRTHDAY_VALUE)
+            }
+        } finally {
+            InstanceGuard.release(key)
+        }
+    }
+
+    /**
+     * MOB-1667: the forced `paused -> SYNCED` mask existed only because a pause froze the poll
+     * loop. Polling now continues, so the engine's own status is reported throughout — a wallet
+     * that is genuinely syncing must not claim to be synced.
+     */
+    @Test
+    fun status_is_not_masked_to_synced_while_paused() {
         val engine = mock(SlipstreamEngine::class.java)
         val engineStatus = MutableStateFlow(Synchronizer.Status.SYNCING)
         val key = newKey()
-        // Override the default SYNCED stub so we can prove the wrap, not the stub.
         val synchronizer = buildSynchronizer(engine = engine, key = key, engineStatusOverride = engineStatus)
         try {
             runBlocking {
                 assertEquals(Synchronizer.Status.SYNCING, synchronizer.status.first())
                 synchronizer.pause()
-                assertEquals(Synchronizer.Status.SYNCED, synchronizer.status.first())
-                synchronizer.resume()
                 assertEquals(Synchronizer.Status.SYNCING, synchronizer.status.first())
+                engineStatus.value = Synchronizer.Status.SYNCED
+                assertEquals(Synchronizer.Status.SYNCED, synchronizer.status.first())
             }
         } finally {
             InstanceGuard.release(key)
@@ -433,7 +523,7 @@ class SlipstreamSynchronizerLifecycleTest {
     }
 
     @Test
-    fun on_foreground_while_paused_does_not_restart_polling() {
+    fun on_foreground_while_paused_still_polls() {
         val engine = mock(SlipstreamEngine::class.java)
         val key = newKey()
         val synchronizer = buildSynchronizer(engine = engine, key = key)
@@ -444,7 +534,7 @@ class SlipstreamSynchronizerLifecycleTest {
 
             synchronizer.onForeground()
 
-            runBlocking { verify(engine, after(SETTLE_MS).never()).startPolling() }
+            runBlocking { verify(engine, timeout(TIMEOUT_MS)).startPolling() }
         } finally {
             InstanceGuard.release(key)
         }
@@ -1099,8 +1189,13 @@ class SlipstreamSynchronizerLifecycleTest {
         }
     }
 
+    /**
+     * MOB-1667: a pause that lands mid-preparation must not cost the host its observation of the
+     * engine — the tail starts polling like any other preparation, and only the network-active tick
+     * consumer stays suppressed.
+     */
     @Test
-    fun preparation_finishing_under_a_migration_pause_does_not_start_polling() {
+    fun preparation_finishing_under_a_migration_pause_still_starts_polling() {
         val engine = mock(SlipstreamEngine::class.java)
         val backend = mock(Backend::class.java)
         val key = newKey()
@@ -1119,11 +1214,8 @@ class SlipstreamSynchronizerLifecycleTest {
 
             runBlocking {
                 verify(engine, timeout(TIMEOUT_MS)).start(UFVK, ANCHOR_HEIGHT)
-                /*
-                 * The queued pause() block runs once preparation publishes Ready.
-                 */
-                verify(engine, timeout(TIMEOUT_MS)).stopPolling()
-                verify(engine, after(SETTLE_MS).never()).startPolling()
+                verify(engine, timeout(TIMEOUT_MS)).startPolling()
+                verify(engine, after(SETTLE_MS).never()).stopPolling()
             }
         } finally {
             InstanceGuard.release(key)
@@ -1504,6 +1596,18 @@ class SlipstreamSynchronizerLifecycleTest {
             uivk = null
         )
 
+    /**
+     * The `onTick` callback the synchronizer's `init` installs on the engine. A mock records the
+     * setter call but its getter answers `null`, so the lambda has to be captured from the call
+     * itself rather than read back.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun captureOnTick(engine: SlipstreamEngine): suspend (SlipstreamSnapshot) -> Unit {
+        val captor = ArgumentCaptor.forClass(Any::class.java)
+        verify(engine).onTick = captor.capture() as? (suspend (SlipstreamSnapshot) -> Unit)
+        return captor.value as suspend (SlipstreamSnapshot) -> Unit
+    }
+
     @Suppress("LongParameterList")
     private fun snapshot(
         state: Int,
@@ -1539,6 +1643,7 @@ class SlipstreamSynchronizerLifecycleTest {
         walletClient: CombinedWalletClient = mock(CombinedWalletClient::class.java),
         transactionsController: TransactionsController = mock(TransactionsController::class.java),
         key: SlipstreamKey = newKey(),
+        resubmissionTicker: ResubmissionTicker = mock(ResubmissionTicker::class.java),
         startBirthday: BlockHeight = BlockHeight.new(STARTING_BIRTHDAY_VALUE),
         engineStatusOverride: MutableStateFlow<Synchronizer.Status>? = null,
         lastSnapshotOverride: MutableStateFlow<SlipstreamSnapshot?>? = null,
@@ -1574,7 +1679,7 @@ class SlipstreamSynchronizerLifecycleTest {
             transactionsController = transactionsController,
             spendService = mock(SlipstreamSpendService::class.java),
             broadcasterImpl = mock(SlipstreamBroadcaster::class.java),
-            resubmissionTicker = mock(ResubmissionTicker::class.java),
+            resubmissionTicker = resubmissionTicker,
             startBirthday = startBirthday,
             prepareInputs = prepareInputs
         )

--- a/sdk-lib/src/test/java/com/zodl/slipstream/SlipstreamSynchronizerLifecycleTest.kt
+++ b/sdk-lib/src/test/java/com/zodl/slipstream/SlipstreamSynchronizerLifecycleTest.kt
@@ -435,6 +435,9 @@ class SlipstreamSynchronizerLifecycleTest {
         val synchronizer = buildSynchronizer(engine = engine, key = key)
         try {
             `when`(engine.isRunning).thenReturn(true)
+            clearInvocations(engine)
+            synchronizer.onForeground()
+            runBlocking { verify(engine, timeout(TIMEOUT_MS)).startPolling() }
             synchronizer.pause()
             clearInvocations(engine)
 
@@ -476,7 +479,11 @@ class SlipstreamSynchronizerLifecycleTest {
         }
     }
 
-    /** Backgrounded, the engine stays stopped — the next foreground event is what restarts it. */
+    /**
+     * Backgrounded, both the engine and the poll loop stay stopped — the next foreground event is
+     * what restarts them. Polling a session [SlipstreamSynchronizer.onBackground] stopped would
+     * spend battery on a dead engine.
+     */
     @Test
     fun resume_while_backgrounded_leaves_a_stopped_engine_stopped() {
         val engine = mock(SlipstreamEngine::class.java)
@@ -490,7 +497,7 @@ class SlipstreamSynchronizerLifecycleTest {
             synchronizer.resume()
 
             runBlocking {
-                verify(engine, timeout(TIMEOUT_MS)).startPolling()
+                verify(engine, after(SETTLE_MS).never()).startPolling()
                 verify(engine, never()).start(null, STARTING_BIRTHDAY_VALUE)
             }
         } finally {

--- a/sdk-lib/src/test/java/com/zodl/slipstream/internal/EngineMappingTest.kt
+++ b/sdk-lib/src/test/java/com/zodl/slipstream/internal/EngineMappingTest.kt
@@ -9,6 +9,7 @@ import com.zodl.slipstream.model.SlipstreamPoolBalance
 import com.zodl.slipstream.model.SlipstreamWalletSummary
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class EngineMappingTest {
@@ -146,6 +147,30 @@ class EngineMappingTest {
 
         assertEquals(99L, balance.ironwood.available.value)
     }
+
+    @Test
+    fun a_fresh_tip_is_effective_regardless_of_the_stale_tick_count() {
+        assertTrue(effectiveTipFresh(tipFresh = true, consecutiveStaleTicks = 0))
+        assertTrue(effectiveTipFresh(tipFresh = true, consecutiveStaleTicks = STALE_MASK_FAIL_OPEN_TICKS))
+    }
+
+    /**
+     * MOB-1667: the mask must fail open once it has been applied to live observations for
+     * [STALE_MASK_FAIL_OPEN_TICKS] consecutive ticks (15 minutes at the 2 s poll interval) - a
+     * `tipFresh` that never latches otherwise pins spendable at zero forever.
+     */
+    @Test
+    fun a_stale_tip_stops_masking_only_once_the_fail_open_threshold_is_reached() {
+        assertFalse(effectiveTipFresh(tipFresh = false, consecutiveStaleTicks = 0))
+        assertFalse(effectiveTipFresh(tipFresh = false, consecutiveStaleTicks = STALE_MASK_FAIL_OPEN_TICKS - 1))
+        assertTrue(effectiveTipFresh(tipFresh = false, consecutiveStaleTicks = STALE_MASK_FAIL_OPEN_TICKS))
+        assertTrue(effectiveTipFresh(tipFresh = false, consecutiveStaleTicks = STALE_MASK_FAIL_OPEN_TICKS + 1))
+    }
+
+    /** 450 ticks at [SlipstreamEngine.POLL_INTERVAL_MS] is the intended 15 minutes. */
+    @Test
+    fun the_fail_open_threshold_is_fifteen_minutes_of_ticks() =
+        assertEquals(15 * 60 * 1_000L, STALE_MASK_FAIL_OPEN_TICKS * SlipstreamEngine.POLL_INTERVAL_MS)
 
     private fun accountBalance(
         uuid: ByteArray,


### PR DESCRIPTION
Fixes [MOB-1667](https://linear.app/zodl/issue/MOB-1667/unable-to-sync-on-android-following-update-to-v390): after updating to Zashi 3.9.0 (SDK 3.0.1), users who had manually migrated Orchard→Ironwood saw a correct total balance but spendable pinned at 0 indefinitely, with a `SYNCED` status and no way to send.

Three defects chained into that state; each commit fixes one:

1. **Bound the `readyToBroadcast` sync-block leg** (`5aefa9f0`). Unlike the other two legs of `isSyncBlockedNow` (both self-expiring), the readiness leg had no time bound — and its only escape, stale-plan expiry, is evaluated against the *scanned* tip, which cannot advance while the block itself keeps sync paused. A migration driver the OS never runs again (aggressive OEM worker scheduling — the reporter is on Xiaomi/MIUI) paused sync forever. Readiness alone now blocks for at most three privacy sync buffers (~30 min mainnet) of continuous untouched readiness, tracked by a persisted stamp that every live `executeNextPendingTransfer` attempt re-arms — a working driver keeps its full decorrelation window; only a dead one lets the cap elapse. The actual send stays protected by the unchanged in-flight and post-broadcast buffer legs.
2. **`pause()` keeps observing; `resume()` restarts a stopped engine** (`ae1ee028`, `851f1f16`). The poll loop performs only local JNI reads — the network session it was meant to decorrelate was never gated here at all — so stopping it merely froze the balances, heights and status the host renders, behind a status forced to `SYNCED`. Pausing now gates just `syncBurst` and transaction resubmission, polling continues, status is truthful, and `resume()` restarts an engine that a preceding `onBackground()` stopped instead of polling a dead session. `restoreAfterBurst()` follows the same rule for a pause landing mid-burst.
3. **The stale-tip spendable mask fails open after 15 minutes of live stale ticks** (`403725b9`). `tipFresh` latches only after a fully successful serial network prologue, and the engine forces `is_recovering = 0` in error states — closing the mask's one escape exactly when the engine is wedged. Any persistent early-prologue failure pinned spendable at zero with no exit. Showing spendable against an unverified tip cannot lose funds (a stale-tip spend fails at propose or broadcast); hiding it indefinitely bricks the wallet.

Recovery for currently-wedged users once released: the existing stuck `STEP_BROADCAST` state arms the cap on first poll, sync resumes within ~30 min even if WorkManager never fires, balances are live immediately, and `tipFresh` latches on the first completed prologue.

Kotlin-only; no Rust/FFI, schema, or dependency changes. `sdk-lib` unit suites (261 tests), `detektAll`, `ktlint`, sdk-incubator-lib/lightwallet-client-lib suites and the demo-app compile are green. Note for reviewers: app `maint/v3.9.x` does not compile against this branch's *base* either (pre-existing voting-API drift in `VotingCryptoClient.kt`), so no end-to-end app assemble was possible from this SDK line.

Deferred follow-ups (out of scope here): JNI-layer independent tip corroboration (needs a Tor-policy review); a first-class `PAUSED` `Synchronizer.Status` (public API change); gating the native session itself during decorrelation windows; app-side expedited/foreground migration worker; a persisted tip-freshness grace window if the tick-based fail-open proves insufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Write any additional comments here when opening the pull request -->

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [ ] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [README.md](../blob/main/README.md), [Architecture.md](../blob/main/docs/Architecture.md), etc.)
- [ ] **Run the demo app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [README.md](../blob/main/README.md), [Architecture.md](/blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the demo app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the SDK, some aspects require manual testing. If you had to manually test 
something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the demo app to look for build failures or crashes, humans running the demo app are 
more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._