### PR TITLE
[MOB-1717] Decouple submit-plan retention and readback from v_transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Resubmission no longer permanently drops a pending submit plan for a wallet-created transaction
+  missing from the derived history view: the wallet store is consulted before pruning - the plan
+  is kept while the transaction exists and is unexpired (or expiry-disabled), and kept when the
+  store read is inconclusive (MOB-1717).
+- A transaction whose raw bytes cannot be read during resubmission is skipped and retried next
+  sync cycle instead of aborting the sync pass with `TransactionNotFoundException` (MOB-1717).
+- Slipstream's post-create transaction readback reads the `transactions` base table instead of
+  `v_transactions`, so sending/shielding no longer fails when the history view has not projected
+  the newly created transaction (MOB-1717).
+
 ## [3.0.2] - 2026-08-13
 
 ### Fixed

--- a/backend-lib/src/main/rust/slipstream/host_read.rs
+++ b/backend-lib/src/main/rust/slipstream/host_read.rs
@@ -650,12 +650,18 @@ pub extern "C" fn Java_com_zodl_slipstream_SlipstreamNative_getTransactionRaw<'l
         let txid_bytes = env.convert_byte_array(&txid)?;
         let conn = read_query::open_read_only(&db_path)?;
 
-        // `v_transactions` is the public, versioned query surface (like every other read in this
-        // module) — never the wallet-internal `transactions` base table. The view has one row per
-        // involved account; `raw`/`expiry_height` are identical across them, so take the first.
+        // Sanctioned exception to this module's usual view-only reads: every other export here
+        // goes through `v_transactions`/`v_tx_outputs`, but created-transaction readback must not
+        // depend on the derived history view, because `v_transactions` is rooted in
+        // received-output relations and may not yet contain a wallet-created transaction that
+        // hasn't been mined or matched an output (MOB-1703 on iOS, MOB-1717 here). Reading
+        // `transactions` directly is safe because we only ever ask for a single txid we ourselves
+        // just created. `COALESCE` keeps the Kotlin `expiryHeight == 0L -> null` mapping intact
+        // for a NULL `expiry_height`, and `raw IS NOT NULL` preserves the "null row = not stored"
+        // contract.
         let found: Option<(Vec<u8>, i64)> = conn
             .query_row(
-                "SELECT raw, expiry_height FROM v_transactions WHERE txid = ? LIMIT 1",
+                "SELECT raw, COALESCE(expiry_height, 0) FROM transactions WHERE txid = ? AND raw IS NOT NULL LIMIT 1",
                 rusqlite::params![txid_bytes],
                 |row| Ok((row.get(0)?, row.get(1)?)),
             )

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessor.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessor.kt
@@ -27,7 +27,6 @@ import cash.z.ecc.android.sdk.exception.CompactBlockProcessorException.Mismatche
 import cash.z.ecc.android.sdk.exception.CompactBlockProcessorException.MismatchedNetwork
 import cash.z.ecc.android.sdk.exception.InitializeException
 import cash.z.ecc.android.sdk.exception.LightWalletException
-import cash.z.ecc.android.sdk.exception.TransactionEncoderException
 import cash.z.ecc.android.sdk.ext.ZcashSdk.MAX_BACKOFF_INTERVAL
 import cash.z.ecc.android.sdk.ext.ZcashSdk.POLL_INTERVAL
 import cash.z.ecc.android.sdk.ext.ZcashSdk.POLL_INTERVAL_SHORT
@@ -47,6 +46,7 @@ import cash.z.ecc.android.sdk.internal.metrics.TraceScope
 import cash.z.ecc.android.sdk.internal.metrics.withTraceScope
 import cash.z.ecc.android.sdk.internal.model.BlockBatch
 import cash.z.ecc.android.sdk.internal.model.DbTransactionOverview
+import cash.z.ecc.android.sdk.internal.model.EncodedTransaction
 import cash.z.ecc.android.sdk.internal.model.JniBlockMeta
 import cash.z.ecc.android.sdk.internal.model.OutputStatusFilter
 import cash.z.ecc.android.sdk.internal.model.RecoveryProgress
@@ -2751,15 +2751,17 @@ class CompactBlockProcessor internal constructor(
         } ?: lowerBoundHeight
 
     /**
-     * This function resubmits the unmined sent transactions that are still within the expiry window. It can produce
-     * [TransactionEncoderException.TransactionNotFoundException] in case the transaction in not found in the database,
-     * but networking issues are not reported, it is retried in the next sync cycle instead.
+     * This function resubmits the unmined sent transactions that are still within the expiry window. A transaction
+     * whose raw bytes cannot be read from the wallet store is skipped and retried in the next sync cycle instead of
+     * aborting this pass; networking issues are likewise not reported and are retried in the next sync cycle.
+     *
+     * Candidate discovery stays view-driven: a wallet-created transaction that hasn't yet been projected into the
+     * derived history view is not synthesized as a resubmission candidate here. Its submit plan is merely kept
+     * around (see [findTransactionsEligibleForResubmission]) until the transaction becomes view-visible or the app
+     * retries via [cash.z.ecc.android.sdk.Broadcaster].
      *
      * @param blockHeight The block height to which transactions should be compared (usually the current chain tip)
-     *
-     * @throws TransactionEncoderException.TransactionNotFoundException in case the encoded transaction is not found
      */
-    @Throws(TransactionEncoderException.TransactionNotFoundException::class)
     private suspend fun resubmitUnminedTransactions(blockHeight: BlockHeight?) {
         // Run the check only in case we have already obtained the current chain tip
         if (blockHeight == null) {
@@ -2770,61 +2772,70 @@ class CompactBlockProcessor internal constructor(
         Twig.debug { "Trx resubmission: ${list.size}, ${list.joinToString(separator = ", ") { it.txIdString() }}" }
 
         if (list.isNotEmpty()) {
-            list.forEach { transaction ->
-                val submitPlan = pendingSubmitPlanStore.getSubmitPlan(transaction.rawId)
-                if (submitPlan == PendingSubmitPlanStore.StoredSubmitPlan.AwaitingPlan) {
-                    Twig.debug {
-                        "Trx resubmission: Skipping ${transaction.txIdString()} until a submit plan is registered"
-                    }
-                    return@forEach
-                }
-
-                val trxForResubmission =
-                    repository.findEncodedTransactionByTxId(transaction.rawId)
-                        ?: throw TransactionEncoderException.TransactionNotFoundException(transaction.rawId)
-
-                Twig.debug { "Trx resubmission: Found: ${trxForResubmission.txIdString()}" }
-
-                retryUpToAndContinue(TRANSACTION_RESUBMIT_RETRIES) {
-                    val response =
-                        when (submitPlan) {
-                            null -> {
-                                txManager.submit(trxForResubmission)
-                            }
-
-                            is PendingSubmitPlanStore.StoredSubmitPlan.Ready -> {
-                                submitPlanExecutor.submit(
-                                    trxForResubmission.toCreatedTransaction(),
-                                    submitPlan.submitPlan
-                                )
-                            }
-
-                            PendingSubmitPlanStore.StoredSubmitPlan.AwaitingPlan -> {
-                                TransactionSubmitResult.NotAttempted(transaction.rawId)
-                            }
-                        }
-
-                    when (response) {
-                        is TransactionSubmitResult.Success -> {
-                            Twig.info { "Trx resubmission success: ${response.txIdString()}" }
-                        }
-
-                        is TransactionSubmitResult.Failure -> {
-                            Twig.error { "Trx resubmission failure: ${response.description}" }
-                            throw LightWalletException.TransactionSubmitException(
-                                response.code,
-                                response.description,
-                            )
-                        }
-
-                        is TransactionSubmitResult.NotAttempted -> {
-                            Twig.warn { "Trx resubmission not attempted: ${response.txIdString()}" }
-                        }
-                    }
-                }
-            }
+            list.forEach { transaction -> resubmitTransaction(transaction) }
         } else {
             Twig.debug { "Trx resubmission: No trx for resubmission found" }
+        }
+    }
+
+    private suspend fun resubmitTransaction(transaction: DbTransactionOverview) {
+        val submitPlan = pendingSubmitPlanStore.getSubmitPlan(transaction.rawId)
+        if (submitPlan == PendingSubmitPlanStore.StoredSubmitPlan.AwaitingPlan) {
+            Twig.debug {
+                "Trx resubmission: Skipping ${transaction.txIdString()} until a submit plan is registered"
+            }
+            return
+        }
+
+        val trxForResubmission =
+            runCatching { repository.findEncodedTransactionByTxId(transaction.rawId) }
+                .getOrNull()
+                ?: run {
+                    Twig.warn {
+                        "Trx resubmission: Unable to read ${transaction.txIdString()} from the wallet " +
+                            "store; it will be retried next sync cycle"
+                    }
+                    return
+                }
+
+        Twig.debug { "Trx resubmission: Found: ${trxForResubmission.txIdString()}" }
+
+        retryUpToAndContinue(TRANSACTION_RESUBMIT_RETRIES) {
+            val response =
+                when (submitPlan) {
+                    null -> {
+                        txManager.submit(trxForResubmission)
+                    }
+
+                    is PendingSubmitPlanStore.StoredSubmitPlan.Ready -> {
+                        submitPlanExecutor.submit(
+                            trxForResubmission.toCreatedTransaction(),
+                            submitPlan.submitPlan
+                        )
+                    }
+
+                    PendingSubmitPlanStore.StoredSubmitPlan.AwaitingPlan -> {
+                        TransactionSubmitResult.NotAttempted(transaction.rawId)
+                    }
+                }
+
+            when (response) {
+                is TransactionSubmitResult.Success -> {
+                    Twig.info { "Trx resubmission success: ${response.txIdString()}" }
+                }
+
+                is TransactionSubmitResult.Failure -> {
+                    Twig.error { "Trx resubmission failure: ${response.description}" }
+                    throw LightWalletException.TransactionSubmitException(
+                        response.code,
+                        response.description,
+                    )
+                }
+
+                is TransactionSubmitResult.NotAttempted -> {
+                    Twig.warn { "Trx resubmission not attempted: ${response.txIdString()}" }
+                }
+            }
         }
     }
 
@@ -2835,8 +2846,41 @@ class CompactBlockProcessor internal constructor(
             loadTransactions = {
                 repository.findUnminedTransactionsWithinExpiry(blockHeight)
             },
-            transactionId = { it.rawId }
+            transactionId = { it.rawId },
+            retainMissing = { txId -> shouldRetainViewInvisiblePlan(txId, blockHeight) }
         )
+
+    /**
+     * Decides whether a submit plan should survive pruning for a transaction id that the derived history view
+     * did not return as a resubmission candidate. This does not synthesize the transaction as a candidate for
+     * resubmission here; it only protects the plan from being discarded before the transaction becomes
+     * view-visible, mirroring the case of a wallet-created transaction that hasn't been projected into the view
+     * yet (see [resubmitUnminedTransactions]).
+     */
+    private suspend fun shouldRetainViewInvisiblePlan(
+        txId: FirstClassByteArray,
+        blockHeight: BlockHeight
+    ): Boolean {
+        val txIdString = txId.byteArray.toHexReversed()
+        return runCatching { repository.findEncodedTransactionByTxId(txId) }
+            .onFailure {
+                Twig.warn { "Trx resubmission pruning: Wallet store read failed for $txIdString, keeping plan" }
+            }.fold(
+                onSuccess = { encodedTransaction -> encodedTransaction.shouldRetainPlan(txIdString, blockHeight) },
+                onFailure = { true }
+            )
+    }
+
+    private fun EncodedTransaction?.shouldRetainPlan(
+        txIdString: String,
+        blockHeight: BlockHeight
+    ): Boolean {
+        if (this == null) {
+            Twig.debug { "Trx resubmission pruning: $txIdString not found in wallet store, pruning plan" }
+        }
+        val expiryHeight = this?.expiryHeight
+        return this != null && (expiryHeight == null || expiryHeight.value == 0L || expiryHeight > blockHeight)
+    }
 
     suspend fun getUtxoCacheBalance(address: String): Zatoshi = backend.getDownloadedUtxoBalance(address)
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/ext/BlockExt.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/ext/BlockExt.kt
@@ -2,6 +2,7 @@
 
 package cash.z.ecc.android.sdk.internal.ext
 
+import cash.z.ecc.android.sdk.ext.fromHex
 import java.util.Locale
 
 internal fun ByteArray.toHexReversed(): String {
@@ -12,3 +13,5 @@ internal fun ByteArray.toHexReversed(): String {
     }
     return sb.toString()
 }
+
+internal fun String.fromHexReversed(): ByteArray = fromHex().reversedArray()

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/PendingSubmitPlanStore.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/PendingSubmitPlanStore.kt
@@ -1,5 +1,6 @@
 package cash.z.ecc.android.sdk.internal.transaction
 
+import cash.z.ecc.android.sdk.internal.ext.fromHexReversed
 import cash.z.ecc.android.sdk.internal.ext.toHexReversed
 import cash.z.ecc.android.sdk.internal.storage.preference.api.PreferenceProvider
 import cash.z.ecc.android.sdk.internal.storage.preference.keys.EncryptedPreferenceKeys
@@ -75,14 +76,21 @@ internal class PendingSubmitPlanStore(
             }
         }
 
+    /**
+     * @param retainMissing Consulted for a stored plan whose transaction id was not among the loaded
+     * [transactionId]s. Returning `true` keeps the plan; the default `false` preserves the previous
+     * prune-everything-missing behavior. Runs under this store's mutex and MUST NOT call back into
+     * [PendingSubmitPlanStore] (deadlock).
+     */
     suspend fun <T> loadTransactionsAndRetainSubmitPlans(
         loadTransactions: suspend () -> List<T>,
-        transactionId: (T) -> FirstClassByteArray
+        transactionId: (T) -> FirstClassByteArray,
+        retainMissing: suspend (FirstClassByteArray) -> Boolean = { false }
     ): List<T> =
         mutex.withLock {
             loadFromPreferencesIfNeeded()
             loadTransactions().also { transactions ->
-                retainLoadedPlansFor(transactions.map(transactionId))
+                retainLoadedPlansFor(transactions.map(transactionId), retainMissing)
             }
         }
 
@@ -124,14 +132,30 @@ internal class PendingSubmitPlanStore(
         )
     }
 
-    private suspend fun retainLoadedPlansFor(txIds: List<FirstClassByteArray>) {
+    private suspend fun retainLoadedPlansFor(
+        txIds: List<FirstClassByteArray>,
+        retainMissing: suspend (FirstClassByteArray) -> Boolean
+    ) {
         val retainedTransactionIds = txIds.map { it.toStableKey() }.toSet()
-        val removed =
-            plansByTransactionId.keys.removeAll { transactionId ->
-                (namespacePrefix.isBlank() || transactionId.startsWith(namespacePrefix)) &&
-                    transactionId !in retainedTransactionIds
+        val keysToRemove = mutableListOf<String>()
+        for (transactionId in plansByTransactionId.keys) {
+            val isNamespaced = namespacePrefix.isBlank() || transactionId.startsWith(namespacePrefix)
+            if (!isNamespaced || transactionId in retainedTransactionIds) {
+                continue
             }
-        if (removed) {
+            val shouldRetain =
+                runCatching {
+                    FirstClassByteArray(transactionId.removePrefix(namespacePrefix).fromHexReversed())
+                }.fold(
+                    onSuccess = { txId -> retainMissing(txId) },
+                    onFailure = { true }
+                )
+            if (!shouldRetain) {
+                keysToRemove.add(transactionId)
+            }
+        }
+        if (keysToRemove.isNotEmpty()) {
+            plansByTransactionId.keys.removeAll(keysToRemove)
             saveToPreferences()
         }
     }

--- a/sdk-lib/src/main/java/com/zodl/slipstream/internal/db/SlipstreamTransactionReader.kt
+++ b/sdk-lib/src/main/java/com/zodl/slipstream/internal/db/SlipstreamTransactionReader.kt
@@ -54,7 +54,11 @@ internal class SlipstreamTransactionReader(
             }
         }
 
-    /** T8's "T6 SQL: SELECT raw FROM transactions WHERE txid = ?" - post-`create` raw-bytes read-back. */
+    /**
+     * T8's post-`create` raw-bytes read-back (T6). Reads the `transactions` base table directly
+     * rather than the `v_transactions` history view, because a wallet-created transaction may not
+     * yet be projected into that view (MOB-1717).
+     */
     suspend fun readRawTransaction(txId: FirstClassByteArray): FirstClassByteArray =
         withContext(Dispatchers.IO) {
             val row = SlipstreamNative.getTransactionRaw(dbFile.absolutePath, txId.byteArray)

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessorTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/block/processor/CompactBlockProcessorTest.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.runBlocking
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.Mockito.`when`
 import kotlin.reflect.full.callSuspend
 import kotlin.reflect.full.declaredMemberFunctions
@@ -35,6 +36,7 @@ import kotlin.reflect.jvm.isAccessible
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class CompactBlockProcessorTest {
@@ -184,6 +186,252 @@ class CompactBlockProcessorTest {
         }
     }
 
+    @Test
+    fun resubmission_pruning_keeps_view_invisible_unexpired_wallet_store_transaction() {
+        runBlocking {
+            val transaction = transactionOverview(1)
+            val endpoint = LightWalletEndpoint("submit.z.cash", 443, true)
+            val repository = mock(DerivedDataRepository::class.java)
+            val txManager = mock(OutboundTransactionManager::class.java)
+            val pendingSubmitPlanStore = PendingSubmitPlanStore()
+            val processor =
+                processor(
+                    repository = repository,
+                    txManager = txManager,
+                    pendingSubmitPlanStore = pendingSubmitPlanStore
+                )
+
+            pendingSubmitPlanStore.storeSubmitPlan(
+                CreatedTransaction(
+                    txId = transaction.rawId,
+                    raw = FirstClassByteArray(byteArrayOf(0x01)),
+                    expiryHeight = transaction.expiryHeight
+                ),
+                TransactionSubmitPlan(listOf(endpoint))
+            )
+            `when`(repository.findUnminedTransactionsWithinExpiry(BlockHeight(100))).thenReturn(emptyList())
+            `when`(repository.findEncodedTransactionByTxId(transaction.rawId)).thenReturn(
+                encodedTransaction(transaction.rawId, expiryHeight = BlockHeight(1000))
+            )
+
+            processor.resubmitUnminedTransactionsForTest(BlockHeight(100))
+
+            assertEquals(
+                PendingSubmitPlanStore.StoredSubmitPlan.Ready(TransactionSubmitPlan(listOf(endpoint))),
+                pendingSubmitPlanStore.getSubmitPlan(transaction.rawId)
+            )
+            verifyNoInteractions(txManager)
+        }
+    }
+
+    @Test
+    fun resubmission_pruning_removes_view_invisible_expired_wallet_store_transaction() {
+        runBlocking {
+            val transaction = transactionOverview(1)
+            val endpoint = LightWalletEndpoint("submit.z.cash", 443, true)
+            val repository = mock(DerivedDataRepository::class.java)
+            val txManager = mock(OutboundTransactionManager::class.java)
+            val pendingSubmitPlanStore = PendingSubmitPlanStore()
+            val processor =
+                processor(
+                    repository = repository,
+                    txManager = txManager,
+                    pendingSubmitPlanStore = pendingSubmitPlanStore
+                )
+
+            pendingSubmitPlanStore.storeSubmitPlan(
+                CreatedTransaction(
+                    txId = transaction.rawId,
+                    raw = FirstClassByteArray(byteArrayOf(0x01)),
+                    expiryHeight = transaction.expiryHeight
+                ),
+                TransactionSubmitPlan(listOf(endpoint))
+            )
+            `when`(repository.findUnminedTransactionsWithinExpiry(BlockHeight(100))).thenReturn(emptyList())
+            `when`(repository.findEncodedTransactionByTxId(transaction.rawId)).thenReturn(
+                encodedTransaction(transaction.rawId, expiryHeight = BlockHeight(50))
+            )
+
+            processor.resubmitUnminedTransactionsForTest(BlockHeight(100))
+
+            assertNull(pendingSubmitPlanStore.getSubmitPlan(transaction.rawId))
+        }
+    }
+
+    @Test
+    fun resubmission_pruning_keeps_plan_when_wallet_store_read_fails() {
+        runBlocking {
+            val transaction = transactionOverview(1)
+            val endpoint = LightWalletEndpoint("submit.z.cash", 443, true)
+            val repository = mock(DerivedDataRepository::class.java)
+            val txManager = mock(OutboundTransactionManager::class.java)
+            val pendingSubmitPlanStore = PendingSubmitPlanStore()
+            val processor =
+                processor(
+                    repository = repository,
+                    txManager = txManager,
+                    pendingSubmitPlanStore = pendingSubmitPlanStore
+                )
+
+            pendingSubmitPlanStore.storeSubmitPlan(
+                CreatedTransaction(
+                    txId = transaction.rawId,
+                    raw = FirstClassByteArray(byteArrayOf(0x01)),
+                    expiryHeight = transaction.expiryHeight
+                ),
+                TransactionSubmitPlan(listOf(endpoint))
+            )
+            `when`(repository.findUnminedTransactionsWithinExpiry(BlockHeight(100))).thenReturn(emptyList())
+            `when`(repository.findEncodedTransactionByTxId(transaction.rawId)).thenThrow(
+                RuntimeException("wallet store unavailable")
+            )
+
+            processor.resubmitUnminedTransactionsForTest(BlockHeight(100))
+
+            assertEquals(
+                PendingSubmitPlanStore.StoredSubmitPlan.Ready(TransactionSubmitPlan(listOf(endpoint))),
+                pendingSubmitPlanStore.getSubmitPlan(transaction.rawId)
+            )
+        }
+    }
+
+    @Test
+    fun resubmission_pruning_removes_plan_for_transaction_absent_from_wallet_store() {
+        runBlocking {
+            val transaction = transactionOverview(1)
+            val endpoint = LightWalletEndpoint("submit.z.cash", 443, true)
+            val repository = mock(DerivedDataRepository::class.java)
+            val txManager = mock(OutboundTransactionManager::class.java)
+            val pendingSubmitPlanStore = PendingSubmitPlanStore()
+            val processor =
+                processor(
+                    repository = repository,
+                    txManager = txManager,
+                    pendingSubmitPlanStore = pendingSubmitPlanStore
+                )
+
+            pendingSubmitPlanStore.storeSubmitPlan(
+                CreatedTransaction(
+                    txId = transaction.rawId,
+                    raw = FirstClassByteArray(byteArrayOf(0x01)),
+                    expiryHeight = transaction.expiryHeight
+                ),
+                TransactionSubmitPlan(listOf(endpoint))
+            )
+            `when`(repository.findUnminedTransactionsWithinExpiry(BlockHeight(100))).thenReturn(emptyList())
+            `when`(repository.findEncodedTransactionByTxId(transaction.rawId)).thenReturn(null)
+
+            processor.resubmitUnminedTransactionsForTest(BlockHeight(100))
+
+            assertNull(pendingSubmitPlanStore.getSubmitPlan(transaction.rawId))
+        }
+    }
+
+    @Test
+    fun resubmission_pruning_keeps_plan_when_expiry_is_disabled() {
+        runBlocking {
+            val transaction = transactionOverview(1)
+            val endpoint = LightWalletEndpoint("submit.z.cash", 443, true)
+            val repository = mock(DerivedDataRepository::class.java)
+            val txManager = mock(OutboundTransactionManager::class.java)
+            val pendingSubmitPlanStore = PendingSubmitPlanStore()
+            val processor =
+                processor(
+                    repository = repository,
+                    txManager = txManager,
+                    pendingSubmitPlanStore = pendingSubmitPlanStore
+                )
+
+            pendingSubmitPlanStore.storeSubmitPlan(
+                CreatedTransaction(
+                    txId = transaction.rawId,
+                    raw = FirstClassByteArray(byteArrayOf(0x01)),
+                    expiryHeight = transaction.expiryHeight
+                ),
+                TransactionSubmitPlan(listOf(endpoint))
+            )
+            `when`(repository.findUnminedTransactionsWithinExpiry(BlockHeight(100))).thenReturn(emptyList())
+            `when`(repository.findEncodedTransactionByTxId(transaction.rawId)).thenReturn(
+                encodedTransaction(transaction.rawId, expiryHeight = null)
+            )
+
+            processor.resubmitUnminedTransactionsForTest(BlockHeight(100))
+
+            assertEquals(
+                PendingSubmitPlanStore.StoredSubmitPlan.Ready(TransactionSubmitPlan(listOf(endpoint))),
+                pendingSubmitPlanStore.getSubmitPlan(transaction.rawId)
+            )
+        }
+    }
+
+    @Test
+    fun resubmission_skips_transaction_whose_bytes_cannot_be_read() {
+        runBlocking {
+            val unreadableTransaction = transactionOverview(1)
+            val resubmittableTransaction = transactionOverview(2)
+            val repository = mock(DerivedDataRepository::class.java)
+            val txManager = mock(OutboundTransactionManager::class.java)
+            val resubmittableEncodedTransaction = encodedTransaction(resubmittableTransaction.rawId)
+            val pendingSubmitPlanStore = PendingSubmitPlanStore()
+            val processor =
+                processor(
+                    repository = repository,
+                    txManager = txManager,
+                    pendingSubmitPlanStore = pendingSubmitPlanStore
+                )
+
+            `when`(repository.findUnminedTransactionsWithinExpiry(BlockHeight(100))).thenReturn(
+                listOf(unreadableTransaction, resubmittableTransaction)
+            )
+            `when`(repository.findEncodedTransactionByTxId(unreadableTransaction.rawId)).thenReturn(null)
+            `when`(repository.findEncodedTransactionByTxId(resubmittableTransaction.rawId)).thenReturn(
+                resubmittableEncodedTransaction
+            )
+            `when`(txManager.submit(resubmittableEncodedTransaction)).thenReturn(
+                TransactionSubmitResult.Success(resubmittableTransaction.rawId)
+            )
+
+            processor.resubmitUnminedTransactionsForTest(BlockHeight(100))
+
+            verify(txManager).submit(resubmittableEncodedTransaction)
+        }
+    }
+
+    @Test
+    fun resubmission_skips_transaction_when_wallet_store_read_throws() {
+        runBlocking {
+            val unreadableTransaction = transactionOverview(1)
+            val resubmittableTransaction = transactionOverview(2)
+            val repository = mock(DerivedDataRepository::class.java)
+            val txManager = mock(OutboundTransactionManager::class.java)
+            val resubmittableEncodedTransaction = encodedTransaction(resubmittableTransaction.rawId)
+            val pendingSubmitPlanStore = PendingSubmitPlanStore()
+            val processor =
+                processor(
+                    repository = repository,
+                    txManager = txManager,
+                    pendingSubmitPlanStore = pendingSubmitPlanStore
+                )
+
+            `when`(repository.findUnminedTransactionsWithinExpiry(BlockHeight(100))).thenReturn(
+                listOf(unreadableTransaction, resubmittableTransaction)
+            )
+            `when`(repository.findEncodedTransactionByTxId(unreadableTransaction.rawId)).thenThrow(
+                RuntimeException("wallet store unavailable")
+            )
+            `when`(repository.findEncodedTransactionByTxId(resubmittableTransaction.rawId)).thenReturn(
+                resubmittableEncodedTransaction
+            )
+            `when`(txManager.submit(resubmittableEncodedTransaction)).thenReturn(
+                TransactionSubmitResult.Success(resubmittableTransaction.rawId)
+            )
+
+            processor.resubmitUnminedTransactionsForTest(BlockHeight(100))
+
+            verify(txManager).submit(resubmittableEncodedTransaction)
+        }
+    }
+
     private suspend fun CompactBlockProcessor.resubmitUnminedTransactionsForTest(blockHeight: BlockHeight) {
         val function =
             CompactBlockProcessor::class
@@ -259,11 +507,13 @@ class CompactBlockProcessorTest {
                 zip318Kind = Zip318Kind.NOT_CLASSIFIED
             )
 
-        private fun encodedTransaction(txId: FirstClassByteArray) =
-            EncodedTransaction(
-                txId = txId,
-                raw = FirstClassByteArray(byteArrayOf(0x01, 0x02)),
-                expiryHeight = BlockHeight(1000)
-            )
+        private fun encodedTransaction(
+            txId: FirstClassByteArray,
+            expiryHeight: BlockHeight? = BlockHeight(1000)
+        ) = EncodedTransaction(
+            txId = txId,
+            raw = FirstClassByteArray(byteArrayOf(0x01, 0x02)),
+            expiryHeight = expiryHeight
+        )
     }
 }

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/transaction/PendingSubmitPlanStoreTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/transaction/PendingSubmitPlanStoreTest.kt
@@ -1,5 +1,6 @@
 package cash.z.ecc.android.sdk.internal.transaction
 
+import cash.z.ecc.android.sdk.internal.ext.fromHexReversed
 import cash.z.ecc.android.sdk.internal.ext.toHexReversed
 import cash.z.ecc.android.sdk.internal.storage.preference.api.PreferenceProvider
 import cash.z.ecc.android.sdk.internal.storage.preference.keys.EncryptedPreferenceKeys
@@ -11,6 +12,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
+import kotlin.random.Random
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
@@ -105,6 +108,109 @@ class PendingSubmitPlanStoreTest {
             )
             assertNull(secondStore.getSubmitPlan(prunedTransaction.txId))
         }
+
+    @Test
+    fun default_retain_missing_prunes_missing_plan() =
+        runBlocking {
+            val preferenceProvider = FakePreferenceProvider()
+            val prunedTransaction = createdTransaction(1)
+            val store = PendingSubmitPlanStore(preferenceProvider)
+            store.storeSubmitPlan(prunedTransaction, TransactionSubmitPlan(listOf(endpoint("a.z.cash"))))
+
+            store.loadTransactionsAndRetainSubmitPlans(
+                loadTransactions = { emptyList<FirstClassByteArray>() },
+                transactionId = { it }
+            )
+
+            assertNull(store.getSubmitPlan(prunedTransaction.txId))
+        }
+
+    @Test
+    fun retain_missing_returning_true_retains_plan_for_missing_transaction() =
+        runBlocking {
+            val preferenceProvider = FakePreferenceProvider()
+            val retainedTransaction = createdTransaction(1)
+            val store = PendingSubmitPlanStore(preferenceProvider)
+            store.storeSubmitPlan(retainedTransaction, TransactionSubmitPlan(listOf(endpoint("a.z.cash"))))
+
+            store.loadTransactionsAndRetainSubmitPlans(
+                loadTransactions = { emptyList<FirstClassByteArray>() },
+                transactionId = { it },
+                retainMissing = { true }
+            )
+
+            assertEquals(
+                PendingSubmitPlanStore.StoredSubmitPlan.Ready(TransactionSubmitPlan(listOf(endpoint("a.z.cash")))),
+                store.getSubmitPlan(retainedTransaction.txId)
+            )
+        }
+
+    @Test
+    fun retain_missing_callback_receives_original_txid_bytes_after_rehydration() =
+        runBlocking {
+            val preferenceProvider = FakePreferenceProvider()
+            val txId = FirstClassByteArray(byteArrayOf(0x01, 0x02, 0x03, 0xAB.toByte(), 0x00))
+            val transaction =
+                CreatedTransaction(
+                    txId = txId,
+                    raw = FirstClassByteArray(byteArrayOf(0x01)),
+                    expiryHeight = null
+                )
+            val firstStore = PendingSubmitPlanStore(preferenceProvider)
+            firstStore.storeSubmitPlan(transaction, TransactionSubmitPlan(listOf(endpoint("a.z.cash"))))
+
+            val secondStore = PendingSubmitPlanStore(preferenceProvider)
+            var receivedTxId: FirstClassByteArray? = null
+            secondStore.loadTransactionsAndRetainSubmitPlans(
+                loadTransactions = { emptyList<FirstClassByteArray>() },
+                transactionId = { it },
+                retainMissing = { candidateTxId ->
+                    receivedTxId = candidateTxId
+                    true
+                }
+            )
+
+            assertContentEquals(txId.byteArray, receivedTxId?.byteArray)
+        }
+
+    @Test
+    fun namespaced_store_only_consults_retain_missing_for_its_own_keys() =
+        runBlocking {
+            val preferenceProvider = FakePreferenceProvider()
+            val ownTransaction = createdTransaction(1)
+            val otherNamespaceTransaction = createdTransaction(2)
+            val ownStore = PendingSubmitPlanStore(preferenceProvider, namespace = "own")
+            val otherStore = PendingSubmitPlanStore(preferenceProvider, namespace = "other")
+
+            ownStore.storeSubmitPlan(ownTransaction, TransactionSubmitPlan(listOf(endpoint("a.z.cash"))))
+            otherStore.storeSubmitPlan(otherNamespaceTransaction, TransactionSubmitPlan(listOf(endpoint("b.z.cash"))))
+
+            val consultedTxIds = mutableListOf<FirstClassByteArray>()
+            val reloadedOwnStore = PendingSubmitPlanStore(preferenceProvider, namespace = "own")
+            reloadedOwnStore.loadTransactionsAndRetainSubmitPlans(
+                loadTransactions = { emptyList<FirstClassByteArray>() },
+                transactionId = { it },
+                retainMissing = { txId ->
+                    consultedTxIds += txId
+                    true
+                }
+            )
+
+            assertEquals(listOf(ownTransaction.txId), consultedTxIds)
+
+            val otherStoreReloaded = PendingSubmitPlanStore(preferenceProvider, namespace = "other")
+            assertEquals(
+                PendingSubmitPlanStore.StoredSubmitPlan.Ready(TransactionSubmitPlan(listOf(endpoint("b.z.cash")))),
+                otherStoreReloaded.getSubmitPlan(otherNamespaceTransaction.txId)
+            )
+        }
+
+    @Test
+    fun to_hex_reversed_and_from_hex_reversed_round_trip() {
+        val bytes = Random(42).nextBytes(37)
+
+        assertContentEquals(bytes, bytes.toHexReversed().fromHexReversed())
+    }
 
     private class FakePreferenceProvider : PreferenceProvider {
         private val values = mutableMapOf<String, String?>()


### PR DESCRIPTION
Android counterpart of the iOS MOB-1703 fix (zcash/zcash-swift-wallet-sdk#1969 "Fix created transaction readback for broadcast", shipped in iOS 3.9.4). The derived `v_transactions` history view is rooted in received-output(-spend) relations, so a wallet-created transaction can exist in the wallet store (with raw bytes) while being absent from the view. Android's classic-stack create/PCZT readback already reads the `transactions` base table and was never affected; the Android exposure was in resubmission and in the Slipstream create path:

- **Resubmission plan retention**: `PendingSubmitPlanStore` used to delete every persisted submit plan whose txid the `v_transactions` resubmission scan did not return — a stored, unmined, unexpired but view-invisible transaction permanently lost its endpoint retry state on the next sync tick. The wallet store is now consulted before pruning: the plan is kept while the transaction exists and is unexpired (or expiry-disabled), kept when the store read is inconclusive, and dropped only when the transaction is absent or expired. View-invisible transactions are not synthesized as resubmission candidates (mirrors iOS semantics — the plan merely survives until the transaction becomes view-visible or the app retries via `Broadcaster`).
- **Non-fatal resubmit readback**: a transaction whose raw bytes cannot be read during resubmission is now logged and skipped (retried next sync cycle) instead of aborting the whole pass with an uncaught `TransactionEncoderException.TransactionNotFoundException`.
- **Slipstream create-path readback**: `getTransactionRaw` (`host_read.rs`) now reads `SELECT raw, COALESCE(expiry_height, 0) FROM transactions WHERE txid = ? AND raw IS NOT NULL` instead of querying `v_transactions` — the literal iOS failure mechanism, which made a send/shield fail with `IllegalStateException` after the transaction was created and stored.

Covered by 12 new unit tests (plan pruning keep/drop/inconclusive/expiry-disabled matrix + skip-on-unreadable-bytes in `CompactBlockProcessorTest`; retention-callback contract, namespace isolation, and hex round-trip in `PendingSubmitPlanStoreTest`). Verified: `make check-rust` / `check-format-rust` / `lint-rust` / `test-rust`, full NDK cross-compile (`make build-rust-android`), ktlint + detekt, `Cargo.lock` untouched (no dependency changes, no `[patch.crates-io]`).

Linear: [MOB-1717](https://linear.app/zodl/issue/MOB-1717/resubmission-drops-submit-plans-and-slipstream-readback-depends-on-v) (related: [MOB-1703](https://linear.app/zodl/issue/MOB-1703/error-when-sending-or-shielding-on-ios-v39), the iOS origin)

Follow-up (main only, deferred): iOS-parity `Backend.getTransaction` JNI export backed by `WalletRead::get_transaction`, rerouting the classic encoder readbacks through the Rust-owned DB connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [ ] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [README.md](../blob/main/README.md), [Architecture.md](../blob/main/docs/Architecture.md), etc.)
- [ ] **Run the demo app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [README.md](../blob/main/README.md), [Architecture.md](/blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the demo app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the SDK, some aspects require manual testing. If you had to manually test 
something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the demo app to look for build failures or crashes, humans running the demo app are 
more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._