### PR TITLE
[#2055] Update the librustzcash crates to their final releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Updated the librustzcash crates to their final releases: `zcash_client_backend 0.24.0`,
+  `zcash_client_sqlite 0.22.0`, `zcash_pool_migration 0.1.0`, `zcash_primitives 0.30.1` and
+  `zip321 0.9.0`, and the Slipstream sync engine to `zodl-slipstream 0.2.0`. A wallet database
+  is now migrated by the finalized `zcash_client_sqlite` schema rather than a release
+  candidate's.
+
 ### Fixed
 - Resubmission no longer permanently drops a pending submit plan for a wallet-created transaction
   missing from the derived history view: the wallet store is consulted before pruning - the plan

--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -7333,9 +7333,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.7"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49636f1d22b0511b2a117548cc9dcf569440a3589b06bf6df422c6b738f6231"
+checksum = "07ad58d8ca5daacbc089bf82ec09e45cf2a8be40adeb40b9399b16545c81a528"
 dependencies = [
  "ambassador",
  "arti-client",
@@ -7407,9 +7407,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.8"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c44798ac3735e85c523899c4c8e06cf94e422a6ceedc9ee5b256a3cf53dd1c96"
+checksum = "dd92e4334619b1e3f67019254049318ec0d0240a3c15d853bdf2ac4bba597078"
 dependencies = [
  "ambassador",
  "bip32",
@@ -7515,9 +7515,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_pool_migration"
-version = "0.1.0-rc.7"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532ac156acab2144a88b3e55763ee9329704863a34839e55c2fa705addf3e57e"
+checksum = "6188c544911aad647bdb0730d18a0309991da1ccbbdab0415d4ef3113ecadcb3"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -7537,9 +7537,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ca4de11896f704ffe6319c2cd7bc8fc6ab31a55cec80d26def15c009d83678"
+checksum = "403d5be1e96339534be098e3377fb8a78d68ca7585b1780133d884b810277418"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7592,9 +7592,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043686451284bcb72e40ffa18e2cdcea3108e8468e3d021062c0b32c4a060c98"
+checksum = "314329b91ec4bbb517441840e47d0b2029bf0b946f086980c96c889c2d92dc5d"
 dependencies = [
  "corez",
  "document-features",
@@ -7729,9 +7729,9 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.9.0-rc.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb464491970d9b61889e4f2b7b00fb9f471a33692e5c0de3122fdc575d8067ab"
+checksum = "e0180028b8807c60498f01eb805a125eed095ab4c4a1737635c80e6ef7cb0a9c"
 dependencies = [
  "base64",
  "nom",
@@ -7748,9 +7748,9 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zodl-slipstream"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "166eb670a194f5da7c20507f0c8d9d6dfa6afd75d50d1ba93b978dba92418325"
+checksum = "03bc2f02e03c29b994b8aae9ef604d430414203047e586bb6bdac9f20e45f3ba"
 dependencies = [
  "ff",
  "futures-util",

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -45,14 +45,14 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(zcash_voting)'] }
 # shipped library. Re-enabling voting means asking for it again — see the shielded-voting
 # block below.
 orchard = { version = "0.15" }
-zcash_pool_migration = { version = "0.1.0-rc.7", features = ["wallet"] }
+zcash_pool_migration = { version = "0.1.0", features = ["wallet"] }
 # `signer` is this branch's addition, for the Keystone batch-signing recipe below
 # (`pczt::roles::signer::batch`).
 pczt = { version = "0.9.0", features = ["prover", "orchard", "sapling", "signer"] }
 sapling = { package = "sapling-crypto", version = "0.7", default-features = false }
 transparent = { package = "zcash_transparent", version = "0.10", default-features = false }
 zcash_address = "0.13"
-zcash_client_backend = { version = "0.24.0-rc.7", features = [
+zcash_client_backend = { version = "0.24.0", features = [
     "orchard",
     "lightwalletd-tonic-tls-webpki-roots",
     "tor",
@@ -60,7 +60,7 @@ zcash_client_backend = { version = "0.24.0-rc.7", features = [
     "unstable",
     "pczt",
 ] }
-zcash_client_sqlite = { version = "0.22.0-rc.8", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
+zcash_client_sqlite = { version = "0.22.0", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
 zcash_note_encryption = "0.4.1"
 zcash_primitives = "0.30"
 zcash_proofs = "0.30"
@@ -157,10 +157,10 @@ xz2 = { version = "0.1", features = ["static"] }
 # instance in the SAME process, or closing one connection drops the other's fcntl locks out
 # from under it (the dual-instance SIGBUS/disk-I/O hazard; see
 # docs/slipstream/android/worklog/ARCHIVE-phases-0-9.md for the full writeup). `slipstream-core`
-# is git-pinned (no machine-local path); backend-lib's `[patch.crates-io]` below is the single
-# source of truth governing the librustzcash rev for `core` and the whole graph. Keep this rev
-# in step with that patch block.
-slipstream-core = { package = "zodl-slipstream", version = "0.1", optional = true }
+# resolves from crates.io, so it takes the librustzcash versions this file requires above; a
+# `[patch.crates-io]` entry below (normally all commented out) overrides them for `core` and the
+# whole graph alike.
+slipstream-core = { package = "zodl-slipstream", version = "0.2", optional = true }
 # The module's owned engine runtime (HOSTING.md §3.1) and the logcat logging layer it wires up.
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"], optional = true }
 
@@ -200,7 +200,7 @@ bip0039 = "0.12"
 # transaction through `zcash_client_sqlite`'s internal pool-migration truncation wiring. Cargo
 # unions this feature set with the `[dependencies]` entry above only for test/bench/example
 # builds, so the release library never links tempfile/rand_chacha/ambassador.
-zcash_client_sqlite = { version = "0.22.0-rc.7", features = ["orchard", "transparent-inputs", "unstable", "serde", "test-dependencies"] }
+zcash_client_sqlite = { version = "0.22.0", features = ["orchard", "transparent-inputs", "unstable", "serde", "test-dependencies"] }
 
 [lib]
 name = "zcashwalletsdk"

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -47,7 +47,6 @@ use std::ptr;
 
 use zcash_client_backend::data_api::wallet::input_selection::LockFilter;
 use zcash_client_backend::data_api::{InputSource, OutputLockStore, WalletRead};
-use zcash_client_backend::keys::UnifiedSpendingKey;
 use zcash_client_backend::wallet::{LockOwner, OutputRef};
 use zcash_client_sqlite::AccountUuid;
 use zcash_client_sqlite::util::SystemClock;
@@ -299,7 +298,7 @@ pub(crate) fn min_pending_anchor_boundary(
 
     let mut min_height: Option<BlockHeight> = None;
     for account in account_ids {
-        let backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let Some(state) = backend.get_migration().map_err(|e| {
             anyhow!(
                 "Error reading migration state for account {:?}: {:?}",
@@ -379,7 +378,7 @@ fn compute_plan(
     account: AccountUuid,
     store_conn: &mut Connection,
 ) -> anyhow::Result<(MigrationPlan, BlockHeight)> {
-    let backend = Backend::new(wallet, account, None, store_conn, *wallet.params())?;
+    let backend = Backend::new(wallet, account, store_conn, *wallet.params())?;
     let mut rng = OsRng;
     let migration_plan = engine::plan_migration(network, &backend, &mut rng)
         .map_err(|e| anyhow!("Error planning migration: {:?}", e))?;
@@ -487,12 +486,11 @@ struct CommitContext<'a> {
 /// reviewed). On the reuse path the handle is not consulted: the commitment already happened —
 /// with a handle-verified plan — and is durable, so there is nothing left the handle could
 /// protect. Shared by both the in-process-signing and external-signer commit paths below; `sign`
-/// picks which `commit_preparation`/`build_preparation_unsigned` variant to run, and whether a
-/// spending key is available to the `Backend` while doing so.
+/// picks which `commit_preparation`/`build_preparation_unsigned` variant to run, and carries the
+/// account's Orchard spend authority when the chosen variant signs in process.
 fn commit_or_reuse(
     ctx: CommitContext<'_>,
     plan_handle: crate::migration_plan_cache::PlanHandle,
-    usk: Option<UnifiedSpendingKey>,
     sign: impl FnOnce(
         &Network,
         BlockHeight,
@@ -509,7 +507,7 @@ fn commit_or_reuse(
         target,
     } = ctx;
     {
-        let backend = Backend::new(wallet, account, None, &mut *store_conn, *wallet.params())?;
+        let backend = Backend::new(wallet, account, &mut *store_conn, *wallet.params())?;
         if let Some(state) = backend
             .get_migration()
             .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
@@ -525,7 +523,7 @@ fn commit_or_reuse(
         }
     }
     let migration_plan = crate::migration_plan_cache::get(account, plan_handle)?;
-    let mut backend = Backend::new(wallet, account, usk, store_conn, *wallet.params())?;
+    let mut backend = Backend::new(wallet, account, store_conn, *wallet.params())?;
     let mut rng = OsRng;
     let result = sign(network, target, &mut backend, &migration_plan, &mut rng)?;
     crate::migration_plan_cache::clear(account);
@@ -1157,7 +1155,7 @@ fn try_prove(
         // finalizes the transaction into the wallet's own tables, in the same database
         // transaction, so its inputs read as spent from here until it is mined.
         Ok(engine::ProveOutcome::Proved(proven)) => {
-            let mut backend = Backend::new(&*wallet, account, None, store_conn, params)?;
+            let mut backend = Backend::new(&*wallet, account, store_conn, params)?;
             backend
                 .store_proved_transaction(state, proven)
                 .map_err(|e| anyhow!("Error storing proved migration transaction: {:?}", e))?;
@@ -1173,7 +1171,7 @@ fn try_prove(
                 id,
                 replan_required
             );
-            let mut backend = Backend::new(&*wallet, account, None, store_conn, params)?;
+            let mut backend = Backend::new(&*wallet, account, store_conn, params)?;
             backend
                 .replace_migration(state)
                 .map_err(|e| anyhow!("Error persisting unsatisfiability mark: {:?}", e))?;
@@ -1241,10 +1239,11 @@ fn finalize_note_split(
     id: MigrationTransferId,
 ) -> anyhow::Result<(Vec<u8>, [u8; 32])> {
     let fvk = {
-        let backend = Backend::new(wallet, account, None, store_conn, *wallet.params())?;
+        let backend = Backend::new(wallet, account, store_conn, *wallet.params())?;
         backend
             .orchard_fvk()
-            .map_err(|e| anyhow!("Error reading account FVK: {:?}", e))?
+            .cloned()
+            .ok_or_else(|| anyhow!("Account has no Orchard full viewing key"))?
     };
     let kind = state
         .transactions()
@@ -1260,7 +1259,7 @@ fn finalize_note_split(
         ));
     }
     {
-        let mut backend = Backend::new(wallet, account, None, store_conn, *wallet.params())?;
+        let mut backend = Backend::new(wallet, account, store_conn, *wallet.params())?;
         backend
             .replace_migration(state)
             .map_err(|e| anyhow!("Error persisting migration state: {:?}", e))?;
@@ -1324,12 +1323,12 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                 target,
             },
             proposal_handle as u64,
-            Some(usk),
             |network, target, backend, migration_plan, rng| {
                 let state = engine::commit_preparation(
                     network,
                     target,
                     backend,
+                    usk.orchard(),
                     migration_plan,
                     rng,
                     ReplanThreshold::DEFAULT,
@@ -1423,7 +1422,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                 // built, which a broadcaster cannot contradict.
                 let _txid = crate::parse_txid(env, tx_id)?;
                 let mut backend =
-                    Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+                    Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
                 let mut state = backend
                     .get_migration()
                     .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
@@ -1450,7 +1449,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                 // `backend` for the `replace_migration` write.
                 let failed_opt: Option<MigrationState> = {
                     let backend_read =
-                        Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+                        Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
                     let current = backend_read
                         .get_migration()
                         .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?;
@@ -1495,7 +1494,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                     )
                     .map_err(|e| anyhow!("Error recording invalidation reason: {:?}", e))?;
                     let mut backend_write =
-                        Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+                        Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
                     backend_write
                         .replace_migration(&failed)
                         .map_err(|e| anyhow!("Error persisting failed migration: {:?}", e))?;
@@ -1510,7 +1509,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
             // not what the rejecting node specifically reported) rather than skipping the report entirely.
             4 => {
                 let mut backend =
-                    Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+                    Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
                 let mut state = backend
                     .get_migration()
                     .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
@@ -1612,7 +1611,7 @@ fn reconcile_invalidated(
 ) -> anyhow::Result<bool> {
     // --- Pass 1 + load current state (read_reconciled persists any Broadcast→Mined promotions). ---
     let mut state = {
-        let mut backend = Backend::new(&*wallet, account, None, store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&*wallet, account, store_conn, *wallet.params())?;
         match read_reconciled(wallet, &mut backend)? {
             Some(s) => s,
             None => return Ok(false),
@@ -1646,7 +1645,7 @@ fn reconcile_invalidated(
             state.mark_broadcast(*id);
             state.mark_mined(*id, *height);
         }
-        let mut backend = Backend::new(&*wallet, account, None, store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&*wallet, account, store_conn, *wallet.params())?;
         backend
             .replace_migration(&state)
             .map_err(|e| anyhow!("Error persisting submit-crash-probe promotions: {:?}", e))?;
@@ -1744,7 +1743,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let tip = target_height(&wallet)? - 1;
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let persisted = read_reconciled(&wallet, &mut backend)?;
         let account_bytes = account.expose_uuid().as_bytes().to_vec();
         Ok(derive_migration_state(env, persisted, tip, &store_conn, &account_bytes)?.into_raw())
@@ -1778,7 +1777,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         // an accidental write reintroduced here fails to compile without first adding `mut` back,
         // which is a visible, reviewable diff (2026-08-07 read/write-separation design, Fable
         // review M1).
-        let backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let persisted = backend
             .get_migration()
             .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?;
@@ -1802,7 +1801,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let tip = target_height(&wallet)? - 1;
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let persisted = read_reconciled(&wallet, &mut backend)?;
         Ok(match persisted {
             Some(state) if !state.is_terminal() => {
@@ -1880,7 +1879,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     let res = catch_unwind(&mut env, |env| {
         let (network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
-        let backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let mut rng = OsRng;
         let estimate = engine::estimate_migration_runs(&network, &backend, &mut rng)
             .map_err(|e| anyhow!("Error estimating migration runs: {:?}", e))?;
@@ -1930,7 +1929,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         } else {
             scanned_tip
         };
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let persisted = read_reconciled(&wallet, &mut backend)?;
         Ok(match persisted {
             Some(mut state) => {
@@ -1959,7 +1958,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     let res = catch_unwind(&mut env, |env| {
         let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let persisted = read_reconciled(&wallet, &mut backend)?;
         Ok(match persisted {
             Some(state) => match state.status() {
@@ -2005,12 +2004,12 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                 target,
             },
             proposal_handle as u64,
-            Some(usk),
             |network, target, backend, migration_plan, rng| {
                 let state = engine::commit_preparation(
                     network,
                     target,
                     backend,
+                    usk.orchard(),
                     migration_plan,
                     rng,
                     ReplanThreshold::DEFAULT,
@@ -2023,7 +2022,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         // (the proposal's `anchorHeight` shown to the app is only a duration-display reference —
         // the per-transfer bucket boundaries exist first here, post-commit).
         let committed_state = {
-            let backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+            let backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
             backend
                 .get_migration()
                 .map_err(|e| anyhow!("Error re-reading committed migration state: {:?}", e))?
@@ -2071,7 +2070,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                     state.replan_threshold(),
                 );
                 let mut backend =
-                    Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+                    Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
                 backend
                     .replace_migration(&cancelled)
                     .map_err(|e| anyhow!("Error cancelling checkpoint-invalid migration: {}", e))?;
@@ -2332,7 +2331,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let target = target_height(&wallet)?;
 
         let (mut state, fvk) = {
-            let backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+            let backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
             let Some(state) = backend
                 .get_migration()
                 .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
@@ -2344,7 +2343,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
             }
             let fvk = backend
                 .orchard_fvk()
-                .map_err(|e| anyhow!("Error reading account FVK: {:?}", e))?;
+                .cloned()
+                .ok_or_else(|| anyhow!("Account has no Orchard full viewing key"))?;
             (state, fvk)
         };
 
@@ -2414,8 +2414,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
             }
         }
         if finalized_count > 0 {
-            let mut backend =
-                Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+            let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
             backend
                 .replace_migration(&state)
                 .map_err(|e| anyhow!("Error persisting migration state: {:?}", e))?;
@@ -2498,7 +2497,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         } else {
             scanned_tip
         };
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let Some(mut state) = read_reconciled(&wallet, &mut backend)? else {
             // No migration: status=0, both nullable fields null.
             return Ok(env
@@ -2640,7 +2639,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let tip = target_height(&wallet)? - 1;
-        let backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let Some(state) = backend
             .get_migration()
             .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
@@ -3263,7 +3262,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     let res = catch_unwind(&mut env, |env| {
         let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let outcome = backend
             .cancel_migration()
             .map_err(|e| anyhow!("Error cancelling migration: {}", e))?;
@@ -3295,7 +3294,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let tip = target_height(&wallet)? - 1;
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let persisted = read_reconciled(&wallet, &mut backend)?;
         Ok(match persisted {
             Some(state) if !state.is_terminal() => {
@@ -3400,7 +3399,6 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                 target,
             },
             proposal_handle as u64,
-            None,
             |network, target, backend, migration_plan, rng| {
                 let (state, unsigned) = engine::build_preparation_unsigned(
                     network,
@@ -3456,7 +3454,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let signed_pczt_bytes = crate::utils::java_bytes_to_rust(env, &signed_pczt)?;
         let mut state = {
-            let backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+            let backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
             backend
                 .get_migration()
                 .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
@@ -3472,8 +3470,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
             return Err(anyhow!("Error applying note-split signature"));
         }
         {
-            let mut backend =
-                Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+            let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
             backend
                 .replace_migration(&state)
                 .map_err(|e| anyhow!("Error persisting migration state: {:?}", e))?;
@@ -3532,7 +3529,6 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                 target,
             },
             proposal_handle as u64,
-            None,
             |network, target, backend, migration_plan, rng| {
                 let (state, unsigned) = engine::build_preparation_unsigned(
                     network,
@@ -3627,7 +3623,6 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                 target,
             },
             proposal_handle as u64,
-            None,
             |network, target, backend, migration_plan, rng| {
                 let (state, unsigned) = engine::build_preparation_unsigned(
                     network,
@@ -3714,7 +3709,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         // not objects.
         let mut raw_ids = vec![0i64; count as usize];
         env.get_long_array_region(&ids, 0, &mut raw_ids)?;
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let mut state = backend
             .get_migration()
             .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
@@ -3982,6 +3977,7 @@ mod live_wallet_tests {
 mod live_wallet_signing_tests {
     use super::*;
     use zcash_client_backend::data_api::Account;
+    use zcash_client_backend::keys::UnifiedSpendingKey;
 
     #[test]
     #[ignore = "requires MIGRATION_TEST_WALLET_DB and MIGRATION_TEST_SEED_PHRASE"]
@@ -4028,13 +4024,14 @@ mod live_wallet_signing_tests {
         let target = tip + 1;
 
         let mut state = {
-            let mut backend = Backend::new(&wallet, account, Some(usk), &mut store_conn, network)
+            let mut backend = Backend::new(&wallet, account, &mut store_conn, network)
                 .expect("account exists for migration store");
             let mut rng = OsRng;
             engine::commit_preparation(
                 &network,
                 target,
                 &mut backend,
+                usk.orchard(),
                 &migration_plan,
                 &mut rng,
                 ReplanThreshold::DEFAULT,
@@ -4047,9 +4044,9 @@ mod live_wallet_signing_tests {
         );
 
         let fvk = {
-            let backend = Backend::new(&wallet, account, None, &mut store_conn, network)
+            let backend = Backend::new(&wallet, account, &mut store_conn, network)
                 .expect("account exists for migration store");
-            backend.orchard_fvk().expect("fvk")
+            backend.orchard_fvk().cloned().expect("fvk")
         };
 
         let ids_and_kinds: Vec<(MigrationTransferId, MigrationTxKind)> = state
@@ -4180,7 +4177,7 @@ mod live_wallet_signing_tests {
         // Mirrors `createUnsignedNoteSplitPcztNative`: build unsigned, leaving every transaction
         // (including the split) `AwaitingSignature` — nothing is signed by this call.
         let (mut state, unsigned) = {
-            let mut backend = Backend::new(&wallet, account, None, &mut store_conn, network)
+            let mut backend = Backend::new(&wallet, account, &mut store_conn, network)
                 .expect("account exists for migration store");
             let mut rng = OsRng;
             engine::build_preparation_unsigned(
@@ -4348,7 +4345,7 @@ mod live_wallet_edge_case_tests {
             plan_for(&network, &wallet, account_a, &mut store_conn).expect("plan_for account_a");
         let target = tip + 1;
         {
-            let mut backend_a = Backend::new(&wallet, account_a, None, &mut store_conn, network)
+            let mut backend_a = Backend::new(&wallet, account_a, &mut store_conn, network)
                 .expect("account exists for migration store");
             let mut rng = OsRng;
             engine::build_preparation_unsigned(
@@ -4365,7 +4362,7 @@ mod live_wallet_edge_case_tests {
         // Asking for account B's migration state goes through the exact same code path
         // (`migrationStateNative`/`commit_or_reuse` do this) — it must see nothing, since B has
         // no migration of its own. Instead it leaks A's.
-        let backend_b = Backend::new(&wallet, account_b, None, &mut store_conn, network)
+        let backend_b = Backend::new(&wallet, account_b, &mut store_conn, network)
             .expect("account exists for migration store");
         let leaked = backend_b
             .get_migration()
@@ -4415,7 +4412,7 @@ mod live_wallet_edge_case_tests {
             plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
         let target = tip + 1;
         let mut state = {
-            let mut backend = Backend::new(&wallet, account, None, &mut store_conn, network)
+            let mut backend = Backend::new(&wallet, account, &mut store_conn, network)
                 .expect("account exists for migration store");
             let mut rng = OsRng;
             let (state, _unsigned) = engine::build_preparation_unsigned(
@@ -4432,7 +4429,7 @@ mod live_wallet_edge_case_tests {
         let some_tx_id = state.transactions()[0].id();
         state.mark_broadcast(some_tx_id);
 
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, network)
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, network)
             .expect("account exists for migration store");
         backend
             .replace_migration(&state)
@@ -4501,7 +4498,7 @@ mod live_wallet_edge_case_tests {
             plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
         let target = tip + 1;
         let mut state = {
-            let mut backend = Backend::new(&wallet, account, None, &mut store_conn, network)
+            let mut backend = Backend::new(&wallet, account, &mut store_conn, network)
                 .expect("account exists for migration store");
             let mut rng = OsRng;
             let (state, _unsigned) = engine::build_preparation_unsigned(
@@ -4518,7 +4515,7 @@ mod live_wallet_edge_case_tests {
         let some_tx_id = state.transactions()[0].id();
         state.mark_broadcast(some_tx_id);
 
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, network)
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, network)
             .expect("account exists for migration store");
         backend
             .replace_migration(&state)
@@ -4574,7 +4571,6 @@ mod live_wallet_edge_case_tests {
                 target,
             },
             handle,
-            None,
             sign_unsigned,
         )
         .expect("first commit_or_reuse call commits");
@@ -4599,7 +4595,6 @@ mod live_wallet_edge_case_tests {
                 target,
             },
             handle,
-            None,
             sign_unsigned,
         )
         .expect("second commit_or_reuse call must reuse, not error");
@@ -4658,7 +4653,6 @@ mod live_wallet_edge_case_tests {
                 target,
             },
             stale_handle,
-            None,
             sign_unsigned,
         )
         .expect_err("committing with a superseded handle must be rejected");
@@ -4677,7 +4671,6 @@ mod live_wallet_edge_case_tests {
                 target,
             },
             current_handle,
-            None,
             sign_unsigned,
         )
         .expect("committing with the current handle succeeds");
@@ -4708,7 +4701,7 @@ mod live_wallet_edge_case_tests {
             plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
         let target = tip + 1;
         {
-            let mut backend = Backend::new(&wallet, account, None, &mut store_conn, network)
+            let mut backend = Backend::new(&wallet, account, &mut store_conn, network)
                 .expect("account exists for migration store");
             let mut rng = OsRng;
             engine::build_preparation_unsigned(
@@ -4722,7 +4715,7 @@ mod live_wallet_edge_case_tests {
             .expect("first commit");
         }
 
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, network)
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, network)
             .expect("account exists for migration store");
         let mut rng = OsRng;
         let result = engine::build_preparation_unsigned(
@@ -4757,7 +4750,7 @@ mod live_wallet_edge_case_tests {
             let (plan, tip, _handle) =
                 plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
             let target = tip + 1;
-            let mut backend = Backend::new(&wallet, account, None, &mut store_conn, network)
+            let mut backend = Backend::new(&wallet, account, &mut store_conn, network)
                 .expect("account exists for migration store");
             let mut rng = OsRng;
             let (state, _unsigned) = engine::build_preparation_unsigned(
@@ -4775,7 +4768,7 @@ mod live_wallet_edge_case_tests {
 
         let (wallet2, mut store_conn2) = open_at(&db_path, network).expect("reopen wallet");
         let account = first_account(&wallet2);
-        let backend2 = Backend::new(&wallet2, account, None, &mut store_conn2, network)
+        let backend2 = Backend::new(&wallet2, account, &mut store_conn2, network)
             .expect("account exists for migration store");
         let reloaded = backend2
             .get_migration()
@@ -4817,7 +4810,7 @@ mod live_wallet_edge_case_tests {
             plan_for(&network, &wallet, account, &mut store_conn).expect("plan before commit");
         let target = target_height(&wallet).expect("target height");
         {
-            let mut backend = Backend::new(&wallet, account, None, &mut store_conn, network)
+            let mut backend = Backend::new(&wallet, account, &mut store_conn, network)
                 .expect("account exists for migration store");
             let mut rng = OsRng;
             engine::build_preparation_unsigned(
@@ -4853,7 +4846,7 @@ mod live_wallet_edge_case_tests {
         let (mut wallet, mut store_conn) = open_at(&db_path, network).expect("open wallet");
         let account_b = create_synthetic_account(&mut wallet, 0x43, "edge-case-empty-account");
 
-        let backend = Backend::new(&wallet, account_b, None, &mut store_conn, network)
+        let backend = Backend::new(&wallet, account_b, &mut store_conn, network)
             .expect("account exists for migration store");
         let mut rng = OsRng;
         let result = engine::plan_migration(&network, &backend, &mut rng);
@@ -6017,7 +6010,7 @@ mod reconcile_tests {
             plan_for(&network, &wallet, account, &mut store_conn).expect("plan_for");
         let target = tip + 1;
         let mut state = {
-            let mut backend = Backend::new(&wallet, account, None, &mut store_conn, network)
+            let mut backend = Backend::new(&wallet, account, &mut store_conn, network)
                 .expect("account exists for migration store");
             let mut rng = OsRng;
             let (state, _unsigned) = engine::build_preparation_unsigned(
@@ -7603,7 +7596,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         } else {
             std::cmp::max(scanned, BlockHeight::from_u32(estimated_tip as u32) + 1)
         };
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let Some(mut state) = backend
             .get_migration()
             .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
@@ -7641,7 +7634,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let target = target_height(&wallet)?;
         let tip = target - 1;
-        let backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let Some(state) = backend
             .get_migration()
             .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
@@ -7706,7 +7699,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let id = decode_transfer_id(transfer_id)?;
         let pczt_bytes = env.convert_byte_array(signed_pczt)?;
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let mut state = backend
             .get_migration()
             .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
@@ -7741,7 +7734,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     let res = catch_unwind(&mut env, |env| {
         let (_network, wallet, mut store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
-        let mut backend = Backend::new(&wallet, account, None, &mut store_conn, *wallet.params())?;
+        let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let Some(mut state) = backend
             .get_migration()
             .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?

--- a/backend-lib/src/main/rust/migration_engine.rs
+++ b/backend-lib/src/main/rust/migration_engine.rs
@@ -2,22 +2,22 @@
 //! `MigrationBackend`/`MigrationCrypto`/`PoolMigrationRead`/`PoolMigrationWrite` traits.
 //!
 //! This is deliberately a separate, thinner adapter than `zcash_pool_migration::wallet::
-//! WalletMigration`: that type's constructor requires a `UnifiedSpendingKey` unconditionally
-//! (its `orchard_fvk()` is derived from the usk), but several JNI entry points in `migration.rs`
-//! only ever plan or build unsigned PCZTs (no usk available at that call site — mirroring the old
-//! `zcash_pool_migration` crate, which likewise derived the FVK from the account's stored UFVK,
-//! not from a spending key). `Backend::usk` is therefore optional: every method needed for
-//! planning/building unsigned PCZTs (`orchard_fvk`, `resolve_wallet_note`,
-//! `spendable_orchard_note_values`, `chain_tip_height`) works without it; only `sign()` requires
-//! one, and `zcash_pool_migration::engine::build_preparation_unsigned` never calls it (only
-//! `commit_preparation`'s in-process-signing path does).
+//! WalletMigration`: that type is handed the account's `UnifiedFullViewingKey` and an abstract
+//! store, whereas a JNI entry point names an account and a wallet database path and nothing else.
+//! This adapter therefore reads the account's Orchard full viewing key out of the wallet itself
+//! and opens the `PoolMigrations` store over the same connection.
+//!
+//! No key with spend authority is held here. In-process signing takes the account's Orchard
+//! spending key as an argument to `zcash_pool_migration::engine::commit_preparation`, live for
+//! that one call, so one `Backend` serves the planning, unsigned-build, proving and persistence
+//! paths alike whether or not the caller has a spending key.
 
 use std::convert::Infallible;
 
 use rusqlite::Connection;
 
 use incrementalmerkletree::Position;
-use orchard::keys::{FullViewingKey, Scope, SpendAuthorizingKey};
+use orchard::keys::{FullViewingKey, Scope};
 use orchard::note::Note as OrchardNote;
 use zcash_client_backend::address::Receiver;
 use zcash_client_backend::data_api::MaxSpendMode;
@@ -26,7 +26,6 @@ use zcash_client_backend::data_api::wallet::input_selection::{LockFilter, Locked
 use zcash_client_backend::data_api::wallet::{ConfirmationsPolicy, propose_send_max_transfer};
 use zcash_client_backend::data_api::{Account, InputSource, WalletRead};
 use zcash_client_backend::fees::StandardFeeRule;
-use zcash_client_backend::keys::UnifiedSpendingKey;
 use zcash_client_backend::proposal::Proposal;
 use zcash_client_sqlite::AccountUuid;
 use zcash_protocol::ShieldedPool;
@@ -54,14 +53,17 @@ type SpendableNote = (OrchardNote, Position, u64);
 /// only ever instantiated over one concrete wallet type.
 pub type EngineError = anyhow::Error;
 
-/// A migration backend over the Android SDK's own wallet database, an account, an optional
-/// spending key (required only for in-process signing), and a `PoolMigrations` store borrow.
+/// A migration backend over the Android SDK's own wallet database, an account, that account's
+/// Orchard full viewing key, and a `PoolMigrations` store borrow.
 pub struct Backend<'a, W> {
     wallet: &'a W,
     account: AccountUuid,
-    usk: Option<UnifiedSpendingKey>,
+    /// The account's Orchard full viewing key, or `None` for an account whose unified key has no
+    /// Orchard component. Resolved once at construction because `MigrationCrypto::orchard_fvk` is
+    /// infallible and hands out a borrow.
+    orchard_fvk: Option<FullViewingKey>,
     /// The store carries the network parameters and a clock because, as of
-    /// `zcash_client_sqlite 0.22.0-rc.7`, `PoolMigrationWrite::store_proved_transaction` finalizes
+    /// `zcash_client_sqlite 0.22.0`, `PoolMigrationWrite::store_proved_transaction` finalizes
     /// a proved migration transaction into the wallet's own transaction tables: it recovers the
     /// transaction's outputs (needing `params`) and stamps the sent-transaction time (needing the
     /// clock). Both are unused by the read/write-state methods.
@@ -89,16 +91,22 @@ where
     pub fn new(
         wallet: &'a W,
         account: AccountUuid,
-        usk: Option<UnifiedSpendingKey>,
         conn: &'a mut Connection,
         params: Network,
     ) -> Result<Self, EngineError> {
+        let orchard_fvk = wallet
+            .get_account(account)
+            .map_err(|e| anyhow::anyhow!("account lookup failed: {e}"))?
+            .ok_or_else(|| anyhow::anyhow!("unknown account"))?
+            .ufvk()
+            .and_then(|ufvk| ufvk.orchard())
+            .cloned();
         let store = PoolMigrations::for_account(params, SystemClock, conn, account)
             .map_err(|e| anyhow::anyhow!("opening pool-migration store failed: {e:?}"))?;
         Ok(Self {
             wallet,
             account,
-            usk,
+            orchard_fvk,
             store,
             spendable: std::cell::RefCell::new(None),
         })
@@ -215,20 +223,11 @@ where
 {
     type Error = EngineError;
 
-    /// Derived from the account's stored Orchard UFVK (not from `self.usk`) so this works whether
-    /// or not a spending key was provided — matches the old `zcash_pool_migration` crate's
-    /// `account_orchard_fvk` helper.
-    fn orchard_fvk(&self) -> Result<FullViewingKey, Self::Error> {
-        let account = self
-            .wallet
-            .get_account(self.account)
-            .map_err(|e| anyhow::anyhow!("account lookup failed: {e}"))?
-            .ok_or_else(|| anyhow::anyhow!("unknown account"))?;
-        account
-            .ufvk()
-            .and_then(|ufvk| ufvk.orchard())
-            .cloned()
-            .ok_or_else(|| anyhow::anyhow!("account has no Orchard full viewing key"))
+    /// The account's stored Orchard viewing key, read from the wallet at construction. `None` is
+    /// an account whose unified key carries no Orchard component; each entry point that needs the
+    /// key reports its absence itself.
+    fn orchard_fvk(&self) -> Option<&FullViewingKey> {
+        self.orchard_fvk.as_ref()
     }
 
     /// The account's ZIP 32 derivation as the wallet records it, or `None` for an account held
@@ -255,16 +254,6 @@ where
             .get(index)
             .ok_or_else(|| anyhow::anyhow!("no spendable note at index {index}"))?;
         Ok(note)
-    }
-
-    fn sign(&self, pczt: pczt::Pczt) -> Result<pczt::Pczt, Self::Error> {
-        let usk = self
-            .usk
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("no spending key available for in-process signing"))?;
-        let ask = SpendAuthorizingKey::from(usk.orchard());
-        zcash_pool_migration::build::sign_pczt(pczt, &ask)
-            .map_err(|e| anyhow::anyhow!("signing the migration PCZT failed: {e:?}"))
     }
 }
 


### PR DESCRIPTION
Closes #2055.

`zcash_client_backend 0.24.0`, `zcash_client_sqlite 0.22.0`,
`zcash_pool_migration 0.1.0`, `zcash_primitives 0.30.1` and `zip321 0.9.0` are
now published, along with `zodl-slipstream 0.2.0` built against them. This
branch had been pinned to release candidates, so a wallet database shipped from
it was migrated by a schema upstream had not finalized — the substantive risk
#2055 raised. (`main` still carries the RC pins; it picks this up through the
usual merge-forward, which is also when GitHub will actually close the issue,
since this PR's base is not the default branch.)

### The API change being adapted to

All of the source churn comes from `zcash_pool_migration` 0.1.0, which moved
spend authority out of the backend trait:

- **`MigrationCrypto::sign` is gone.** `commit_preparation` (and
  `commit_preparation_with_funding`, `rebuild_expired_transfer`) now take
  `&orchard::keys::SpendingKey` directly, live for that one call. `Backend` no
  longer holds a `UnifiedSpendingKey`, so `commit_or_reuse` stops routing one
  through, and the two in-process-signing entry points (`signNoteSplitNative`,
  `signAndStoreMigrationScheduleNative`) pass `usk.orchard()` from their own
  closures.

- **`MigrationCrypto::orchard_fvk` is infallible and lends its key:**
  `Option<&FullViewingKey>` rather than `Result<FullViewingKey, E>`. `Backend`
  resolves the account's Orchard FVK once in `new()` (still out of the stored
  UFVK) and lends it. `None` — an account whose unified key has no Orchard
  component — is now reported by the entry points that need the key, per the new
  trait contract.

`zcash_client_backend`, `zcash_client_sqlite`, `zcash_primitives` and `zip321`
needed no source changes at all; the rest of the diff is the 51 `Backend::new`
call sites losing an argument.

### Worth a reviewer's attention

The engine now derives the FVK from the supplied spending key and compares it
against the one the backend reports, refusing with
`CommitError::WrongSpendAuthority` before anything is built. The old `sign()`
signed with whatever key it was handed, unchecked. Not reachable through the
public Kotlin API, which always passes the account's own USK, so it gets no
changelog entry — but it is a real behavioural tightening at the JNI boundary.

Two comments are corrected in passing, both on lines this diff already touches:
`migration_engine.rs` referenced `zcash_client_sqlite 0.22.0-rc.7`, and the
`slipstream-core` block still described the dependency as git-pinned, which it
has not been since 70853f24 moved it to the published crate.

### Verification

All on `--all-features`, from a clean tree:

- [x] `cargo check --all-targets --locked` — clean, zero warnings
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test` — 84 passed, 0 failed, 14 ignored (the live-wallet tests
      needing `MIGRATION_TEST_WALLET_DB`, which compile but have no fixture
      here — the in-process signing path is verified by type-checking only)
- [x] Feature matrix probed separately (default, `slipstream`,
      `android-test-fixtures`, `--all-features`) — all clean
- [x] `cargo tree -e features --features slipstream` confirms orchard's
      `unstable-voting-circuits` stays out of the resolved graph, per the
      invariant `Cargo.toml` documents
- [ ] CI green on this PR

Filed with Claude Code assistance.
