### PR TITLE
MOB-1541: Tolerate unknown-pool subtree root fetch failures without retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   store read is inconclusive (MOB-1717).
 - A transaction whose raw bytes cannot be read during resubmission is skipped and retried next
   sync cycle instead of aborting the sync pass with `TransactionNotFoundException` (MOB-1717).
+- Fetching subtree roots against a lightwalletd that doesn't recognize the Ironwood pool (or whose
+  backing node predates NU6.3) no longer burns all retry attempts or logs fatal-looking errors; the
+  server response is now recognized and tolerated on the first attempt. Genuine Ironwood fetch
+  failures are recorded the same way as Sapling/Orchard failures instead of being silently
+  tolerated, and a failed Orchard or Ironwood fetch can no longer be masked by a successful Sapling
+  fetch into a false-positive spend-before-sync result (MOB-1541).
 
 ## [3.0.2] - 2026-08-13
 

--- a/sdk-lib/build.gradle.kts
+++ b/sdk-lib/build.gradle.kts
@@ -136,6 +136,7 @@ dependencies {
     testImplementation(libs.kotlin.test)
     testImplementation(libs.bundles.junit)
     testImplementation(libs.mockito.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
 
     // NOTE: androidTests will use JUnit4, while src/test/java tests will leverage Junit5
     // Attempting to use JUnit5 via https://github.com/mannodermaus/android-junit5 was painful. The plugin configuration

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessor.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessor.kt
@@ -1207,7 +1207,9 @@ class CompactBlockProcessor internal constructor(
          *   (2) with that description.
          * - An upgraded lightwalletd whose backing node is pre-NU6.3:
          *   `status.Errorf(codes.InvalidArgument, "GetSubtreeRoots: bad shielded protocol specifier error: ...")`,
-         *   which surfaces as INVALID_ARGUMENT (3).
+         *   which surfaces as INVALID_ARGUMENT (3) and is matched on the `"bad shielded protocol specifier"`
+         *   substring, not the more generic `"shielded protocol"`, so an INVALID_ARGUMENT failure for an
+         *   unrelated reason isn't mistaken for an unrecognized pool.
          * - UNIMPLEMENTED (12) is matched defensively for other indexers (e.g. Zaino) that haven't implemented
          *   the pool at all.
          *
@@ -1221,7 +1223,7 @@ class CompactBlockProcessor internal constructor(
                 }
 
                 GRPC_CODE_INVALID_ARGUMENT -> {
-                    description?.contains("shielded protocol", ignoreCase = true) == true
+                    description?.contains("bad shielded protocol specifier", ignoreCase = true) == true
                 }
 
                 GRPC_CODE_UNIMPLEMENTED -> {

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessor.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessor.kt
@@ -1181,6 +1181,59 @@ class CompactBlockProcessor internal constructor(
         internal const val GET_SUBTREE_ROOTS_RETRIES = 3
 
         /**
+         * gRPC status code for UNKNOWN failures, i.e. the server returned a generic error with no matching
+         * gRPC status. sdk-lib has no `io.grpc.Status` on its compile classpath, so this mirrors
+         * `io.grpc.Status.Code.UNKNOWN`'s numeric value.
+         */
+        private const val GRPC_CODE_UNKNOWN = 2
+
+        /**
+         * gRPC status code for INVALID_ARGUMENT failures. Mirrors `io.grpc.Status.Code.INVALID_ARGUMENT`.
+         */
+        private const val GRPC_CODE_INVALID_ARGUMENT = 3
+
+        /**
+         * gRPC status code for UNIMPLEMENTED failures. Mirrors `io.grpc.Status.Code.UNIMPLEMENTED`.
+         */
+        private const val GRPC_CODE_UNIMPLEMENTED = 12
+
+        /**
+         * Classifies a subtree roots [Response.Failure] as coming from a server that doesn't recognize the
+         * requested shielded protocol, rather than as a genuine fetch failure. Covers the failure shapes
+         * empirically observed against lightwalletd:
+         *
+         * - A deployed pre-Ironwood lightwalletd (v0.4.x): its `GetSubtreeRoots` handler's pool switch returns
+         *   a plain Go error (`errors.New("unrecognized shielded protocol")`), which surfaces as gRPC UNKNOWN
+         *   (2) with that description.
+         * - An upgraded lightwalletd whose backing node is pre-NU6.3:
+         *   `status.Errorf(codes.InvalidArgument, "GetSubtreeRoots: bad shielded protocol specifier error: ...")`,
+         *   which surfaces as INVALID_ARGUMENT (3).
+         * - UNIMPLEMENTED (12) is matched defensively for other indexers (e.g. Zaino) that haven't implemented
+         *   the pool at all.
+         *
+         * UNKNOWN is gRPC's catch-all, so the code alone can't distinguish an unrecognized pool from any other
+         * unknown error; the description text is required to discriminate.
+         */
+        private fun Response.Failure<*>.isUnknownPoolFailure(): Boolean =
+            when (code) {
+                GRPC_CODE_UNKNOWN -> {
+                    description?.contains("unrecognized shielded protocol", ignoreCase = true) == true
+                }
+
+                GRPC_CODE_INVALID_ARGUMENT -> {
+                    description?.contains("shielded protocol", ignoreCase = true) == true
+                }
+
+                GRPC_CODE_UNIMPLEMENTED -> {
+                    true
+                }
+
+                else -> {
+                    false
+                }
+            }
+
+        /**
          * The theoretical maximum number of blocks in a reorg, due to other bottlenecks in the protocol design.
          */
         internal const val MAX_REORG_SIZE = 100
@@ -1373,30 +1426,22 @@ class CompactBlockProcessor internal constructor(
         Twig.debug { "Fetching SubtreeRoots..." }
         val traceScope = TraceScope("CompactBlockProcessor.getSubtreeRoots")
 
-        var result: GetSubtreeRootsResult = GetSubtreeRootsResult.Linear
-
-        // Fetching the subtree roots of a pool differs only in which pool is targeted and in
-        // whether a failure is recorded, so the three per-pool retry loops share one implementation.
-        //
-        // Sapling and Orchard record into [result] exactly as they did before Ironwood existed.
-        // Only the Ironwood fetch tolerates failure: no deployed lightwalletd answers for a pool
-        // that activates at NU6.3, so until the server population is upgraded this request fails
-        // for every wallet, on every sync start. Recording that would set a value the trailing
-        // `saplingSubtreeRootList.isNotEmpty()` block discards anyway; tolerating it keeps the
-        // absence of Ironwood roots from reading as a fetch failure.
-        //
-        // This tolerance is transitional and must not outlive the server rollout, or a genuine
-        // Ironwood fetch fault will be ignored and spend-before-sync will proceed on an
-        // incomplete Ironwood commitment tree. Tracked in
-        // https://github.com/zcash/zcash-android-wallet-sdk/issues/2061.
+        /*
+         * Fetching the subtree roots of a pool differs only in which pool is targeted, so the three per-pool
+         * retry loops share one implementation. A server that doesn't recognize the requested pool (see
+         * [isUnknownPoolFailure]) is tolerated uniformly across all three pools: it's logged at info level
+         * and the fetch completes with an empty root list on the first attempt, without retrying and without
+         * being recorded as a failure. Any other failure is recorded identically for all three pools - there
+         * is no longer a pool-specific blanket tolerance. This resolves the transitional Ironwood-only
+         * tolerance debt tracked in https://github.com/zcash/zcash-android-wallet-sdk/issues/2061.
+         */
         suspend fun fetchSubtreeRoots(
             startIndex: UInt,
-            shieldedProtocol: ShieldedProtocolEnum,
-            onFailure: (GetSubtreeRootsResult) -> Unit
-        ): List<SubtreeRoot> {
-            var roots: List<SubtreeRoot> = emptyList()
+            shieldedProtocol: ShieldedProtocolEnum
+        ): PoolFetchOutcome {
+            var outcome: PoolFetchOutcome = PoolFetchOutcome.Roots(emptyList())
             retryUpToAndContinue(GET_SUBTREE_ROOTS_RETRIES) {
-                roots =
+                val roots =
                     downloader
                         .getSubtreeRoots(
                             startIndex = startIndex,
@@ -1413,30 +1458,42 @@ class CompactBlockProcessor internal constructor(
                                 }
 
                                 is Response.Failure -> {
-                                    val error =
-                                        LightWalletException.GetSubtreeRootsException(
-                                            response.code,
-                                            response.description,
-                                            response.toThrowable()
-                                        )
-                                    if (response is Response.Failure.Server.Unavailable) {
-                                        Twig.error {
-                                            "Fetching $shieldedProtocol SubtreeRoot failed due to server" +
-                                                " communication problem with failure: ${response.toThrowable()}"
+                                    if (response.isUnknownPoolFailure()) {
+                                        Twig.info {
+                                            "$shieldedProtocol subtree roots are not provided by this server" +
+                                                " (code: ${response.code}, description: ${response.description});" +
+                                                " proceeding without them"
                                         }
-                                        onFailure(GetSubtreeRootsResult.FailureConnection)
                                     } else {
-                                        Twig.error {
-                                            "Fetching $shieldedProtocol SubtreeRoot failed with failure:" +
-                                                " ${response.toThrowable()}"
+                                        val error =
+                                            LightWalletException.GetSubtreeRootsException(
+                                                response.code,
+                                                response.description,
+                                                response.toThrowable()
+                                            )
+                                        if (response is Response.Failure.Server.Unavailable) {
+                                            Twig.error {
+                                                "Fetching $shieldedProtocol SubtreeRoot failed due to server" +
+                                                    " communication problem with failure: ${response.toThrowable()}"
+                                            }
+                                            outcome =
+                                                PoolFetchOutcome.Failed(GetSubtreeRootsResult.FailureConnection)
+                                        } else {
+                                            Twig.error {
+                                                "Fetching $shieldedProtocol SubtreeRoot failed with failure:" +
+                                                    " ${response.toThrowable()}"
+                                            }
+                                            outcome =
+                                                PoolFetchOutcome.Failed(GetSubtreeRootsResult.OtherFailure(error))
                                         }
-                                        onFailure(GetSubtreeRootsResult.OtherFailure(error))
+                                        /*
+                                         * Deliberately not ending [traceScope] here: `retryUpToAndContinue`
+                                         * swallows this after the last attempt, so control always reaches the
+                                         * single `traceScope.end()` below. Ending it per failed attempt closed
+                                         * the scope early and logged "ended more than once" for each retry.
+                                         */
+                                        throw error
                                     }
-                                    // Deliberately not ending [traceScope] here: `retryUpToAndContinue`
-                                    // swallows this after the last attempt, so control always reaches the
-                                    // single `traceScope.end()` below. Ending it per failed attempt closed
-                                    // the scope early and logged "ended more than once" for each retry.
-                                    throw error
                                 }
                             }
                         }.filterIsInstance<Response.Success<SubtreeRootUnsafe>>()
@@ -1446,33 +1503,51 @@ class CompactBlockProcessor internal constructor(
                         .map {
                             SubtreeRoot.new(it)
                         }
+                outcome = PoolFetchOutcome.Roots(roots)
             }
-            return roots
+            return outcome
         }
 
-        val saplingSubtreeRootList =
-            fetchSubtreeRoots(saplingStartIndex, ShieldedProtocolEnum.SAPLING) { failure -> result = failure }
-        val orchardSubtreeRootList =
-            fetchSubtreeRoots(orchardStartIndex, ShieldedProtocolEnum.ORCHARD) { failure -> result = failure }
-        val ironwoodSubtreeRootList =
-            fetchSubtreeRoots(ironwoodStartIndex, ShieldedProtocolEnum.IRONWOOD) { /* tolerated; see above */ }
+        val saplingOutcome = fetchSubtreeRoots(saplingStartIndex, ShieldedProtocolEnum.SAPLING)
+        val orchardOutcome = fetchSubtreeRoots(orchardStartIndex, ShieldedProtocolEnum.ORCHARD)
+        val ironwoodOutcome = fetchSubtreeRoots(ironwoodStartIndex, ShieldedProtocolEnum.IRONWOOD)
 
-        // Intentionally omitting [orchardSubtreeRootList]/[ironwoodSubtreeRootList], e.g., for Mainnet usage, we
-        // could check it, but on custom networks without NU5/NU6.3 activation, it wouldn't work. If the Orchard or
-        // Ironwood subtree roots are empty, it's technically still ok (both activate after Sapling, so on a network
-        // that doesn't have them activated yet, this would behave correctly). In contrast, if the Sapling subtree
-        // roots are empty, we cannot do SbS at all.
-        if (saplingSubtreeRootList.isNotEmpty()) {
-            result =
-                GetSubtreeRootsResult.SpendBeforeSync(
-                    saplingStartIndex,
-                    saplingSubtreeRootList,
-                    orchardStartIndex,
-                    orchardSubtreeRootList,
-                    ironwoodStartIndex,
-                    ironwoodSubtreeRootList
-                )
-        }
+        val failures = listOf(saplingOutcome, orchardOutcome, ironwoodOutcome).filterIsInstance<PoolFetchOutcome.Failed>()
+
+        val result =
+            when {
+                failures.any { it.failure == GetSubtreeRootsResult.FailureConnection } -> {
+                    GetSubtreeRootsResult.FailureConnection
+                }
+
+                failures.isNotEmpty() -> {
+                    failures.first().failure
+                }
+
+                else -> {
+                    /*
+                     * Intentionally omitting the Orchard/Ironwood root lists here, e.g., for Mainnet usage, we
+                     * could check them, but on custom networks without NU5/NU6.3 activation, that wouldn't work.
+                     * If the Orchard or Ironwood subtree roots are empty, it's technically still ok (both
+                     * activate after Sapling, so on a network that doesn't have them activated yet, this would
+                     * behave correctly). In contrast, if the Sapling subtree roots are empty, we cannot do SbS
+                     * at all.
+                     */
+                    val saplingRoots = (saplingOutcome as PoolFetchOutcome.Roots).list
+                    if (saplingRoots.isEmpty()) {
+                        GetSubtreeRootsResult.Linear
+                    } else {
+                        GetSubtreeRootsResult.SpendBeforeSync(
+                            saplingStartIndex,
+                            saplingRoots,
+                            orchardStartIndex,
+                            (orchardOutcome as PoolFetchOutcome.Roots).list,
+                            ironwoodStartIndex,
+                            (ironwoodOutcome as PoolFetchOutcome.Roots).list
+                        )
+                    }
+                }
+            }
 
         traceScope.end()
         return result
@@ -2987,6 +3062,22 @@ class CompactBlockProcessor internal constructor(
             }
         }
     }
+}
+
+/**
+ * Outcome of fetching the subtree roots for a single pool within [CompactBlockProcessor.getSubtreeRoots].
+ * [Roots] covers both a genuinely successful fetch and one tolerated as an unknown-pool failure (see
+ * `isUnknownPoolFailure`), since both leave the pool with a (possibly empty) root list and no failure to
+ * propagate.
+ */
+private sealed interface PoolFetchOutcome {
+    data class Roots(
+        val list: List<SubtreeRoot>
+    ) : PoolFetchOutcome
+
+    data class Failed(
+        val failure: GetSubtreeRootsResult
+    ) : PoolFetchOutcome
 }
 
 private const val NOT_FOUND_MESSAGE_WORKAROUND = "Transaction not found"

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessor.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessor.kt
@@ -1211,12 +1211,15 @@ class CompactBlockProcessor internal constructor(
          *   substring, not the more generic `"shielded protocol"`, so an INVALID_ARGUMENT failure for an
          *   unrelated reason isn't mistaken for an unrecognized pool.
          * - UNIMPLEMENTED (12) is matched defensively for other indexers (e.g. Zaino) that haven't implemented
-         *   the pool at all.
+         *   the pool at all — but only for pools other than Sapling. Sapling is the baseline pool every
+         *   spend-before-sync-capable server must serve, so a Sapling UNIMPLEMENTED means the server doesn't
+         *   implement the `GetSubtreeRoots` RPC at all and is treated as a genuine failure rather than being
+         *   silently tolerated as "no Sapling roots".
          *
          * UNKNOWN is gRPC's catch-all, so the code alone can't distinguish an unrecognized pool from any other
          * unknown error; the description text is required to discriminate.
          */
-        private fun Response.Failure<*>.isUnknownPoolFailure(): Boolean =
+        private fun Response.Failure<*>.isUnknownPoolFailure(shieldedProtocol: ShieldedProtocolEnum): Boolean =
             when (code) {
                 GRPC_CODE_UNKNOWN -> {
                     description?.contains("unrecognized shielded protocol", ignoreCase = true) == true
@@ -1227,7 +1230,7 @@ class CompactBlockProcessor internal constructor(
                 }
 
                 GRPC_CODE_UNIMPLEMENTED -> {
-                    true
+                    shieldedProtocol != ShieldedProtocolEnum.SAPLING
                 }
 
                 else -> {
@@ -1431,9 +1434,10 @@ class CompactBlockProcessor internal constructor(
         /*
          * Fetching the subtree roots of a pool differs only in which pool is targeted, so the three per-pool
          * retry loops share one implementation. A server that doesn't recognize the requested pool (see
-         * [isUnknownPoolFailure]) is tolerated uniformly across all three pools: it's logged at info level
-         * and the fetch completes with an empty root list on the first attempt, without retrying and without
-         * being recorded as a failure. Any other failure is recorded identically for all three pools - there
+         * [isUnknownPoolFailure], which exempts Sapling from the UNIMPLEMENTED tolerance) is tolerated:
+         * it's logged at info level and the fetch completes with an empty root list on the first attempt,
+         * without retrying and without being recorded as a failure. Any other failure is recorded identically for all three pools -
+         * there
          * is no longer a pool-specific blanket tolerance. This resolves the transitional Ironwood-only
          * tolerance debt tracked in https://github.com/zcash/zcash-android-wallet-sdk/issues/2061.
          */
@@ -1460,7 +1464,7 @@ class CompactBlockProcessor internal constructor(
                                 }
 
                                 is Response.Failure -> {
-                                    if (response.isUnknownPoolFailure()) {
+                                    if (response.isUnknownPoolFailure(shieldedProtocol)) {
                                         Twig.info {
                                             "$shieldedProtocol subtree roots are not provided by this server" +
                                                 " (code: ${response.code}, description: ${response.description});" +

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessorTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessorTest.kt
@@ -483,6 +483,67 @@ class CompactBlockProcessorTest {
         }
 
     @Test
+    fun sapling_unknown_code_is_tolerated_as_an_unknown_pool_failure() =
+        runTest {
+            val downloader = mock(CompactBlockDownloader::class.java)
+            val processor = subtreeRootsProcessor()
+
+            stubSubtreeRoots(
+                downloader,
+                SAPLING_START_INDEX,
+                ShieldedProtocolEnum.SAPLING,
+                flowOf(unknownFailure(code = 2, description = "unrecognized shielded protocol"))
+            )
+            stubSubtreeRoots(downloader, ORCHARD_START_INDEX, ShieldedProtocolEnum.ORCHARD, successFlow())
+            stubSubtreeRoots(downloader, IRONWOOD_START_INDEX, ShieldedProtocolEnum.IRONWOOD, successFlow())
+
+            val result =
+                processor.getSubtreeRoots(
+                    downloader = downloader,
+                    saplingStartIndex = SAPLING_START_INDEX,
+                    orchardStartIndex = ORCHARD_START_INDEX,
+                    ironwoodStartIndex = IRONWOOD_START_INDEX
+                )
+
+            assertEquals(GetSubtreeRootsResult.Linear, result)
+            verify(downloader, times(1))
+                .getSubtreeRoots(SAPLING_START_INDEX, ShieldedProtocolEnum.SAPLING, UInt.MIN_VALUE, ServiceMode.Direct)
+        }
+
+    @Test
+    fun sapling_invalid_argument_is_tolerated_as_an_unknown_pool_failure() =
+        runTest {
+            val downloader = mock(CompactBlockDownloader::class.java)
+            val processor = subtreeRootsProcessor()
+
+            stubSubtreeRoots(
+                downloader,
+                SAPLING_START_INDEX,
+                ShieldedProtocolEnum.SAPLING,
+                flowOf(
+                    otherFailure(
+                        code = 3,
+                        description = "GetSubtreeRoots: bad shielded protocol specifier error: x"
+                    )
+                )
+            )
+            stubSubtreeRoots(downloader, ORCHARD_START_INDEX, ShieldedProtocolEnum.ORCHARD, successFlow())
+            stubSubtreeRoots(downloader, IRONWOOD_START_INDEX, ShieldedProtocolEnum.IRONWOOD, successFlow())
+
+            val result =
+                processor.getSubtreeRoots(
+                    downloader = downloader,
+                    saplingStartIndex = SAPLING_START_INDEX,
+                    orchardStartIndex = ORCHARD_START_INDEX,
+                    ironwoodStartIndex = IRONWOOD_START_INDEX
+                )
+
+            assertEquals(GetSubtreeRootsResult.Linear, result)
+            verify(downloader, times(1))
+                .getSubtreeRoots(SAPLING_START_INDEX, ShieldedProtocolEnum.SAPLING, UInt.MIN_VALUE, ServiceMode.Direct)
+        }
+
+    @Test
     fun sapling_unimplemented_is_a_genuine_failure_not_an_unknown_pool() =
         runTest {
             val downloader = mock(CompactBlockDownloader::class.java)

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessorTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessorTest.kt
@@ -1,5 +1,6 @@
 package cash.z.ecc.android.sdk.block.processor
 
+import cash.z.ecc.android.sdk.block.processor.model.GetSubtreeRootsResult
 import cash.z.ecc.android.sdk.internal.SaplingParamFetcher
 import cash.z.ecc.android.sdk.internal.TypesafeBackend
 import cash.z.ecc.android.sdk.internal.block.CompactBlockDownloader
@@ -19,14 +20,24 @@ import cash.z.ecc.android.sdk.model.TransactionSubmitResult
 import cash.z.ecc.android.sdk.model.Zatoshi
 import cash.z.ecc.android.sdk.model.ZcashNetwork
 import cash.z.ecc.android.sdk.model.Zip318Kind
+import co.electriccoin.lightwallet.client.ServiceMode
+import co.electriccoin.lightwallet.client.model.BlockHeightUnsafe
 import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
+import co.electriccoin.lightwallet.client.model.Response
+import co.electriccoin.lightwallet.client.model.ShieldedProtocolEnum
+import co.electriccoin.lightwallet.client.model.SubtreeRootUnsafe
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
+import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.Mockito.`when`
@@ -432,6 +443,253 @@ class CompactBlockProcessorTest {
         }
     }
 
+    @Test
+    fun unknown_pool_failure_is_tolerated_without_retry() =
+        runTest {
+            val unknownPoolFailures =
+                listOf(
+                    unknownFailure(code = 2, description = "unrecognized shielded protocol"),
+                    otherFailure(code = 3, description = "GetSubtreeRoots: bad shielded protocol specifier error: x"),
+                    otherFailure(code = 12, description = null)
+                )
+
+            unknownPoolFailures.forEach { failure ->
+                val downloader = mock(CompactBlockDownloader::class.java)
+                val processor = subtreeRootsProcessor()
+
+                stubSubtreeRoots(downloader, SAPLING_START_INDEX, ShieldedProtocolEnum.SAPLING, successFlow())
+                stubSubtreeRoots(downloader, ORCHARD_START_INDEX, ShieldedProtocolEnum.ORCHARD, successFlow())
+                stubSubtreeRoots(downloader, IRONWOOD_START_INDEX, ShieldedProtocolEnum.IRONWOOD, flowOf(failure))
+
+                val result =
+                    processor.getSubtreeRoots(
+                        downloader = downloader,
+                        saplingStartIndex = SAPLING_START_INDEX,
+                        orchardStartIndex = ORCHARD_START_INDEX,
+                        ironwoodStartIndex = IRONWOOD_START_INDEX
+                    )
+
+                assertTrue(result is GetSubtreeRootsResult.SpendBeforeSync)
+                assertTrue(result.ironwoodSubtreeRootList.isEmpty())
+                verify(downloader, times(1))
+                    .getSubtreeRoots(
+                        IRONWOOD_START_INDEX,
+                        ShieldedProtocolEnum.IRONWOOD,
+                        UInt.MIN_VALUE,
+                        ServiceMode.Direct
+                    )
+            }
+        }
+
+    @Test
+    fun orchard_genuine_failure_is_not_masked_by_successful_sapling_fetch() =
+        runTest {
+            val downloader = mock(CompactBlockDownloader::class.java)
+            val processor = subtreeRootsProcessor()
+
+            stubSubtreeRoots(downloader, SAPLING_START_INDEX, ShieldedProtocolEnum.SAPLING, successFlow())
+            stubSubtreeRoots(
+                downloader,
+                ORCHARD_START_INDEX,
+                ShieldedProtocolEnum.ORCHARD,
+                flowOf(otherFailure(code = 13, description = "internal")),
+                flowOf(otherFailure(code = 13, description = "internal")),
+                flowOf(otherFailure(code = 13, description = "internal"))
+            )
+            stubSubtreeRoots(downloader, IRONWOOD_START_INDEX, ShieldedProtocolEnum.IRONWOOD, successFlow())
+
+            val result =
+                processor.getSubtreeRoots(
+                    downloader = downloader,
+                    saplingStartIndex = SAPLING_START_INDEX,
+                    orchardStartIndex = ORCHARD_START_INDEX,
+                    ironwoodStartIndex = IRONWOOD_START_INDEX
+                )
+
+            assertTrue(result is GetSubtreeRootsResult.OtherFailure)
+            verify(downloader, times(3))
+                .getSubtreeRoots(ORCHARD_START_INDEX, ShieldedProtocolEnum.ORCHARD, UInt.MIN_VALUE, ServiceMode.Direct)
+        }
+
+    @Test
+    fun sapling_transient_failure_then_success_is_not_poisoned_by_first_attempt() =
+        runTest {
+            val downloader = mock(CompactBlockDownloader::class.java)
+            val processor = subtreeRootsProcessor()
+
+            stubSubtreeRoots(
+                downloader,
+                SAPLING_START_INDEX,
+                ShieldedProtocolEnum.SAPLING,
+                flowOf(otherFailure(code = 13, description = "temporary")),
+                successFlow()
+            )
+            stubSubtreeRoots(downloader, ORCHARD_START_INDEX, ShieldedProtocolEnum.ORCHARD, successFlow())
+            stubSubtreeRoots(downloader, IRONWOOD_START_INDEX, ShieldedProtocolEnum.IRONWOOD, successFlow())
+
+            val result =
+                processor.getSubtreeRoots(
+                    downloader = downloader,
+                    saplingStartIndex = SAPLING_START_INDEX,
+                    orchardStartIndex = ORCHARD_START_INDEX,
+                    ironwoodStartIndex = IRONWOOD_START_INDEX
+                )
+
+            assertTrue(result is GetSubtreeRootsResult.SpendBeforeSync)
+            verify(downloader, times(2))
+                .getSubtreeRoots(SAPLING_START_INDEX, ShieldedProtocolEnum.SAPLING, UInt.MIN_VALUE, ServiceMode.Direct)
+        }
+
+    @Test
+    fun empty_sapling_roots_yields_linear_result() =
+        runTest {
+            val downloader = mock(CompactBlockDownloader::class.java)
+            val processor = subtreeRootsProcessor()
+
+            stubSubtreeRoots(downloader, SAPLING_START_INDEX, ShieldedProtocolEnum.SAPLING, emptyFlow())
+            stubSubtreeRoots(downloader, ORCHARD_START_INDEX, ShieldedProtocolEnum.ORCHARD, successFlow())
+            stubSubtreeRoots(downloader, IRONWOOD_START_INDEX, ShieldedProtocolEnum.IRONWOOD, successFlow())
+
+            val result =
+                processor.getSubtreeRoots(
+                    downloader = downloader,
+                    saplingStartIndex = SAPLING_START_INDEX,
+                    orchardStartIndex = ORCHARD_START_INDEX,
+                    ironwoodStartIndex = IRONWOOD_START_INDEX
+                )
+
+            assertEquals(GetSubtreeRootsResult.Linear, result)
+        }
+
+    @Test
+    fun sapling_unavailable_on_all_attempts_yields_failure_connection() =
+        runTest {
+            val downloader = mock(CompactBlockDownloader::class.java)
+            val processor = subtreeRootsProcessor()
+
+            stubSubtreeRoots(
+                downloader,
+                SAPLING_START_INDEX,
+                ShieldedProtocolEnum.SAPLING,
+                flowOf(unavailableFailure(code = 14, description = "unavailable")),
+                flowOf(unavailableFailure(code = 14, description = "unavailable")),
+                flowOf(unavailableFailure(code = 14, description = "unavailable"))
+            )
+            stubSubtreeRoots(downloader, ORCHARD_START_INDEX, ShieldedProtocolEnum.ORCHARD, successFlow())
+            stubSubtreeRoots(downloader, IRONWOOD_START_INDEX, ShieldedProtocolEnum.IRONWOOD, successFlow())
+
+            val result =
+                processor.getSubtreeRoots(
+                    downloader = downloader,
+                    saplingStartIndex = SAPLING_START_INDEX,
+                    orchardStartIndex = ORCHARD_START_INDEX,
+                    ironwoodStartIndex = IRONWOOD_START_INDEX
+                )
+
+            assertEquals(GetSubtreeRootsResult.FailureConnection, result)
+            verify(downloader, times(3))
+                .getSubtreeRoots(SAPLING_START_INDEX, ShieldedProtocolEnum.SAPLING, UInt.MIN_VALUE, ServiceMode.Direct)
+        }
+
+    @Test
+    fun connection_failure_takes_precedence_over_other_failure() =
+        runTest {
+            val downloader = mock(CompactBlockDownloader::class.java)
+            val processor = subtreeRootsProcessor()
+
+            stubSubtreeRoots(downloader, SAPLING_START_INDEX, ShieldedProtocolEnum.SAPLING, successFlow())
+            stubSubtreeRoots(
+                downloader,
+                ORCHARD_START_INDEX,
+                ShieldedProtocolEnum.ORCHARD,
+                flowOf(unavailableFailure(code = 14, description = "unavailable")),
+                flowOf(unavailableFailure(code = 14, description = "unavailable")),
+                flowOf(unavailableFailure(code = 14, description = "unavailable"))
+            )
+            stubSubtreeRoots(
+                downloader,
+                IRONWOOD_START_INDEX,
+                ShieldedProtocolEnum.IRONWOOD,
+                flowOf(otherFailure(code = 13, description = "internal")),
+                flowOf(otherFailure(code = 13, description = "internal")),
+                flowOf(otherFailure(code = 13, description = "internal"))
+            )
+
+            val result =
+                processor.getSubtreeRoots(
+                    downloader = downloader,
+                    saplingStartIndex = SAPLING_START_INDEX,
+                    orchardStartIndex = ORCHARD_START_INDEX,
+                    ironwoodStartIndex = IRONWOOD_START_INDEX
+                )
+
+            assertEquals(GetSubtreeRootsResult.FailureConnection, result)
+        }
+
+    private fun subtreeRootsProcessor(): CompactBlockProcessor =
+        processor(
+            repository = mock(DerivedDataRepository::class.java),
+            txManager = mock(OutboundTransactionManager::class.java),
+            pendingSubmitPlanStore = PendingSubmitPlanStore()
+        )
+
+    private fun successFlow(): Flow<Response<SubtreeRootUnsafe>> =
+        flowOf(
+            Response.Success(
+                SubtreeRootUnsafe(
+                    rootHash = byteArrayOf(0x01),
+                    completingBlockHash = byteArrayOf(0x02),
+                    completingBlockHeight = BlockHeightUnsafe(SUBTREE_ROOT_COMPLETING_HEIGHT)
+                )
+            )
+        )
+
+    private fun otherFailure(
+        code: Int,
+        description: String?
+    ): Response.Failure.Server.Other<SubtreeRootUnsafe> =
+        Response.Failure.Server.Other(
+            cause = Exception(description ?: "failure"),
+            code = code,
+            description = description
+        )
+
+    private fun unavailableFailure(
+        code: Int,
+        description: String?
+    ): Response.Failure.Server.Unavailable<SubtreeRootUnsafe> =
+        Response.Failure.Server.Unavailable(
+            cause = Exception(description ?: "failure"),
+            code = code,
+            description = description
+        )
+
+    private fun unknownFailure(
+        code: Int,
+        description: String?
+    ): Response.Failure.Server.Unknown<SubtreeRootUnsafe> =
+        Response.Failure.Server.Unknown(
+            cause = Exception(description ?: "failure"),
+            code = code,
+            description = description
+        )
+
+    private suspend fun stubSubtreeRoots(
+        downloader: CompactBlockDownloader,
+        startIndex: UInt,
+        shieldedProtocol: ShieldedProtocolEnum,
+        vararg responses: Flow<Response<SubtreeRootUnsafe>>
+    ) {
+        `when`(
+            downloader.getSubtreeRoots(
+                startIndex = startIndex,
+                shieldedProtocol = shieldedProtocol,
+                maxEntries = UInt.MIN_VALUE,
+                serviceMode = ServiceMode.Direct
+            )
+        ).thenReturn(responses[0], *responses.drop(1).toTypedArray())
+    }
+
     private suspend fun CompactBlockProcessor.resubmitUnminedTransactionsForTest(blockHeight: BlockHeight) {
         val function =
             CompactBlockProcessor::class
@@ -515,5 +773,10 @@ class CompactBlockProcessorTest {
             raw = FirstClassByteArray(byteArrayOf(0x01, 0x02)),
             expiryHeight = expiryHeight
         )
+
+        private const val SAPLING_START_INDEX: UInt = 10u
+        private const val ORCHARD_START_INDEX: UInt = 20u
+        private const val IRONWOOD_START_INDEX: UInt = 30u
+        private const val SUBTREE_ROOT_COMPLETING_HEIGHT = 1_000_000L
     }
 }

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessorTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessorTest.kt
@@ -50,6 +50,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+@Suppress("LargeClass")
 class CompactBlockProcessorTest {
     @Test
     fun should_refresh_preparation_test() {
@@ -479,6 +480,36 @@ class CompactBlockProcessorTest {
                         ServiceMode.Direct
                     )
             }
+        }
+
+    @Test
+    fun sapling_unimplemented_is_a_genuine_failure_not_an_unknown_pool() =
+        runTest {
+            val downloader = mock(CompactBlockDownloader::class.java)
+            val processor = subtreeRootsProcessor()
+
+            stubSubtreeRoots(
+                downloader,
+                SAPLING_START_INDEX,
+                ShieldedProtocolEnum.SAPLING,
+                flowOf(otherFailure(code = 12, description = null)),
+                flowOf(otherFailure(code = 12, description = null)),
+                flowOf(otherFailure(code = 12, description = null))
+            )
+            stubSubtreeRoots(downloader, ORCHARD_START_INDEX, ShieldedProtocolEnum.ORCHARD, successFlow())
+            stubSubtreeRoots(downloader, IRONWOOD_START_INDEX, ShieldedProtocolEnum.IRONWOOD, successFlow())
+
+            val result =
+                processor.getSubtreeRoots(
+                    downloader = downloader,
+                    saplingStartIndex = SAPLING_START_INDEX,
+                    orchardStartIndex = ORCHARD_START_INDEX,
+                    ironwoodStartIndex = IRONWOOD_START_INDEX
+                )
+
+            assertTrue(result is GetSubtreeRootsResult.OtherFailure)
+            verify(downloader, times(3))
+                .getSubtreeRoots(SAPLING_START_INDEX, ShieldedProtocolEnum.SAPLING, UInt.MIN_VALUE, ServiceMode.Direct)
         }
 
     @Test


### PR DESCRIPTION
## Summary

Against a lightwalletd that doesn't recognize the Ironwood pool (or whose backing node predates
NU6.3), `CompactBlockProcessor.getSubtreeRoots` was burning all `GET_SUBTREE_ROOTS_RETRIES`
attempts with exponential backoff on every spend-before-sync init and logging fatal-looking
errors. Two behavior changes fix this:

- **First-attempt tolerance of unknown-pool responses.** A new `isUnknownPoolFailure()` classifier
  recognizes the gRPC failure shapes a server returns when it doesn't know about a requested pool
  (UNKNOWN/2 + "unrecognized shielded protocol", INVALID_ARGUMENT/3 + "shielded protocol",
  UNIMPLEMENTED/12), and tolerates them: logged at info level, empty root list, no retry. The
  description-gated shapes apply uniformly across all three pools; the UNIMPLEMENTED tolerance
  exempts Sapling, since Sapling is the baseline pool every spend-before-sync-capable server must
  serve — a Sapling UNIMPLEMENTED means the server doesn't implement `GetSubtreeRoots` at all and
  stays a genuine failure.
- **Failures are no longer masked by Sapling success.** Previously, a genuine Orchard fetch
  failure was recorded but then silently discarded whenever the Sapling root list was non-empty,
  producing a false-positive `SpendBeforeSync` result. Fetch outcomes for all three pools are now
  combined explicitly: any `FailureConnection` wins, otherwise the first recorded failure wins,
  otherwise the result is derived from the Sapling root list as before.

This also removes the transitional Ironwood-only blanket failure tolerance tracked in #2061, since
Ironwood failures are now handled the same way as Sapling/Orchard failures.

Adds seven new `CompactBlockProcessorTest` tests covering: unknown-pool tolerance without retry
(all three failure shapes), a Sapling UNIMPLEMENTED surfacing as a genuine failure, an unmasked
genuine Orchard failure, a transient-then-success Sapling fetch, empty Sapling roots yielding
`Linear`, all-attempts-unavailable yielding `FailureConnection`, and connection-failure precedence
over other failures.

Closes #2058
Closes #2061

<!-- Write any additional comments here when opening the pull request -->

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [ ] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [README.md](../blob/main/README.md), [Architecture.md](../blob/main/docs/Architecture.md), etc.)
- [ ] **Run the demo app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [README.md](../blob/main/README.md), [Architecture.md](/blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the demo app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the SDK, some aspects require manual testing. If you had to manually test 
something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the demo app to look for build failures or crashes, humans running the demo app are 
more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

