### PR TITLE
SPIKE: size Keystone migration runs by signing-round capacity, not note count

### DIFF
--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -1206,7 +1206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d308ebe4b10924331bd079044b418da7b227d724d3e2408567a47ad7c3da2a0"
 dependencies = [
  "derive-deftly-macros",
- "heck 0.5.0",
+ "heck 0.4.1",
 ]
 
 [[package]]
@@ -1215,7 +1215,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "indexmap 2.14.0",
  "itertools 0.15.0",
  "proc-macro-crate",
@@ -1342,7 +1342,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1572,8 +1572,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
+source = "git+https://github.com/zcash/librustzcash?rev=0891e00d6c6319d2354c9a2c69e3191eac3f8f0c#0891e00d6c6319d2354c9a2c69e3191eac3f8f0c"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1592,7 +1591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1609,8 +1608,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+source = "git+https://github.com/zcash/librustzcash?rev=0891e00d6c6319d2354c9a2c69e3191eac3f8f0c#0891e00d6c6319d2354c9a2c69e3191eac3f8f0c"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2635,7 +2633,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2984,7 +2982,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3328,8 +3326,7 @@ dependencies = [
 [[package]]
 name = "pczt"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5592f4f3eba7f9344cc423f45b6e65911e0630c9b89968d5a20792aadd5a0eb"
+source = "git+https://github.com/zcash/librustzcash?rev=0891e00d6c6319d2354c9a2c69e3191eac3f8f0c#0891e00d6c6319d2354c9a2c69e3191eac3f8f0c"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -3788,7 +3785,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -4261,7 +4258,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4801,7 +4798,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -5009,7 +5006,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6961,7 +6958,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7471,8 +7468,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
+source = "git+https://github.com/zcash/librustzcash?rev=0891e00d6c6319d2354c9a2c69e3191eac3f8f0c#0891e00d6c6319d2354c9a2c69e3191eac3f8f0c"
 dependencies = [
  "bech32",
  "bs58",
@@ -7485,8 +7481,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49636f1d22b0511b2a117548cc9dcf569440a3589b06bf6df422c6b738f6231"
+source = "git+https://github.com/zcash/librustzcash?rev=0891e00d6c6319d2354c9a2c69e3191eac3f8f0c#0891e00d6c6319d2354c9a2c69e3191eac3f8f0c"
 dependencies = [
  "ambassador",
  "arti-client",
@@ -7559,8 +7554,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c44798ac3735e85c523899c4c8e06cf94e422a6ceedc9ee5b256a3cf53dd1c96"
+source = "git+https://github.com/zcash/librustzcash?rev=0891e00d6c6319d2354c9a2c69e3191eac3f8f0c#0891e00d6c6319d2354c9a2c69e3191eac3f8f0c"
 dependencies = [
  "ambassador",
  "bip32",
@@ -7623,8 +7617,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def800f128e459eedebc900f36f408eaf0687634128dcf64ecfeaeebc3e16c14"
+source = "git+https://github.com/zcash/librustzcash?rev=0891e00d6c6319d2354c9a2c69e3191eac3f8f0c#0891e00d6c6319d2354c9a2c69e3191eac3f8f0c"
 dependencies = [
  "bech32",
  "bip32",
@@ -7667,8 +7660,7 @@ dependencies = [
 [[package]]
 name = "zcash_pool_migration"
 version = "0.1.0-rc.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532ac156acab2144a88b3e55763ee9329704863a34839e55c2fa705addf3e57e"
+source = "git+https://github.com/zcash/librustzcash?rev=0891e00d6c6319d2354c9a2c69e3191eac3f8f0c#0891e00d6c6319d2354c9a2c69e3191eac3f8f0c"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -7689,8 +7681,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ca4de11896f704ffe6319c2cd7bc8fc6ab31a55cec80d26def15c009d83678"
+source = "git+https://github.com/zcash/librustzcash?rev=0891e00d6c6319d2354c9a2c69e3191eac3f8f0c#0891e00d6c6319d2354c9a2c69e3191eac3f8f0c"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7721,8 +7712,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea125021aaa749e966989c7f7aaa18afe2f89474573f5f0dfac8b98083a6d095"
+source = "git+https://github.com/zcash/librustzcash?rev=0891e00d6c6319d2354c9a2c69e3191eac3f8f0c#0891e00d6c6319d2354c9a2c69e3191eac3f8f0c"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7744,8 +7734,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043686451284bcb72e40ffa18e2cdcea3108e8468e3d021062c0b32c4a060c98"
+source = "git+https://github.com/zcash/librustzcash?rev=0891e00d6c6319d2354c9a2c69e3191eac3f8f0c#0891e00d6c6319d2354c9a2c69e3191eac3f8f0c"
 dependencies = [
  "corez",
  "document-features",
@@ -7786,8 +7775,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "547c012778bae17f58007731af074d638aa146ab0ecfc120adebf23d049aff6c"
+source = "git+https://github.com/zcash/librustzcash?rev=0891e00d6c6319d2354c9a2c69e3191eac3f8f0c#0891e00d6c6319d2354c9a2c69e3191eac3f8f0c"
 dependencies = [
  "bip32",
  "bs58",
@@ -7937,8 +7925,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb464491970d9b61889e4f2b7b00fb9f471a33692e5c0de3122fdc575d8067ab"
+source = "git+https://github.com/zcash/librustzcash?rev=0891e00d6c6319d2354c9a2c69e3191eac3f8f0c#0891e00d6c6319d2354c9a2c69e3191eac3f8f0c"
 dependencies = [
  "base64",
  "nom",

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -220,14 +220,14 @@ crate-type = ["staticlib", "cdylib"]
 # author and reviewer should have certainty that the revision *will end up
 # merged to `main`* so that commits in our history can always be successfully
 # built. 
-#pczt = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-#zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-#zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-#zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-#zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-#zcash_pool_migration = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-#zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-#zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-#zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-#zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
-#zip321 = { git = "https://github.com/zcash/librustzcash", rev = "REPLACE_ME" }
+pczt = { git = "https://github.com/zcash/librustzcash", rev = "0891e00d6c6319d2354c9a2c69e3191eac3f8f0c" }
+zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "0891e00d6c6319d2354c9a2c69e3191eac3f8f0c" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "0891e00d6c6319d2354c9a2c69e3191eac3f8f0c" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "0891e00d6c6319d2354c9a2c69e3191eac3f8f0c" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "0891e00d6c6319d2354c9a2c69e3191eac3f8f0c" }
+zcash_pool_migration = { git = "https://github.com/zcash/librustzcash", rev = "0891e00d6c6319d2354c9a2c69e3191eac3f8f0c" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "0891e00d6c6319d2354c9a2c69e3191eac3f8f0c" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "0891e00d6c6319d2354c9a2c69e3191eac3f8f0c" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "0891e00d6c6319d2354c9a2c69e3191eac3f8f0c" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "0891e00d6c6319d2354c9a2c69e3191eac3f8f0c" }
+zip321 = { git = "https://github.com/zcash/librustzcash", rev = "0891e00d6c6319d2354c9a2c69e3191eac3f8f0c" }

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -43,6 +43,7 @@ use jni::{
 use prost::Message;
 use rand::rngs::OsRng;
 use rusqlite::Connection;
+use std::num::NonZeroUsize;
 use std::ptr;
 
 use zcash_client_backend::data_api::wallet::input_selection::LockFilter;
@@ -64,10 +65,11 @@ use zcash_pool_migration::{
         MigrationTransferId, MigrationTxKind, MigrationTxState, PoolMigrationRead,
         PoolMigrationWrite, ProveError,
     },
-    preparation::{PrepInput, PreparationPlan},
+    preparation::{PrepInput, PreparationPlan, default_portfolio},
     satisfiability::{
         AdvanceConfig, DuenessTargets, ReorgSettleDepth, ReplanThreshold, advance_migration,
     },
+    signing_rounds::RunSigningCapacity,
     state::{AdvanceStep, NextAction, StepKind},
 };
 
@@ -110,6 +112,17 @@ const JNI_KEYSTONE_BATCH_SIGNED_PCZTS: &str =
 /// transfer. 100,000 zatoshi = 0.001 ZEC. A fixed protocol-level constant, not derived from wallet
 /// or account state, so it needs no database access to read.
 pub const MIGRATION_DUST_THRESHOLD_ZATOSHI: u64 = 100_000;
+
+/// The per-run prepared-note cap for zodl's own in-process signer, well above the crate's
+/// [`MIGRATION_MAX_PREPARED_NOTES_PER_RUN`](zcash_pool_migration::denomination::MIGRATION_MAX_PREPARED_NOTES_PER_RUN)
+/// default of 50. That default exists to bound a run's transaction/proving cost for a signer that
+/// must sign it within a per-round action budget (Keystone); zodl's own signer has no such round
+/// to bound, so a larger cap just means fewer runs (and so fewer background sync/broadcast
+/// campaigns) for the same wallet, at the cost of a longer single planning/proving pass.
+const ZODL_MAX_PREPARED_NOTES_PER_RUN: NonZeroUsize = match NonZeroUsize::new(200) {
+    Some(v) => v,
+    None => panic!("nonzero"),
+};
 
 pub(crate) type Wallet = zcash_client_sqlite::WalletDb<Connection, Network, SystemClock, OsRng>;
 
@@ -299,7 +312,7 @@ pub(crate) fn min_pending_anchor_boundary(
 
     let mut min_height: Option<BlockHeight> = None;
     for account in account_ids {
-        let backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let Some(state) = backend.get_migration().map_err(|e| {
             anyhow!(
                 "Error reading migration state for account {:?}: {:?}",
@@ -373,16 +386,38 @@ fn natural_anchor_height(wallet: &Wallet) -> anyhow::Result<BlockHeight> {
 /// JNI-free — see `open_at`'s doc comment. Every `MIGRATION_DIAG` log line this crate has needed
 /// so far to diagnose a live bug (anchor/witness resolution, schedule spread, note-split
 /// detection) came from here or `migration_finalize`, both callable directly from `cargo test`.
+///
+/// Run sizing branches on `Backend::is_keystone`: a Keystone account is sized to fit one QR
+/// signing round (a manual, minutes-long scan), while zodl's own in-process signer keeps the
+/// crate's plain note-cap sizing — it has no per-round cost a signing-round budget would be
+/// bounding, so applying one would only shrink its runs for no benefit.
 fn compute_plan(
     network: &Network,
     wallet: &Wallet,
     account: AccountUuid,
     store_conn: &mut Connection,
 ) -> anyhow::Result<(MigrationPlan, BlockHeight)> {
-    let backend = Backend::new(wallet, account, None, store_conn, *wallet.params())?;
+    let backend = Backend::new(wallet, account, store_conn, *wallet.params())?;
     let mut rng = OsRng;
-    let migration_plan = engine::plan_migration(network, &backend, &mut rng)
-        .map_err(|e| anyhow!("Error planning migration: {:?}", e))?;
+    // Keystone signs one round per manual QR scan (minutes of user time), so a Keystone run is
+    // sized to fit one round (96 actions) rather than a fixed note count — a run's action count
+    // follows the wallet's fragmentation, so a note cap alone cannot promise that (see
+    // `zcash_pool_migration::signing_rounds` module doc). zodl's own in-process signer has no such
+    // per-round cost, so it keeps a note-cap sizing instead — just a much larger cap than the
+    // crate's Keystone-oriented 50-note default (see `ZODL_MAX_PREPARED_NOTES_PER_RUN`).
+    let migration_plan = if backend.is_keystone() {
+        engine::plan_migration_for_signer(RunSigningCapacity::KEYSTONE, network, &backend, &mut rng)
+            .map_err(|e| anyhow!("Error planning migration: {:?}", e))?
+    } else {
+        engine::plan_migration_with(
+            &default_portfolio(),
+            ZODL_MAX_PREPARED_NOTES_PER_RUN,
+            network,
+            &backend,
+            &mut rng,
+        )
+        .map_err(|e| anyhow!("Error planning migration: {:?}", e))?
+    };
     let prep = migration_plan.preparation();
     tracing::debug!(
         "MIGRATION_DIAG plan: preparation has {} layer(s), {} prep transaction(s) total, {} \
@@ -487,12 +522,12 @@ struct CommitContext<'a> {
 /// reviewed). On the reuse path the handle is not consulted: the commitment already happened —
 /// with a handle-verified plan — and is durable, so there is nothing left the handle could
 /// protect. Shared by both the in-process-signing and external-signer commit paths below; `sign`
-/// picks which `commit_preparation`/`build_preparation_unsigned` variant to run, and whether a
-/// spending key is available to the `Backend` while doing so.
+/// picks which `commit_preparation`/`build_preparation_unsigned` variant to run, and (if signing
+/// in process) supplies the spending key directly to that call rather than to the `Backend`,
+/// which never holds spending authority.
 fn commit_or_reuse(
     ctx: CommitContext<'_>,
     plan_handle: crate::migration_plan_cache::PlanHandle,
-    usk: Option<UnifiedSpendingKey>,
     sign: impl FnOnce(
         &Network,
         BlockHeight,
@@ -509,7 +544,7 @@ fn commit_or_reuse(
         target,
     } = ctx;
     {
-        let backend = Backend::new(wallet, account, None, &mut *store_conn, *wallet.params())?;
+        let backend = Backend::new(wallet, account, &mut *store_conn, *wallet.params())?;
         if let Some(state) = backend
             .get_migration()
             .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
@@ -525,7 +560,7 @@ fn commit_or_reuse(
         }
     }
     let migration_plan = crate::migration_plan_cache::get(account, plan_handle)?;
-    let mut backend = Backend::new(wallet, account, usk, store_conn, *wallet.params())?;
+    let mut backend = Backend::new(wallet, account, store_conn, *wallet.params())?;
     let mut rng = OsRng;
     let result = sign(network, target, &mut backend, &migration_plan, &mut rng)?;
     crate::migration_plan_cache::clear(account);
@@ -1157,7 +1192,7 @@ fn try_prove(
         // finalizes the transaction into the wallet's own tables, in the same database
         // transaction, so its inputs read as spent from here until it is mined.
         Ok(engine::ProveOutcome::Proved(proven)) => {
-            let mut backend = Backend::new(&*wallet, account, None, store_conn, params)?;
+            let mut backend = Backend::new(&*wallet, account, store_conn, params)?;
             backend
                 .store_proved_transaction(state, proven)
                 .map_err(|e| anyhow!("Error storing proved migration transaction: {:?}", e))?;
@@ -1173,7 +1208,7 @@ fn try_prove(
                 id,
                 replan_required
             );
-            let mut backend = Backend::new(&*wallet, account, None, store_conn, params)?;
+            let mut backend = Backend::new(&*wallet, account, store_conn, params)?;
             backend
                 .replace_migration(state)
                 .map_err(|e| anyhow!("Error persisting unsatisfiability mark: {:?}", e))?;
@@ -1241,10 +1276,11 @@ fn finalize_note_split(
     id: MigrationTransferId,
 ) -> anyhow::Result<(Vec<u8>, [u8; 32])> {
     let fvk = {
-        let backend = Backend::new(wallet, account, None, store_conn, *wallet.params())?;
+        let backend = Backend::new(wallet, account, store_conn, *wallet.params())?;
         backend
             .orchard_fvk()
-            .map_err(|e| anyhow!("Error reading account FVK: {:?}", e))?
+            .cloned()
+            .ok_or_else(|| anyhow!("account has no Orchard full viewing key"))?
     };
     let kind = state
         .transactions()
@@ -1260,7 +1296,7 @@ fn finalize_note_split(
         ));
     }
     {
-        let mut backend = Backend::new(wallet, account, None, store_conn, *wallet.params())?;
+        let mut backend = Backend::new(wallet, account, store_conn, *wallet.params())?;
         backend
             .replace_migration(state)
             .map_err(|e| anyhow!("Error persisting migration state: {:?}", e))?;
@@ -1324,12 +1360,12 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                 target,
             },
             proposal_handle as u64,
-            Some(usk),
             |network, target, backend, migration_plan, rng| {
                 let state = engine::commit_preparation(
                     network,
                     target,
                     backend,
+                    usk.orchard(),
                     migration_plan,
                     rng,
                     ReplanThreshold::DEFAULT,
@@ -1423,7 +1459,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                 // built, which a broadcaster cannot contradict.
                 let _txid = crate::parse_txid(env, tx_id)?;
                 let mut backend =
-                    Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+                    Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
                 let mut state = backend
                     .get_migration()
                     .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
@@ -1450,7 +1486,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                 // `backend` for the `replace_migration` write.
                 let failed_opt: Option<MigrationState> = {
                     let backend_read =
-                        Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+                        Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
                     let current = backend_read
                         .get_migration()
                         .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?;
@@ -1495,7 +1531,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                     )
                     .map_err(|e| anyhow!("Error recording invalidation reason: {:?}", e))?;
                     let mut backend_write =
-                        Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+                        Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
                     backend_write
                         .replace_migration(&failed)
                         .map_err(|e| anyhow!("Error persisting failed migration: {:?}", e))?;
@@ -1510,7 +1546,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
             // not what the rejecting node specifically reported) rather than skipping the report entirely.
             4 => {
                 let mut backend =
-                    Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+                    Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
                 let mut state = backend
                     .get_migration()
                     .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
@@ -1612,7 +1648,7 @@ fn reconcile_invalidated(
 ) -> anyhow::Result<bool> {
     // --- Pass 1 + load current state (read_reconciled persists any Broadcast→Mined promotions). ---
     let mut state = {
-        let mut backend = Backend::new(&*wallet, account, None, store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&*wallet, account, store_conn, *wallet.params())?;
         match read_reconciled(wallet, &mut backend)? {
             Some(s) => s,
             None => return Ok(false),
@@ -1646,7 +1682,7 @@ fn reconcile_invalidated(
             state.mark_broadcast(*id);
             state.mark_mined(*id, *height);
         }
-        let mut backend = Backend::new(&*wallet, account, None, store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&*wallet, account, store_conn, *wallet.params())?;
         backend
             .replace_migration(&state)
             .map_err(|e| anyhow!("Error persisting submit-crash-probe promotions: {:?}", e))?;
@@ -1744,7 +1780,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let tip = target_height(&wallet)? - 1;
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let persisted = read_reconciled(&wallet, &mut backend)?;
         let account_bytes = account.expose_uuid().as_bytes().to_vec();
         Ok(derive_migration_state(env, persisted, tip, &store_conn, &account_bytes)?.into_raw())
@@ -1778,7 +1814,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         // an accidental write reintroduced here fails to compile without first adding `mut` back,
         // which is a visible, reviewable diff (2026-08-07 read/write-separation design, Fable
         // review M1).
-        let backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let persisted = backend
             .get_migration()
             .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?;
@@ -1802,7 +1838,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let tip = target_height(&wallet)? - 1;
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let persisted = read_reconciled(&wallet, &mut backend)?;
         Ok(match persisted {
             Some(state) if !state.is_terminal() => {
@@ -1862,8 +1898,11 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     unwrap_exc_or(&mut env, res, JNI_FALSE)
 }
 
-/// How many successive migration runs (see `engine::estimate_migration_runs`'s doc) the account's
-/// current Orchard balance would need, given the engine's per-run note cap. Purely a stateless
+/// How many successive migration runs (see `engine::estimate_migration_runs`/
+/// `engine::estimate_migration_runs_for_signer`'s docs) the account's current Orchard balance
+/// would need — for a Keystone account, each run sized to fit one signing round (96 actions);
+/// for zodl's own in-process signer, the crate's plain note-cap sizing (see `compute_plan`'s doc
+/// comment for why the two differ). Purely a stateless
 /// preview — it has no memory of prior calls or rounds already committed, so callers must call this
 /// fresh every time they need it rather than caching the result across a multi-round campaign (see
 /// zashi-android's `docs/superpowers/specs/2026-07-22-keystone-multi-round-migration-continuation-design.md`).
@@ -1880,10 +1919,27 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     let res = catch_unwind(&mut env, |env| {
         let (network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
-        let backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let mut rng = OsRng;
-        let estimate = engine::estimate_migration_runs(&network, &backend, &mut rng)
-            .map_err(|e| anyhow!("Error estimating migration runs: {:?}", e))?;
+        // Must mirror `compute_plan`'s sizing knob exactly, or this preview describes a different
+        // migration from the one that actually gets planned.
+        let estimate = if backend.is_keystone() {
+            engine::estimate_migration_runs_for_signer(
+                RunSigningCapacity::KEYSTONE,
+                &network,
+                &backend,
+                &mut rng,
+            )
+        } else {
+            engine::estimate_migration_runs_with(
+                &default_portfolio(),
+                ZODL_MAX_PREPARED_NOTES_PER_RUN,
+                &network,
+                &backend,
+                &mut rng,
+            )
+        }
+        .map_err(|e| anyhow!("Error estimating migration runs: {:?}", e))?;
         Ok(estimate.run_count() as jint)
     });
     unwrap_exc_or(&mut env, res, 0)
@@ -1930,7 +1986,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         } else {
             scanned_tip
         };
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let persisted = read_reconciled(&wallet, &mut backend)?;
         Ok(match persisted {
             Some(mut state) => {
@@ -1959,7 +2015,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     let res = catch_unwind(&mut env, |env| {
         let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let persisted = read_reconciled(&wallet, &mut backend)?;
         Ok(match persisted {
             Some(state) => match state.status() {
@@ -2005,12 +2061,12 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                 target,
             },
             proposal_handle as u64,
-            Some(usk),
             |network, target, backend, migration_plan, rng| {
                 let state = engine::commit_preparation(
                     network,
                     target,
                     backend,
+                    usk.orchard(),
                     migration_plan,
                     rng,
                     ReplanThreshold::DEFAULT,
@@ -2023,7 +2079,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         // (the proposal's `anchorHeight` shown to the app is only a duration-display reference —
         // the per-transfer bucket boundaries exist first here, post-commit).
         let committed_state = {
-            let backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+            let backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
             backend
                 .get_migration()
                 .map_err(|e| anyhow!("Error re-reading committed migration state: {:?}", e))?
@@ -2071,7 +2127,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                     state.replan_threshold(),
                 );
                 let mut backend =
-                    Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+                    Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
                 backend
                     .replace_migration(&cancelled)
                     .map_err(|e| anyhow!("Error cancelling checkpoint-invalid migration: {}", e))?;
@@ -2332,7 +2388,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let target = target_height(&wallet)?;
 
         let (mut state, fvk) = {
-            let backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+            let backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
             let Some(state) = backend
                 .get_migration()
                 .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
@@ -2344,7 +2400,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
             }
             let fvk = backend
                 .orchard_fvk()
-                .map_err(|e| anyhow!("Error reading account FVK: {:?}", e))?;
+                .cloned()
+                .ok_or_else(|| anyhow!("account has no Orchard full viewing key"))?;
             (state, fvk)
         };
 
@@ -2415,7 +2472,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         }
         if finalized_count > 0 {
             let mut backend =
-                Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+                Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
             backend
                 .replace_migration(&state)
                 .map_err(|e| anyhow!("Error persisting migration state: {:?}", e))?;
@@ -2498,7 +2555,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         } else {
             scanned_tip
         };
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let Some(mut state) = read_reconciled(&wallet, &mut backend)? else {
             // No migration: status=0, both nullable fields null.
             return Ok(env
@@ -2640,7 +2697,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let tip = target_height(&wallet)? - 1;
-        let backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let Some(state) = backend
             .get_migration()
             .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
@@ -3263,7 +3320,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     let res = catch_unwind(&mut env, |env| {
         let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let outcome = backend
             .cancel_migration()
             .map_err(|e| anyhow!("Error cancelling migration: {}", e))?;
@@ -3295,7 +3352,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let tip = target_height(&wallet)? - 1;
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let persisted = read_reconciled(&wallet, &mut backend)?;
         Ok(match persisted {
             Some(state) if !state.is_terminal() => {
@@ -3400,7 +3457,6 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                 target,
             },
             proposal_handle as u64,
-            None,
             |network, target, backend, migration_plan, rng| {
                 let (state, unsigned) = engine::build_preparation_unsigned(
                     network,
@@ -3456,7 +3512,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let signed_pczt_bytes = crate::utils::java_bytes_to_rust(env, &signed_pczt)?;
         let mut state = {
-            let backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+            let backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
             backend
                 .get_migration()
                 .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
@@ -3473,7 +3529,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         }
         {
             let mut backend =
-                Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+                Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
             backend
                 .replace_migration(&state)
                 .map_err(|e| anyhow!("Error persisting migration state: {:?}", e))?;
@@ -3532,7 +3588,6 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                 target,
             },
             proposal_handle as u64,
-            None,
             |network, target, backend, migration_plan, rng| {
                 let (state, unsigned) = engine::build_preparation_unsigned(
                     network,
@@ -3627,7 +3682,6 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                 target,
             },
             proposal_handle as u64,
-            None,
             |network, target, backend, migration_plan, rng| {
                 let (state, unsigned) = engine::build_preparation_unsigned(
                     network,
@@ -3714,7 +3768,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         // not objects.
         let mut raw_ids = vec![0i64; count as usize];
         env.get_long_array_region(&ids, 0, &mut raw_ids)?;
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let mut state = backend
             .get_migration()
             .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
@@ -4028,13 +4082,14 @@ mod live_wallet_signing_tests {
         let target = tip + 1;
 
         let mut state = {
-            let mut backend = Backend::new(&wallet, account, Some(usk), &mut store_conn, network)
+            let mut backend = Backend::new(&wallet, account, &mut store_conn, network)
                 .expect("account exists for migration store");
             let mut rng = OsRng;
             engine::commit_preparation(
                 &network,
                 target,
                 &mut backend,
+                usk.orchard(),
                 &migration_plan,
                 &mut rng,
                 ReplanThreshold::DEFAULT,
@@ -4047,9 +4102,9 @@ mod live_wallet_signing_tests {
         );
 
         let fvk = {
-            let backend = Backend::new(&wallet, account, None, &mut store_conn, network)
+            let backend = Backend::new(&wallet, account, &mut store_conn, network)
                 .expect("account exists for migration store");
-            backend.orchard_fvk().expect("fvk")
+            backend.orchard_fvk().expect("fvk").clone()
         };
 
         let ids_and_kinds: Vec<(MigrationTransferId, MigrationTxKind)> = state
@@ -4180,7 +4235,7 @@ mod live_wallet_signing_tests {
         // Mirrors `createUnsignedNoteSplitPcztNative`: build unsigned, leaving every transaction
         // (including the split) `AwaitingSignature` — nothing is signed by this call.
         let (mut state, unsigned) = {
-            let mut backend = Backend::new(&wallet, account, None, &mut store_conn, network)
+            let mut backend = Backend::new(&wallet, account, &mut store_conn, network)
                 .expect("account exists for migration store");
             let mut rng = OsRng;
             engine::build_preparation_unsigned(
@@ -4348,7 +4403,7 @@ mod live_wallet_edge_case_tests {
             plan_for(&network, &wallet, account_a, &mut store_conn).expect("plan_for account_a");
         let target = tip + 1;
         {
-            let mut backend_a = Backend::new(&wallet, account_a, None, &mut store_conn, network)
+            let mut backend_a = Backend::new(&wallet, account_a, &mut store_conn, network)
                 .expect("account exists for migration store");
             let mut rng = OsRng;
             engine::build_preparation_unsigned(
@@ -4365,7 +4420,7 @@ mod live_wallet_edge_case_tests {
         // Asking for account B's migration state goes through the exact same code path
         // (`migrationStateNative`/`commit_or_reuse` do this) — it must see nothing, since B has
         // no migration of its own. Instead it leaks A's.
-        let backend_b = Backend::new(&wallet, account_b, None, &mut store_conn, network)
+        let backend_b = Backend::new(&wallet, account_b, &mut store_conn, network)
             .expect("account exists for migration store");
         let leaked = backend_b
             .get_migration()
@@ -4415,7 +4470,7 @@ mod live_wallet_edge_case_tests {
             plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
         let target = tip + 1;
         let mut state = {
-            let mut backend = Backend::new(&wallet, account, None, &mut store_conn, network)
+            let mut backend = Backend::new(&wallet, account, &mut store_conn, network)
                 .expect("account exists for migration store");
             let mut rng = OsRng;
             let (state, _unsigned) = engine::build_preparation_unsigned(
@@ -4432,7 +4487,7 @@ mod live_wallet_edge_case_tests {
         let some_tx_id = state.transactions()[0].id();
         state.mark_broadcast(some_tx_id);
 
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, network)
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, network)
             .expect("account exists for migration store");
         backend
             .replace_migration(&state)
@@ -4501,7 +4556,7 @@ mod live_wallet_edge_case_tests {
             plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
         let target = tip + 1;
         let mut state = {
-            let mut backend = Backend::new(&wallet, account, None, &mut store_conn, network)
+            let mut backend = Backend::new(&wallet, account, &mut store_conn, network)
                 .expect("account exists for migration store");
             let mut rng = OsRng;
             let (state, _unsigned) = engine::build_preparation_unsigned(
@@ -4518,7 +4573,7 @@ mod live_wallet_edge_case_tests {
         let some_tx_id = state.transactions()[0].id();
         state.mark_broadcast(some_tx_id);
 
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, network)
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, network)
             .expect("account exists for migration store");
         backend
             .replace_migration(&state)
@@ -4574,7 +4629,6 @@ mod live_wallet_edge_case_tests {
                 target,
             },
             handle,
-            None,
             sign_unsigned,
         )
         .expect("first commit_or_reuse call commits");
@@ -4599,7 +4653,6 @@ mod live_wallet_edge_case_tests {
                 target,
             },
             handle,
-            None,
             sign_unsigned,
         )
         .expect("second commit_or_reuse call must reuse, not error");
@@ -4658,7 +4711,6 @@ mod live_wallet_edge_case_tests {
                 target,
             },
             stale_handle,
-            None,
             sign_unsigned,
         )
         .expect_err("committing with a superseded handle must be rejected");
@@ -4677,7 +4729,6 @@ mod live_wallet_edge_case_tests {
                 target,
             },
             current_handle,
-            None,
             sign_unsigned,
         )
         .expect("committing with the current handle succeeds");
@@ -4708,7 +4759,7 @@ mod live_wallet_edge_case_tests {
             plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
         let target = tip + 1;
         {
-            let mut backend = Backend::new(&wallet, account, None, &mut store_conn, network)
+            let mut backend = Backend::new(&wallet, account, &mut store_conn, network)
                 .expect("account exists for migration store");
             let mut rng = OsRng;
             engine::build_preparation_unsigned(
@@ -4722,7 +4773,7 @@ mod live_wallet_edge_case_tests {
             .expect("first commit");
         }
 
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, network)
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, network)
             .expect("account exists for migration store");
         let mut rng = OsRng;
         let result = engine::build_preparation_unsigned(
@@ -4757,7 +4808,7 @@ mod live_wallet_edge_case_tests {
             let (plan, tip, _handle) =
                 plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
             let target = tip + 1;
-            let mut backend = Backend::new(&wallet, account, None, &mut store_conn, network)
+            let mut backend = Backend::new(&wallet, account, &mut store_conn, network)
                 .expect("account exists for migration store");
             let mut rng = OsRng;
             let (state, _unsigned) = engine::build_preparation_unsigned(
@@ -4775,7 +4826,7 @@ mod live_wallet_edge_case_tests {
 
         let (wallet2, mut store_conn2) = open_at(&db_path, network).expect("reopen wallet");
         let account = first_account(&wallet2);
-        let backend2 = Backend::new(&wallet2, account, None, &mut store_conn2, network)
+        let backend2 = Backend::new(&wallet2, account, &mut store_conn2, network)
             .expect("account exists for migration store");
         let reloaded = backend2
             .get_migration()
@@ -4817,7 +4868,7 @@ mod live_wallet_edge_case_tests {
             plan_for(&network, &wallet, account, &mut store_conn).expect("plan before commit");
         let target = target_height(&wallet).expect("target height");
         {
-            let mut backend = Backend::new(&wallet, account, None, &mut store_conn, network)
+            let mut backend = Backend::new(&wallet, account, &mut store_conn, network)
                 .expect("account exists for migration store");
             let mut rng = OsRng;
             engine::build_preparation_unsigned(
@@ -4853,7 +4904,7 @@ mod live_wallet_edge_case_tests {
         let (mut wallet, mut store_conn) = open_at(&db_path, network).expect("open wallet");
         let account_b = create_synthetic_account(&mut wallet, 0x43, "edge-case-empty-account");
 
-        let backend = Backend::new(&wallet, account_b, None, &mut store_conn, network)
+        let backend = Backend::new(&wallet, account_b, &mut store_conn, network)
             .expect("account exists for migration store");
         let mut rng = OsRng;
         let result = engine::plan_migration(&network, &backend, &mut rng);
@@ -6017,7 +6068,7 @@ mod reconcile_tests {
             plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
         let target = tip + 1;
         let mut state = {
-            let mut backend = Backend::new(&wallet, account, None, &mut store_conn, network)
+            let mut backend = Backend::new(&wallet, account, &mut store_conn, network)
                 .expect("account exists for migration store");
             let mut rng = OsRng;
             let (state, _unsigned) = engine::build_preparation_unsigned(
@@ -7603,7 +7654,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         } else {
             std::cmp::max(scanned, BlockHeight::from_u32(estimated_tip as u32) + 1)
         };
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let Some(mut state) = backend
             .get_migration()
             .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
@@ -7641,7 +7692,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let target = target_height(&wallet)?;
         let tip = target - 1;
-        let backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let Some(state) = backend
             .get_migration()
             .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
@@ -7706,7 +7757,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let id = decode_transfer_id(transfer_id)?;
         let pczt_bytes = env.convert_byte_array(signed_pczt)?;
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let mut state = backend
             .get_migration()
             .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
@@ -7741,7 +7792,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     let res = catch_unwind(&mut env, |env| {
         let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let Some(mut state) = backend
             .get_migration()
             .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?

--- a/backend-lib/src/main/rust/migration_engine.rs
+++ b/backend-lib/src/main/rust/migration_engine.rs
@@ -2,22 +2,20 @@
 //! `MigrationBackend`/`MigrationCrypto`/`PoolMigrationRead`/`PoolMigrationWrite` traits.
 //!
 //! This is deliberately a separate, thinner adapter than `zcash_pool_migration::wallet::
-//! WalletMigration`: that type's constructor requires a `UnifiedSpendingKey` unconditionally
-//! (its `orchard_fvk()` is derived from the usk), but several JNI entry points in `migration.rs`
-//! only ever plan or build unsigned PCZTs (no usk available at that call site — mirroring the old
-//! `zcash_pool_migration` crate, which likewise derived the FVK from the account's stored UFVK,
-//! not from a spending key). `Backend::usk` is therefore optional: every method needed for
-//! planning/building unsigned PCZTs (`orchard_fvk`, `resolve_wallet_note`,
-//! `spendable_orchard_note_values`, `chain_tip_height`) works without it; only `sign()` requires
-//! one, and `zcash_pool_migration::engine::build_preparation_unsigned` never calls it (only
-//! `commit_preparation`'s in-process-signing path does).
+//! WalletMigration`. `Backend` never holds spending authority (matching upstream's "never hold
+//! spending authority in the adapter" — `MigrationCrypto` has no `sign` method): the account's
+//! Orchard full viewing key is resolved once, from the account's stored UFVK, at construction
+//! time, and cached so `orchard_fvk()` can hand back a reference (the trait's contract). Signing,
+//! where needed, is an argument the caller passes directly to `commit_preparation`/
+//! `rebuild_expired_transfer` (see `migration.rs`), derived from a `UnifiedSpendingKey` decoded at
+//! the JNI boundary — `Backend` itself never sees it.
 
 use std::convert::Infallible;
 
 use rusqlite::Connection;
 
 use incrementalmerkletree::Position;
-use orchard::keys::{FullViewingKey, Scope, SpendAuthorizingKey};
+use orchard::keys::{FullViewingKey, Scope};
 use orchard::note::Note as OrchardNote;
 use zcash_client_backend::address::Receiver;
 use zcash_client_backend::data_api::MaxSpendMode;
@@ -26,7 +24,6 @@ use zcash_client_backend::data_api::wallet::input_selection::{LockFilter, Locked
 use zcash_client_backend::data_api::wallet::{ConfirmationsPolicy, propose_send_max_transfer};
 use zcash_client_backend::data_api::{Account, InputSource, WalletRead};
 use zcash_client_backend::fees::StandardFeeRule;
-use zcash_client_backend::keys::UnifiedSpendingKey;
 use zcash_client_backend::proposal::Proposal;
 use zcash_client_sqlite::AccountUuid;
 use zcash_protocol::ShieldedPool;
@@ -54,12 +51,23 @@ type SpendableNote = (OrchardNote, Position, u64);
 /// only ever instantiated over one concrete wallet type.
 pub type EngineError = anyhow::Error;
 
-/// A migration backend over the Android SDK's own wallet database, an account, an optional
-/// spending key (required only for in-process signing), and a `PoolMigrations` store borrow.
+/// A migration backend over the Android SDK's own wallet database, an account, and a
+/// `PoolMigrations` store borrow. Holds no spending key — see the module doc.
 pub struct Backend<'a, W> {
     wallet: &'a W,
     account: AccountUuid,
-    usk: Option<UnifiedSpendingKey>,
+    /// The account's Orchard full viewing key, resolved once at construction (see
+    /// `MigrationCrypto::orchard_fvk`'s contract: infallible, because the backend is handed this
+    /// key rather than going to look for one on every call). `None` for an account whose unified
+    /// key carries no Orchard component.
+    orchard_fvk: Option<FullViewingKey>,
+    /// Whether the account's `key_source` is `"keystone"` (case-insensitive) — the same tag
+    /// `AccountDataSource.importKeystoneAccount` (`ui-lib`) stamps on import via
+    /// `UnifiedFullViewingKey.keySource`. Only Keystone signing has a per-round QR-scanning cost;
+    /// zodl's own accounts (`keySource = "zashi"`) sign everything in one pass regardless of
+    /// action count, so sizing a run for them by a signing-round budget would only shrink runs for
+    /// no benefit — see `is_keystone`'s use in `migration.rs::compute_plan`.
+    is_keystone: bool,
     /// The store carries the network parameters and a clock because, as of
     /// `zcash_client_sqlite 0.22.0-rc.7`, `PoolMigrationWrite::store_proved_transaction` finalizes
     /// a proved migration transaction into the wallet's own transaction tables: it recovers the
@@ -89,19 +97,35 @@ where
     pub fn new(
         wallet: &'a W,
         account: AccountUuid,
-        usk: Option<UnifiedSpendingKey>,
         conn: &'a mut Connection,
         params: Network,
     ) -> Result<Self, EngineError> {
         let store = PoolMigrations::for_account(params, SystemClock, conn, account)
             .map_err(|e| anyhow::anyhow!("opening pool-migration store failed: {e:?}"))?;
+        let account_row = wallet
+            .get_account(account)
+            .map_err(|e| anyhow::anyhow!("account lookup failed: {e}"))?
+            .ok_or_else(|| anyhow::anyhow!("unknown account"))?;
+        let orchard_fvk = account_row.ufvk().and_then(|ufvk| ufvk.orchard()).cloned();
+        let is_keystone = account_row
+            .source()
+            .key_source()
+            .is_some_and(|s| s.eq_ignore_ascii_case("keystone"));
         Ok(Self {
             wallet,
             account,
-            usk,
+            orchard_fvk,
+            is_keystone,
             store,
             spendable: std::cell::RefCell::new(None),
         })
+    }
+
+    /// Whether this account is signed via Keystone (see the `is_keystone` field's doc) — the
+    /// signal `migration.rs::compute_plan`/`estimateMigrationRunCountNative` use to decide
+    /// whether a run must fit one QR-scanned signing round.
+    pub fn is_keystone(&self) -> bool {
+        self.is_keystone
     }
 
     /// Cancels this account's migration via the real store-level primitive
@@ -215,20 +239,9 @@ where
 {
     type Error = EngineError;
 
-    /// Derived from the account's stored Orchard UFVK (not from `self.usk`) so this works whether
-    /// or not a spending key was provided — matches the old `zcash_pool_migration` crate's
-    /// `account_orchard_fvk` helper.
-    fn orchard_fvk(&self) -> Result<FullViewingKey, Self::Error> {
-        let account = self
-            .wallet
-            .get_account(self.account)
-            .map_err(|e| anyhow::anyhow!("account lookup failed: {e}"))?
-            .ok_or_else(|| anyhow::anyhow!("unknown account"))?;
-        account
-            .ufvk()
-            .and_then(|ufvk| ufvk.orchard())
-            .cloned()
-            .ok_or_else(|| anyhow::anyhow!("account has no Orchard full viewing key"))
+    /// Resolved once at construction (see the `orchard_fvk` field's doc) so this is infallible.
+    fn orchard_fvk(&self) -> Option<&FullViewingKey> {
+        self.orchard_fvk.as_ref()
     }
 
     /// The account's ZIP 32 derivation as the wallet records it, or `None` for an account held
@@ -255,16 +268,6 @@ where
             .get(index)
             .ok_or_else(|| anyhow::anyhow!("no spendable note at index {index}"))?;
         Ok(note)
-    }
-
-    fn sign(&self, pczt: pczt::Pczt) -> Result<pczt::Pczt, Self::Error> {
-        let usk = self
-            .usk
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("no spending key available for in-process signing"))?;
-        let ask = SpendAuthorizingKey::from(usk.orchard());
-        zcash_pool_migration::build::sign_pczt(pczt, &ask)
-            .map_err(|e| anyhow::anyhow!("signing the migration PCZT failed: {e:?}"))
     }
 }
 


### PR DESCRIPTION
**Draft/spike — not ready to merge.** Opened so the iOS SDK can look at the approach while
the real `librustzcash` release for this is still pending; see caveats below before relying
on it for anything beyond reference.

## What this does

Adopts zcash/librustzcash#2962 + #2970 (Danny Willems): a migration run's signing-round
count depends on the wallet's fragmentation (16 actions per preparation tx + 3 per
transfer), not on how many notes it prepares — so the crate's flat 50-note-per-run default
could still need several Keystone QR-scanning rounds inside what the UI presents as one
migration run.

- Keystone accounts (`key_source == "keystone"`, matching
  `AccountDataSource.importKeystoneAccount` on the app side) now plan via
  `plan_migration_for_signer`/`estimate_migration_runs_for_signer` with
  `RunSigningCapacity::KEYSTONE` (96 actions/round), so one run fits one QR round.
- zodl's own in-process signer keeps note-cap sizing — it has no per-round QR-scanning cost
  to bound — just raised from the crate's Keystone-oriented 50-note default to 200
  (`ZODL_MAX_PREPARED_NOTES_PER_RUN`).
- `migration_engine::Backend` no longer holds spending authority (adapts to the upstream
  `MigrationCrypto` trait shrinking that shipped as part of #2970's base); a spending key is
  now an argument to `commit_preparation` et al. directly, not something the backend holds
  across its lifetime.

## Caveats

- `[patch.crates-io]` pins the whole `librustzcash` family to `main`
  (`0891e00d6c6319d2354c9a2c69e3191eac3f8f0c`) via git rev, not a published crate — #2962/
  #2970 are merged but not yet cut into a `zcash_pool_migration` RC. Re-pin to the real RC
  once it's published and re-verify. The `Cargo.lock`/`Cargo.toml` diff exists only to make
  that pin buildable.
- That same `main` tip also carries an unrelated commit (Kris Nuttycombe, *"zcash_pool_migration:
  Never hold spending authority in the adapter"*) that this branch had to adapt to just to
  compile — it is not part of the sizing feature itself, just unavoidable API drift from the
  same tip.
- `cargo test --all-features` passes (84 passed / 14 ignored, fixture-only). Built, installed,
  and manually smoke-tested on-device (app-side); not yet exercised end-to-end against a real
  Keystone signer through a full multi-round migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)