### PR TITLE
Derive the governance PCZT branch id from the round, not the caller's network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,4 +104,4 @@ backup-dbs/
 
 # Design docs, implementation plans, and other working notes. These are
 # conversation artifacts rather than repository history.
-.plans/
+.plans

--- a/backend-lib/src/main/rust/voting/delegation.rs
+++ b/backend-lib/src/main/rust/voting/delegation.rs
@@ -164,15 +164,7 @@ fn build_governance_pczt_for_bundle(
     )
     .map_err(|e| anyhow!("DelegationKeys::with_voting_hotkey: {}", e))?;
 
-    // build_governance_pczt now validates the branch id against the round's
-    // own snapshot_height (see lwd::branch_id_for_height), so it must be
-    // resolved per round instead of the old hardcoded Nu6 constant.
-    let round_state = db
-        .get_round_state(round_id)
-        .map_err(|e| anyhow!("get_round_state: {}", e))?;
-    let consensus_branch_id =
-        voting::delegate::branch_id_for_height(db.network, round_state.snapshot_height)
-            .map_err(|e| anyhow!("branch_id_for_height: {}", e))?;
+    let consensus_branch_id = consensus_branch_id_for_round(db, round_id, db.network)?;
 
     let pczt = db
         .build_governance_pczt(
@@ -856,6 +848,40 @@ fn require_round_phase_not_after(
     Ok(())
 }
 
+/// Resolves the consensus branch id `build_governance_pczt` must be given for `round_id`.
+///
+/// Both inputs to the resolution come from the round itself: `zcash_voting` stores the network
+/// alongside the snapshot height when the round is initialized, and `get_round_state` returns
+/// both. Deriving the branch from `handle_network` instead would take a value the database
+/// already knows authoritatively from JNI caller input (`openVotingDbNative`'s `network_id`),
+/// which is what this function exists to avoid.
+///
+/// `handle_network` is still *checked* against the round, because a disagreement means the
+/// caller opened this database for the wrong network, so every key derived from that network
+/// (the voting hotkey, hence `DelegationKeys::network`) is wrong for this round. Upstream
+/// rejects that mismatch as well (`validate_network_matches_round`, consulted from
+/// `build_governance_pczt`), so today this only turns a downstream error into a local one; it is
+/// checked here so the invariant does not depend on a guarantee that lives in another crate.
+fn consensus_branch_id_for_round(
+    db: &VotingDb,
+    round_id: &str,
+    handle_network: voting::types::Network,
+) -> anyhow::Result<u32> {
+    let state = db
+        .get_round_state(round_id)
+        .map_err(|e| anyhow!("get_round_state: {}", e))?;
+    if state.network != handle_network {
+        return Err(anyhow!(
+            "voting DB was opened for network {:?}, but round {round_id} is stored for network {:?}",
+            handle_network,
+            state.network
+        ));
+    }
+
+    voting::delegate::branch_id_for_height(state.network, state.snapshot_height)
+        .map_err(|e| anyhow!("branch_id_for_height: {}", e))
+}
+
 fn verify_delegation_submission_sig(data: &DelegationSubmissionData) -> anyhow::Result<()> {
     let rk = fixed_bytes::<PROTOCOL_FIELD_BYTES>(data.rk.clone(), "rk")?;
     let sighash = fixed_bytes::<PROTOCOL_FIELD_BYTES>(data.sighash.clone(), "sighash")?;
@@ -1014,6 +1040,44 @@ mod tests {
         let mut bad_sighash = data.clone();
         bad_sighash.sighash[0] ^= 1;
         assert!(verify_delegation_submission_sig(&bad_sighash).is_err());
+    }
+
+    /// The branch must come from the network the ROUND was stored with, not from the network the
+    /// JNI caller opened the handle with. The two are distinguishable here: the test round's
+    /// snapshot height is inside Regtest's Ironwood range but far below any mainnet upgrade, so
+    /// resolving it against the wrong network yields a different branch id.
+    #[test]
+    fn consensus_branch_id_for_round_resolves_against_the_rounds_stored_network() {
+        let (db, round_id) = test_db_with_round();
+        let regtest = voting::types::Network::Regtest;
+
+        let branch_id = consensus_branch_id_for_round(&db, &round_id, regtest)
+            .expect("branch id for the round's own network");
+
+        let expected =
+            voting::delegate::branch_id_for_height(regtest, round_params().snapshot_height)
+                .expect("regtest branch id");
+        assert_eq!(branch_id, expected);
+
+        let if_caller_network_were_used = voting::delegate::branch_id_for_height(
+            voting::types::Network::Mainnet,
+            round_params().snapshot_height,
+        )
+        .expect("mainnet branch id");
+        assert_ne!(branch_id, if_caller_network_were_used);
+    }
+
+    #[test]
+    fn consensus_branch_id_for_round_rejects_a_handle_opened_for_another_network() {
+        let (db, round_id) = test_db_with_round();
+
+        let err = consensus_branch_id_for_round(&db, &round_id, voting::types::Network::Mainnet)
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("is stored for network"),
+            "unexpected error: {err}"
+        );
     }
 
     fn test_hotkey() -> VotingHotkey {


### PR DESCRIPTION
Closes [MOB-1561](https://linear.app/zodl/issue/MOB-1561/round-consensus-branch-id-derives-the-branch-from-the-callers-network) / #2078.

## The defect

`build_governance_pczt_for_bundle` resolved the consensus branch id as:

```rust
voting::delegate::branch_id_for_height(db.network, round_state.snapshot_height)
```

The snapshot height came from the round. The network did not: `VotingDbHandle::network` is whatever `network_id` the JNI caller passed to `openVotingDbNative`, stored once at open time and never revalidated against the database's contents. Two different networks were in play for one round:

| | source | authority |
|---|---|---|
| `db.network` | JNI `network_id` at open time | whatever the caller said |
| `round_state.network` | the `rounds` table, written at `init_round` | the database |

`zcash_voting` persists the network alongside the round and returns it on `RoundState`, so both inputs to the resolution can come from the round.

Note the issue text is stale in two ways: there is no `round_consensus_branch_id` function (the code is in the private helper `build_governance_pczt_for_bundle`), and the `snapshot_height` half was already fixed. Only the network argument remained.

## The change

Extract `consensus_branch_id_for_round`, which reads both `network` and `snapshot_height` off `get_round_state` and resolves the branch from those. One call site.

The handle's network is still **checked** against the round rather than simply dropped. A disagreement means the database was opened for the wrong network, so the voting hotkey, and hence `DelegationKeys::network`, is wrong for this round too. Upstream rejects that mismatch as well (`validate_network_matches_round`, consulted from `build_governance_pczt`), so this only turns a downstream error into a local one today. It is checked here so the invariant does not depend on a guarantee that lives in another crate, which was the issue's actual objection.

**Constraint for any follow-up:** `DelegationKeys::network` must keep deriving from the handle. The upstream check compares it against the stored round network, and it only has content because the two values arrive from independent sources. Deriving both from the round would make the comparison vacuously true and silently delete a fail-closed guard.

## Reachability

Not exploitable today, and it failed closed. The mismatch is reachable across handles rather than within one: `open_managed_db` rejects a differing network only while a handle for the same path is still live in-process, so a fresh handle opened over an existing database with another `network_id` is not caught.

## Not changed

The other direct `storage::queries::load_round_params` call, in `require_witnesses_match_bundle`, is left as is. It reads only `nc_root`, no network is involved, and the migration note's preference for `VotingDb::...` accessors cannot be honoured there because `VotingDb` exposes no method returning `VotingRoundParams`.

## Tests

Two added, both in `voting::delegation::tests`:

- `consensus_branch_id_for_round_resolves_against_the_rounds_stored_network` asserts the result equals the Regtest-derived branch, and via `assert_ne!` that the mainnet-derived value at the same height differs. That inequality is what makes the second test meaningful.
- `consensus_branch_id_for_round_rejects_a_handle_opened_for_another_network` is the regression test. Under the old code this returned a mainnet branch id with no error, so `unwrap_err()` would have panicked.

## Verification

- `cargo test --lib voting::` green (14/14)
- `cargo fmt -- --check` clean
- `cargo clippy --all-targets -- -D warnings` clean

No changelog entry: the Unreleased section is user-facing API deltas, and this is invisible to callers on every supported path. Happy to add one if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)