### PR TITLE
MOB-1654: Remove Synchronizer.refreshUtxos direct-mode UTXO fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,13 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   318 parameters. A testnet wallet that committed a migration before this change
   has its transfers anchored to the old grid; those runs must be restarted.
 
+### Removed
+- `Synchronizer.refreshUtxos(account, since)` is removed. It fetched all of an account's
+  transparent receivers over a direct (non-Tor) connection, linking the caller's IP address
+  to the wallet's t-addresses regardless of the Tor setting. UTXOs are refreshed
+  automatically during sync; use `Synchronizer.fetchUtxosByAddress`, which uses an isolated
+  Tor circuit, or `Synchronizer.checkSingleUseTransparentAddress` instead.
+
 ### Fixed
 - The legacy `Synchronizer.createProposedTransactions` and `Synchronizer.createTransactionFromPczt`
   helpers now register transactions in `PendingSubmitPlanStore`. Before this change the legacy

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
@@ -1177,9 +1177,19 @@ class SdkSynchronizer private constructor(
         )
     }
 
-    override suspend fun refreshUtxos(
+    /**
+     * Downloads all UTXOs for the given account's addresses over a legacy direct (non-Tor)
+     * connection and stores any new ones in the database. Not part of the [Synchronizer] API;
+     * the remaining direct-connection paths are tracked by MOB-1652.
+     *
+     * @param account The Account, for which all addresses blocks will be downloaded.
+     * @param since The BlockHeight, from which blocks will be downloaded.
+     *
+     * @return the number of utxos that were downloaded and added to the UTXO table.
+     */
+    suspend fun refreshUtxos(
         account: Account,
-        since: BlockHeight
+        since: BlockHeight = network.saplingActivationHeight
     ): Int = processor.refreshUtxos(account, since)
 
     override suspend fun getTransparentBalance(tAddr: String): Zatoshi = processor.getUtxoCacheBalance(tAddr)

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
@@ -588,20 +588,8 @@ interface Synchronizer {
     suspend fun validateAddress(address: String): AddressType
 
     /**
-     * Download all UTXOs for the given account addresses and store any new ones in the database.
-     *
-     * @param account The Account, for which all addresses blocks will be downloaded.
-     * @param since The BlockHeight, from which blocks will be downloaded.
-     *
-     * @return the number of utxos that were downloaded and added to the UTXO table.
-     */
-    suspend fun refreshUtxos(
-        account: Account,
-        since: BlockHeight = network.saplingActivationHeight
-    ): Int?
-
-    /**
-     * Returns the balance that the wallet knows about. This should be called after [refreshUtxos].
+     * Returns the balance that the wallet knows about. UTXOs are refreshed automatically during
+     * sync; see [fetchUtxosByAddress] for on-demand per-address retrieval.
      */
     suspend fun getTransparentBalance(tAddr: String): Zatoshi
 

--- a/sdk-lib/src/main/java/com/zodl/slipstream/SlipstreamSynchronizer.kt
+++ b/sdk-lib/src/main/java/com/zodl/slipstream/SlipstreamSynchronizer.kt
@@ -1151,36 +1151,6 @@ class SlipstreamSynchronizer internal constructor(
         return spendService.getTransparentBalance(tAddr)
     }
 
-    override suspend fun refreshUtxos(
-        account: Account,
-        since: BlockHeight
-    ): Int? {
-        awaitReady()
-        return runCatchingCancellable {
-            var count = 0
-            val tAddresses = backend.listTransparentReceivers(account.accountUuid.value)
-            walletClient
-                .fetchUtxos(
-                    tAddresses = tAddresses,
-                    startHeight = BlockHeightUnsafe(since.value),
-                    serviceMode = ServiceMode.Direct
-                ).collect { response ->
-                    if (response is Response.Success) {
-                        val utxo = response.result
-                        backend.putUtxo(
-                            txId = utxo.txid,
-                            index = utxo.index,
-                            script = utxo.script,
-                            value = utxo.valueZat,
-                            height = utxo.height
-                        )
-                        count++
-                    }
-                }
-            count
-        }.getOrNull()
-    }
-
     /**
      * The `engine.start(ufvk = null, ...)` restart below is keyless (`FFI_JNI_CONTRACT.md` section
      * 3.5) - legal only because provisioning guarantees an account row already exists by the time


### PR DESCRIPTION
Closes gap 2 of [MOB-1654](https://linear.app/zodl/issue/MOB-1654/slipstream-residual-tor-gaps-one-shared-circuit-for-all-t-addresses): removes `Synchronizer.refreshUtxos(account, since)` from the public API.

The method fetched **all of an account's transparent receivers** over a direct (non-Tor) connection (`ServiceMode.Direct` hardcoded in `SlipstreamSynchronizer`), asserting the IP ↔ t-address linkage regardless of the user's Tor setting — the exact MOB-1652 leak, kept alive as a public entry point. Per the triage thread it was "a foot-gun waiting to happen"; removal was the agreed fix since:

- it has **zero production callers** in the SDK slipstream path and in Zashi;
- the Slipstream engine already refreshes UTXOs internally on every sync pass over isolated Tor circuits;
- Tor-correct public replacements exist: `fetchUtxosByAddress` (per-address `ServiceMode.UniqueTor`) and `checkSingleUseTransparentAddress`;
- "just switching the mode" is not possible: `CombinedWalletClientImpl.fetchUtxos` hard-rejects non-Direct modes and the bulk multi-address fetch has no Tor implementation.

`SdkSynchronizer.refreshUtxos` survives as a plain public method on the concrete class (no longer an interface override), so the legacy internal `refreshAllAccountsUtxos` path and the androidTest `TestWallet` fixtures keep compiling unchanged; that legacy direct path stays tracked by MOB-1652.

Gap 1 of MOB-1654 (one shared Tor circuit for all t-addresses inside the engine) is deliberately **not** addressed here — deferred until t-address rotation per triage; details in the Linear ticket.

Companion app PR (removes the now-dangling `MockSynchronizer` override): [zodl-inc/zodl-android#2426](https://github.com/zodl-inc/zodl-android/pull/2426) — already merged.

**Note for reviewers:** CI is red on this branch independently of this PR — `backend-lib/Cargo.toml` pins `slipstream-core` to rev `0da0c44d…` (came in with #2139), which no longer exists on `zodl-inc/slipstream`: that repo's `main` has since been rewritten to a fresh history in which the crate is renamed `zodl-slipstream` v0.1.1, so no rev on any live branch satisfies the current `[patch.crates-io]` entry and a plain re-pin cannot fix it (details in the comment below). This PR touches no Rust; Kotlin compile, unit tests, ktlint/detekt, and androidTest compilation were verified with the cargo tasks excluded.

<!-- Write any additional comments here when opening the pull request -->

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [ ] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [README.md](../blob/main/README.md), [Architecture.md](../blob/main/docs/Architecture.md), etc.)
- [ ] **Run the demo app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [README.md](../blob/main/README.md), [Architecture.md](/blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the demo app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the SDK, some aspects require manual testing. If you had to manually test 
something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the demo app to look for build failures or crashes, humans running the demo app are 
more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._
🤖 Generated with [Claude Code](https://claude.com/claude-code)

