### PR TITLE
Remove accidentally-merged voting from maint/v3.0.x

### DIFF
--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -2311,22 +2311,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.27.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "tokio",
- "tokio-rustls",
- "tower-service",
- "webpki-roots",
-]
-
-[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2388,20 +2372,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "imt-tree"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aad3e3ab5a46f4a08d00f5525b86cd0d5204cba64ba68f46e20a590e1808aec"
-dependencies = [
- "anyhow",
- "ff",
- "halo2_gadgets",
- "hex",
- "pasta_curves",
- "rayon",
-]
 
 [[package]]
 name = "incrementalmerkletree"
@@ -3510,38 +3480,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pir-client"
-version = "0.4.0-rc.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d28b9974a13bdde2f90c614e3e399ec260165554fd1077b07290c73b075cc3"
-dependencies = [
- "anyhow",
- "ff",
- "futures",
- "hex",
- "imt-tree",
- "log",
- "pasta_curves",
- "pir-types",
- "serde_json",
- "tokio",
- "valar-ypir",
-]
-
-[[package]]
-name = "pir-types"
-version = "0.3.0-rc.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a363975b44d002bfa04c2003bdcd1b4564cd54bbd99bc0862140bc86865580"
-dependencies = [
- "anyhow",
- "ff",
- "imt-tree",
- "pasta_curves",
- "serde",
-]
 
 [[package]]
 name = "pkcs1"
@@ -6625,38 +6563,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "valar-spiral-rs"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "208d4b69c6a9b7b0c7d856133009a514e10236cdc698ad0b6b87f2e3c4e6d9cb"
-dependencies = [
- "fastrand",
- "getrandom 0.2.17",
- "rand 0.8.7",
- "rand_chacha 0.3.1",
- "serde_json",
- "sha2 0.10.9",
- "subtle",
-]
-
-[[package]]
-name = "valar-ypir"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c3852d9476a0e3efd6c3bfbfc54d3a21a68d8818c4779824ace78aec84a042"
-dependencies = [
- "cc",
- "fastrand",
- "log",
- "rand 0.8.7",
- "rand_chacha 0.3.1",
- "serde",
- "serde_json",
- "sha1",
- "valar-spiral-rs",
-]
-
-[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6690,60 +6596,6 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "vote-commitment-tree"
-version = "0.4.0-rc.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3e4675e494f06faa7a5e571c69ec9e74142a2d222384696ba3d313a938b11e"
-dependencies = [
- "anyhow",
- "ff",
- "halo2_gadgets",
- "imt-tree",
- "incrementalmerkletree",
- "lazy_static",
- "libc",
- "pasta_curves",
- "shardtree",
-]
-
-[[package]]
-name = "vote-commitment-tree-client"
-version = "0.6.0-rc.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9bf6de4d2870aff92b3388df3572d186b1bf64fda3cee623e220d3874f7665"
-dependencies = [
- "base64",
- "ff",
- "hex",
- "pasta_curves",
- "serde",
- "serde_json",
- "thiserror 2.0.19",
- "vote-commitment-tree",
-]
-
-[[package]]
-name = "voting-circuits"
-version = "0.9.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f116ea00a3fd0be51027a4d809953b88338020ac8f40ec9f5ec087b21a7a5c8"
-dependencies = [
- "blake2b_simd",
- "ff",
- "group",
- "halo2_gadgets",
- "halo2_poseidon",
- "halo2_proofs",
- "incrementalmerkletree",
- "itertools 0.14.0",
- "lazy_static",
- "orchard",
- "pasta_curves",
- "rand 0.8.7",
- "sinsemilla",
-]
 
 [[package]]
 name = "wagyu-zcash-parameters"
@@ -7419,7 +7271,6 @@ dependencies = [
  "bytes",
  "dlopen2",
  "eip681",
- "ff",
  "fs-mistrust",
  "hex",
  "http",
@@ -7431,7 +7282,6 @@ dependencies = [
  "nonempty",
  "orchard",
  "paranoid-android",
- "pasta_curves",
  "pczt",
  "prost 0.14.4",
  "rand 0.8.7",
@@ -7463,7 +7313,6 @@ dependencies = [
  "zcash_protocol",
  "zcash_script",
  "zcash_transparent",
- "zcash_voting",
  "zip32",
  "zodl-slipstream",
 ]
@@ -7806,62 +7655,6 @@ dependencies = [
  "zcash_protocol",
  "zcash_script",
  "zcash_spec",
- "zip32",
-]
-
-[[package]]
-name = "zcash_voting"
-version = "2.0.0-rc.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb38f2178857e07f0d832c701ee0fb5b752660a12ccc89df3efcae6a5ee8c42"
-dependencies = [
- "anyhow",
- "base64",
- "blake2b_simd",
- "bytes",
- "ed25519-dalek",
- "ff",
- "group",
- "halo2_gadgets",
- "halo2_proofs",
- "hex",
- "http",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "imt-tree",
- "incrementalmerkletree",
- "nonempty",
- "orchard",
- "pasta_curves",
- "pczt",
- "pir-client",
- "pir-types",
- "prost 0.14.4",
- "rand 0.8.7",
- "rusqlite",
- "rustls",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "sinsemilla",
- "subtle",
- "thiserror 2.0.19",
- "tokio",
- "tonic",
- "uuid",
- "valar-spiral-rs",
- "valar-ypir",
- "vote-commitment-tree",
- "vote-commitment-tree-client",
- "voting-circuits",
- "zcash_client_backend",
- "zcash_client_sqlite",
- "zcash_keys",
- "zcash_primitives",
- "zcash_protocol",
- "zeroize",
  "zip32",
 ]
 

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -44,7 +44,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(zcash_voting)'] }
 # unstable-voting-circuits` should stay empty; if it ever isn't, the circuits are back in the
 # shipped library. Re-enabling voting means asking for it again — see the shielded-voting
 # block below.
-orchard = { version = "0.15", features = ["unstable-voting-circuits"] }
+orchard = { version = "0.15" }
 zcash_pool_migration = { version = "0.1.0-rc.7", features = ["wallet"] }
 # `signer` is this branch's addition, for the Keystone batch-signing recipe below
 # (`pczt::roles::signer::batch`).
@@ -140,14 +140,14 @@ xz2 = { version = "0.1", features = ["static"] }
 # tree is written against are a published crates.io release, so no `[patch.crates-io]`
 # entry is needed. `incrementalmerkletree` above stays uncommented either way -- the
 # migration engine uses it too.
-zcash_voting = { version = "2.0.0-rc.5" }
+# zcash_voting = { version = "2.0.0-rc.5" }
 
 # The delegation-submission signing recipe (voting/delegation.rs) derives the account
 # SpendAuth key locally and needs the same Pallas scalar/field types zcash_voting and
 # orchard already carry transitively; pin to the versions already resolved for them
 # (see Cargo.lock) so this stays the same crate instance, not a second copy.
-pasta_curves = { version = "0.5" }
-ff = { version = "0.13" }
+# pasta_curves = { version = "0.5" }
+# ff = { version = "0.13" }
 
 # Slipstream sync engine. Its JNI binding is folded into this crate as the `slipstream` module
 # (src/main/rust/slipstream/), gated by the off-by-default `slipstream` feature above, so the

--- a/backend-lib/build.gradle.kts
+++ b/backend-lib/build.gradle.kts
@@ -143,11 +143,6 @@ cargo {
     // https://developer.android.com/about/versions/15/behavior-changes-all#16-kb
     exec = { spec, _ ->
         spec.environment["RUST_ANDROID_GRADLE_CC_LINK_ARG"] = "-Wl,-z,max-page-size=16384"
-        // chp worktree: shielded voting re-enabled for real-device trial. `mod voting` in lib.rs
-        // is gated behind this cfg (not a Cargo feature, see backend-lib/Cargo.toml), so it must
-        // be threaded through here too or the shipped .so still omits the VotingRustBackend_*
-        // JNI exports even with the zcash_voting dependency uncommented.
-        spec.environment["RUSTFLAGS"] = "--cfg zcash_voting"
     }
     // GUI-launched IDEs (Android Studio from Finder/Dock) inherit a minimal PATH that omits
     // ~/.cargo/bin, so the rustup `cargo`/`rustc` shims are not found and cargoBuild fails with

--- a/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
+++ b/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
@@ -12,6 +12,7 @@ import cash.z.ecc.android.sdk.internal.model.voting.JniVoteCommitmentResult
 import cash.z.ecc.android.sdk.internal.model.voting.JniWireEncryptedShare
 import cash.z.ecc.android.sdk.internal.model.voting.JniWitnessData
 import kotlinx.coroutines.test.runTest
+import org.junit.Ignore
 import org.junit.Test
 import java.io.File
 import kotlin.io.path.createTempDirectory
@@ -25,10 +26,14 @@ import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.minutes
 
 @OptIn(ExperimentalStdlibApi::class)
-// Re-enabled on the chp worktree: cfg(zcash_voting) is now threaded through
-// backend-lib/build.gradle.kts's cargo exec block and the zcash_voting dependency is
-// uncommented in Cargo.toml (pinned to valargroup/zcash_voting@7d39d02b, v1.0.0).
 @Suppress("LargeClass", "MagicNumber", "DEPRECATION_ERROR")
+@Ignore(
+    "zcash_voting is disabled on maint/v3.0.x (the Cargo dependency is commented out, see " +
+        "backend-lib/Cargo.toml) so the native library exports none of the symbols these tests " +
+        "bind to and every one of them would fail with UnsatisfiedLinkError. The Kotlin/Rust " +
+        "voting API surface here is otherwise unchanged and kept compiling so it's ready to " +
+        "run again the moment voting is re-enabled."
+)
 class VotingRustBackendTest {
     companion object {
         private const val FIELD_BYTES = 32


### PR DESCRIPTION
## Summary

`zcash_voting` was accidentally reenabled on `maint/v3.0.x` via #2157 and
#2161. `zcash_voting` work belongs on `main`; the 3.0.x maintenance line
was never meant to carry it. Root cause (per the team thread): the real
need behind #2157 was verifying the CHP delegation fix on a real device
against the 3.0.x-based app, which never required actually merging to
`maint/v3.0.x`.

**Surgical, dependency-only fix** (not a full revert of #2157/#2161):
reverting those merges wholesale would also throw away the legitimate
`tx1_effects`/`DelegationPhase` fixes they carried and unnecessarily
diverge this branch's voting source from `main`'s own line. Instead:

- Comment out `zcash_voting`/`pasta_curves`/`ff` in `Cargo.toml`, drop
  `orchard`'s `unstable-voting-circuits` feature — matches the
  "to re-enable, uncomment these three" comment that was already in the
  file (and that the accidental re-enable had drifted out of sync with)
- `Cargo.lock` regenerated (`cargo check`): drops `zcash_voting`,
  `voting-circuits`, `vote-commitment-tree(-client)`, `pir-client`,
  `pir-types`, `valar-spiral-rs`, `valar-ypir`, `imt-tree`,
  `hyper-rustls` — 10 crates fully out of the resolved dependency graph.
  This was the actual binary-size/build-time concern raised in the
  thread, and it's fully addressed here — same win as a full revert.
- Drop the `--cfg zcash_voting` RUSTFLAGS thread-through in
  `build.gradle.kts` — load-bearing, not cosmetic: left in place, every
  Gradle-driven `cargoBuild` would try to compile `mod voting` against
  the now-absent crate and fail.

`mod voting` in `lib.rs` stays behind `#[cfg(zcash_voting)]`, so none of
`voting/delegation.rs`, `voting/helpers.rs`, `voting/rounds.rs`, or the
Kotlin JNI/API surface (`VotingRustBackend.kt`, `JniConstants.kt`,
`JniVotingModels.kt`, `TypesafeVotingBackend*.kt`) needed to change —
they're simply not compiled in this default config, same as before
MOB-1545 reintroduced the module. Only exception: `VotingRustBackendTest`
actually exercises the native symbols at runtime, so it needs `@Ignore`
again now that they're not linked; everything else in that file is
untouched.

**Deliberately not touched:** `.github/workflows/pull-request.yml`'s
60min CI timeout bump (and its now-stale "this branch re-enables
shielded voting" comment). It's inaccurate now but harmless — a looser
timeout than needed, not a failure — and reverting it isn't required
for the dependency removal to work. Left alone to keep this diff to
exactly what the fix needs; happy to clean it up separately if wanted.

**Net effect for the app: none.** `VotingCryptoClient.kt`'s existing
`pirDepth`/`pirTier0Layers`/`pirTier1Layers` call-site shim (added in
zodl-android commit `227ee1e09` to match #2157's SDK signature) keeps
compiling as-is, since that signature didn't change. No companion app
PR is needed — verified with a full
`:app:assembleZcashmainnetInternalDebug` build against this branch via
an included-build composite (app on `maint/v3.9.x`, SDK on this
branch) — **BUILD SUCCESSFUL**, APK produced.

## ⚠️ Forward-merge caution

`#2157`/`#2161` never landed on `main` — `main` has its own, further-
developed `zcash_voting` line. When this branch is eventually cascaded
forward (`maint/v3.0.x` → newer maint → `main`), the diff here is small
and dependency-only (`Cargo.toml`/`Cargo.lock`/`build.gradle.kts`/one
`@Ignore`), so the collision surface with `main`'s active voting work is
much smaller than a full revert would have been — but still worth a
manual look at those files during that merge rather than trusting it
blind.

## Test plan

- [x] `cargo check` / `cargo check --all-targets` on `backend-lib`
      (default, non-voting config) — clean
- [x] Confirmed via `Cargo.lock` diff that all 10 voting-related crates
      drop out of the resolved graph
- [x] No production Kotlin/Rust voting API/logic files touched
      (`git diff --stat` scoped to `backend-lib/src/main`/`sdk-lib` is
      empty)
- [x] Full app build (`:app:assembleZcashmainnetInternalDebug`) against
      this branch via composite build — BUILD SUCCESSFUL
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)