### PR TITLE
Remove suppression of nonexistent semgrep rule kotlin-typesafe-returns-jni-model

### DIFF
--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeVotingBackend.kt
@@ -109,7 +109,6 @@ internal interface TypesafeVotingDb {
         notes: List<VotingNoteInfo>
     ): JniBundleSetupResult
 
-    // nosemgrep: kotlin-typesafe-returns-jni-model -- voting internals consume this JNI carrier.
     suspend fun generateHotkey(
         roundId: String,
         seed: ByteArray


### PR DESCRIPTION
<!-- Write any additional comments here when opening the pull request -->

## Summary

Removes the `// nosemgrep: kotlin-typesafe-returns-jni-model -- voting internals consume this JNI carrier.` suppression comment from `TypesafeVotingBackend.kt` on this maintenance line.

Per the findings posted on #2080 (https://github.com/zcash/zcash-android-wallet-sdk/issues/2080#issuecomment-5277296620), the `kotlin-typesafe-returns-jni-model` semgrep rule has no definition anywhere reachable — no rule file, no CI step, no Semgrep registry entry, and zero semgrep SARIF uploads ever recorded against this repo. The name was invented in one un-announced line of commit `1bdf0a2b` and has never been checked by anything, on this branch or any other. The comment is dead weight regardless of its placement, so it comes out.

One correction versus how this was scoped in the issue: on `main`, later commits (`e4226589`, `c00803be`) detached this comment from its declaration during ktlint-driven reshuffles, which is why the issue describes an "orphaned" copy. That history is **not** present on `maint/v2.8.x` — this branch only carries the original commit that introduced the rule name, where the comment sits directly above `generateHotkey()`, correctly adjacent to its declaration. So this specific removal is not about fixing a detached comment; it's simply removing a suppression for a rule that doesn't exist. The `main`-side cleanup (removing the three live suppressions there, the rationale header, and the ktlint `@Suppress` that exists solely to protect their adjacency) is a separate, larger change and will follow via merge-forward once this PR merges — not part of this PR.

Related: zcash/zcash-android-wallet-sdk#2080 / MOB-1563.

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [ ] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [README.md](../blob/main/README.md), [Architecture.md](../blob/main/docs/Architecture.md), etc.)
- [ ] **Run the demo app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [README.md](../blob/main/README.md), [Architecture.md](/blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the demo app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the SDK, some aspects require manual testing. If you had to manually test 
something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the demo app to look for build failures or crashes, humans running the demo app are 
more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
