### PR TITLE
MOB-1723: report insufficient funds and multi-step PCZT proposals as typed exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `TransactionEncoderException.InsufficientFundsException` is thrown - by both the upstream and the
+  Slipstream engine - when a proposal cannot be created because the account lacks the spendable funds
+  to cover the requested amount together with its fee. It replaces
+  `ProposalFromParametersException`/`ProposalFromUriException`/`ProposalShieldingException` for that
+  specific failure, so callers no longer have to match on the Rust layer's error message (MOB-1723,
+  #680).
+- `PcztException.MultiStepProposalUnsupportedException` is thrown by `createPcztFromProposal` when the
+  given proposal needs more than one transaction. Only TEX (ZIP-320) payments produce such proposals,
+  so this is what a caller sees when it tries to pay a TEX address with an external signer (MOB-1723).
+
+### Changed
+- The Slipstream engine's `proposeTransfer`, `proposeFulfillingPaymentUri`, `proposeShielding` and
+  `proposeOrchardToIronwoodMigration` now report failures with the same `TransactionEncoderException`
+  subtypes the upstream engine uses, instead of letting the raw Rust `RuntimeException` escape
+  (MOB-1723).
+
 ## [3.1.0] - 2026-08-20
 
 ### Added

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/SdkSynchronizer.kt
@@ -31,6 +31,7 @@ import cash.z.ecc.android.sdk.internal.db.derived.DbDerivedDataRepository
 import cash.z.ecc.android.sdk.internal.db.derived.DerivedDataDb
 import cash.z.ecc.android.sdk.internal.exchange.UsdExchangeRateFetcher
 import cash.z.ecc.android.sdk.internal.ext.existsSuspend
+import cash.z.ecc.android.sdk.internal.ext.requireSingleStepForPczt
 import cash.z.ecc.android.sdk.internal.ext.tryNull
 import cash.z.ecc.android.sdk.internal.jni.RustBackend
 import cash.z.ecc.android.sdk.internal.model.LazyTorClient
@@ -1156,7 +1157,10 @@ class SdkSynchronizer private constructor(
     override suspend fun createPcztFromProposal(
         accountUuid: AccountUuid,
         proposal: Proposal
-    ) = txManager.createPcztFromProposal(accountUuid, proposal)
+    ): Pczt {
+        proposal.requireSingleStepForPczt()
+        return txManager.createPcztFromProposal(accountUuid, proposal)
+    }
 
     override suspend fun redactPcztForSigner(pczt: Pczt) = txManager.redactPcztForSigner(pczt)
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/Synchronizer.kt
@@ -328,6 +328,11 @@ interface Synchronizer {
      * @param memo the optional memo to include as part of the proposal's transactions.
      *
      * @return the proposal or an exception
+     *
+     * @throws TransactionEncoderException.InsufficientFundsException if the account cannot cover the
+     * requested amount together with the required fee
+     * @throws TransactionEncoderException.ProposalFromParametersException if the proposal cannot be
+     * created for any other reason
      */
     suspend fun proposeTransfer(
         account: Account,
@@ -357,6 +362,8 @@ interface Synchronizer {
      *
      * @return the proposal or an exception
      *
+     * @throws TransactionEncoderException.InsufficientFundsException if the account cannot cover the
+     * migration together with the required fee
      * @throws TransactionEncoderException.ProposalFromParametersException if NU6.3 is not
      * active, if any Orchard note is not yet spendable, or if the proposal cannot be created
      */
@@ -369,6 +376,11 @@ interface Synchronizer {
      * @param uri a ZIP-321 compliant payment URI String
      *
      * @return the proposal or an exception
+     *
+     * @throws TransactionEncoderException.InsufficientFundsException if the account cannot cover the
+     * requested payment together with the required fee
+     * @throws TransactionEncoderException.ProposalFromUriException if the proposal cannot be created
+     * for any other reason
      */
     suspend fun proposeFulfillingPaymentUri(
         account: Account,
@@ -390,8 +402,11 @@ interface Synchronizer {
      * @return the proposal, or null if the transparent balance that would be shielded is
      *         zero or below `shieldingThreshold`.
      *
-     * @throws Exception if `transparentReceiver` is null and there are transparent funds
-     *         in more than one of the account's transparent receivers.
+     * @throws TransactionEncoderException.InsufficientFundsException if the transparent funds do not
+     *         cover the required fee
+     * @throws TransactionEncoderException.ProposalShieldingException if the proposal cannot be
+     *         created for any other reason, e.g. if `transparentReceiver` is null and there are
+     *         transparent funds in more than one of the account's transparent receivers.
      */
     suspend fun proposeShielding(
         account: Account,
@@ -427,9 +442,14 @@ interface Synchronizer {
      *
      * @return The partially created transaction in [Pczt] format.
      *
+     * @throws PcztException.MultiStepProposalUnsupportedException if the proposal needs more than one
+     * transaction, which an external PCZT signer cannot fulfill
      * @throws PcztException.CreatePcztFromProposalException as a common indicator of the operation failure
      */
-    @Throws(PcztException.CreatePcztFromProposalException::class)
+    @Throws(
+        PcztException.MultiStepProposalUnsupportedException::class,
+        PcztException.CreatePcztFromProposalException::class
+    )
     suspend fun createPcztFromProposal(
         accountUuid: AccountUuid,
         proposal: Proposal

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/exception/Exceptions.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/exception/Exceptions.kt
@@ -520,6 +520,20 @@ sealed class PcztException(
             "Failed to extract and store transaction from PCZT with message: ${description ?: "-"}",
             cause
         )
+
+    /**
+     * Signals that the given proposal needs more than one transaction to be fulfilled, which the PCZT
+     * (external signer) flow cannot express. Only TEX (ZIP-320) payments currently produce multi-step
+     * proposals, so this is what a caller sees when it tries to pay a TEX address with an account whose
+     * key material lives in an external signer.
+     */
+    class MultiStepProposalUnsupportedException(
+        cause: Throwable? = null
+    ) : PcztException(
+            "PCZT generation does not support multi-step proposals. Only TEX (ZIP-320) payments currently produce " +
+                "multi-step proposals, so this proposal cannot be fulfilled by an external PCZT signer.",
+            cause
+        )
 }
 
 /**
@@ -586,6 +600,20 @@ sealed class TransactionEncoderException(
         val rootCause: Throwable
     ) : TransactionEncoderException(
             "The attempt to create a new proposal for shielding operation from the given parameters failed due to: " +
+                "${rootCause.message}",
+            rootCause
+        )
+
+    /**
+     * Signals that a proposal could not be created because the account does not hold enough spendable
+     * funds to cover the requested amount together with the required fee. Replaces the generic
+     * [ProposalFromParametersException]/[ProposalFromUriException]/[ProposalShieldingException] for
+     * this specific failure, so that callers can react to it by type instead of by error message.
+     */
+    data class InsufficientFundsException(
+        val rootCause: Throwable
+    ) : TransactionEncoderException(
+            "The proposal could not be created because the wallet lacks sufficient spendable funds: " +
                 "${rootCause.message}",
             rootCause
         )

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/ext/ExceptionExt.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/ext/ExceptionExt.kt
@@ -1,5 +1,6 @@
 package cash.z.ecc.android.sdk.internal.ext
 
+import cash.z.ecc.android.sdk.exception.TransactionEncoderException
 import cash.z.ecc.android.sdk.internal.Twig
 
 @Suppress("SwallowedException", "TooGenericExceptionCaught")
@@ -73,3 +74,51 @@ internal fun Throwable.isScanContinuityError(): Boolean {
     }
     return false
 }
+
+// Note: Do NOT change these texts as they match the ones the proposal machinery of
+// librustzcash/zcash_client_backend reports when an account cannot cover a spend. They are the only
+// signal the FFI gives us for this failure (cf. issue #680).
+internal const val INSUFFICIENT_BALANCE = "Insufficient balance" // $NON-NLS
+internal const val ADDITIONAL_CHANGE_OUTPUT_REQUIRED =
+    "The transaction requires an additional change output of" // $NON-NLS
+
+private const val CAUSE_CHAIN_MAX_DEPTH = 10
+
+/**
+ * Check whether this error - or any error within the first [CAUSE_CHAIN_MAX_DEPTH] links of its cause
+ * chain - is the Rust layer reporting that the account lacks the spendable funds a proposal needs.
+ * The walk is bounded and cycle-safe, as a cause chain coming across the FFI is not guaranteed to be
+ * either.
+ *
+ * @return true in case of the check match, false otherwise
+ */
+internal fun Throwable.indicatesInsufficientFunds(): Boolean {
+    val markers = listOf(INSUFFICIENT_BALANCE, ADDITIONAL_CHANGE_OUTPUT_REQUIRED)
+    val visited = mutableSetOf<Throwable>()
+    var current: Throwable? = this
+    var depth = 0
+    while (current != null && depth < CAUSE_CHAIN_MAX_DEPTH && visited.add(current)) {
+        val message = current.message
+        if (message != null && markers.any { message.contains(it, ignoreCase = true) }) {
+            return true
+        }
+        current = current.cause
+        depth++
+    }
+    return false
+}
+
+/**
+ * Maps a failed proposal attempt onto the typed exception that describes it: an insufficient-funds
+ * failure - whatever the propose operation was - becomes
+ * [TransactionEncoderException.InsufficientFundsException]; anything else is handed to the
+ * per-operation [fallback] wrapper.
+ */
+internal fun Throwable.toProposalException(
+    fallback: (Throwable) -> TransactionEncoderException
+): TransactionEncoderException =
+    if (indicatesInsufficientFunds()) {
+        TransactionEncoderException.InsufficientFundsException(this)
+    } else {
+        fallback(this)
+    }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/ext/ProposalExt.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/ext/ProposalExt.kt
@@ -1,0 +1,21 @@
+package cash.z.ecc.android.sdk.internal.ext
+
+import cash.z.ecc.android.sdk.exception.PcztException
+import cash.z.ecc.android.sdk.model.Proposal
+
+/**
+ * Guards the PCZT (external signer) flow against proposals it cannot express. A PCZT carries exactly
+ * one transaction, so a proposal that needs several steps - which in this wallet only a TEX (ZIP-320)
+ * payment produces - can never be fulfilled through an external signer. The Rust layer rejects the
+ * same shape, but untyped; the step count is available here, so the failure is detected structurally
+ * and reported as [PcztException.MultiStepProposalUnsupportedException] before any FFI call is made.
+ *
+ * @throws PcztException.MultiStepProposalUnsupportedException if the proposal needs more than one
+ * transaction
+ */
+@Throws(PcztException.MultiStepProposalUnsupportedException::class)
+internal fun Proposal.requireSingleStepForPczt() {
+    if (transactionCount() > 1) {
+        throw PcztException.MultiStepProposalUnsupportedException()
+    }
+}

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/TransactionEncoderImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/transaction/TransactionEncoderImpl.kt
@@ -6,6 +6,7 @@ import cash.z.ecc.android.sdk.ext.masked
 import cash.z.ecc.android.sdk.internal.SaplingParamFetcher
 import cash.z.ecc.android.sdk.internal.Twig
 import cash.z.ecc.android.sdk.internal.TypesafeBackend
+import cash.z.ecc.android.sdk.internal.ext.toProposalException
 import cash.z.ecc.android.sdk.internal.model.EncodedTransaction
 import cash.z.ecc.android.sdk.internal.repository.DerivedDataRepository
 import cash.z.ecc.android.sdk.model.Account
@@ -39,9 +40,14 @@ internal class TransactionEncoderImpl(
      *
      * @return the proposal or an exception
      *
+     * @throws TransactionEncoderException.InsufficientFundsException if the account cannot cover the
+     * requested payment together with its fee
      * @throws TransactionEncoderException.ProposalFromUriException
      */
-    @Throws(TransactionEncoderException.ProposalFromUriException::class)
+    @Throws(
+        TransactionEncoderException.InsufficientFundsException::class,
+        TransactionEncoderException.ProposalFromUriException::class
+    )
     override suspend fun proposeTransferFromUri(
         account: Account,
         uri: String
@@ -60,11 +66,14 @@ internal class TransactionEncoderImpl(
         }.onFailure {
             Twig.error(it) { "Caught exception while creating proposal from URI String." }
         }.getOrElse {
-            throw TransactionEncoderException.ProposalFromUriException(it)
+            throw it.toProposalException(TransactionEncoderException::ProposalFromUriException)
         }
     }
 
-    @Throws(TransactionEncoderException.ProposalFromParametersException::class)
+    @Throws(
+        TransactionEncoderException.InsufficientFundsException::class,
+        TransactionEncoderException.ProposalFromParametersException::class
+    )
     override suspend fun proposeOrchardToIronwoodMigration(account: Account): Proposal {
         Twig.debug { "creating proposal to migrate the Orchard balance into Ironwood" }
 
@@ -75,11 +84,14 @@ internal class TransactionEncoderImpl(
         }.onFailure {
             Twig.error(it) { "Caught exception while creating the migration proposal." }
         }.getOrElse {
-            throw TransactionEncoderException.ProposalFromParametersException(it)
+            throw it.toProposalException(TransactionEncoderException::ProposalFromParametersException)
         }
     }
 
-    @Throws(TransactionEncoderException.ProposalFromParametersException::class)
+    @Throws(
+        TransactionEncoderException.InsufficientFundsException::class,
+        TransactionEncoderException.ProposalFromParametersException::class
+    )
     override suspend fun proposeTransfer(
         account: Account,
         recipient: String,
@@ -103,11 +115,14 @@ internal class TransactionEncoderImpl(
         }.onFailure {
             Twig.error(it) { "Caught exception while creating proposal." }
         }.getOrElse {
-            throw TransactionEncoderException.ProposalFromParametersException(it)
+            throw it.toProposalException(TransactionEncoderException::ProposalFromParametersException)
         }
     }
 
-    @Throws(TransactionEncoderException.ProposalShieldingException::class)
+    @Throws(
+        TransactionEncoderException.InsufficientFundsException::class,
+        TransactionEncoderException.ProposalShieldingException::class
+    )
     override suspend fun proposeShielding(
         account: Account,
         shieldingThreshold: Zatoshi,
@@ -117,14 +132,11 @@ internal class TransactionEncoderImpl(
         runCatching {
             backend.proposeShielding(account, shieldingThreshold.value, memo, transparentReceiver)
         }.onFailure {
-            // TODO [#680]: if this error matches: Insufficient balance (have 0, need 1000 including fee)
-            //  then consider custom error that says no UTXOs existed to shield
-            // TODO [#680]: https://github.com/zcash/zcash-android-wallet-sdk/issues/680
             Twig.error(it) { "proposeShielding failed" }
         }.onSuccess { result ->
             Twig.info { "Result of proposeShielding: ${result?.toPrettyString()}" }
         }.getOrElse {
-            throw TransactionEncoderException.ProposalShieldingException(it)
+            throw it.toProposalException(TransactionEncoderException::ProposalShieldingException)
         }
 
     @Throws(

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/ext/ExceptionExtTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/ext/ExceptionExtTest.kt
@@ -1,11 +1,18 @@
 package cash.z.ecc.android.sdk.ext
 
+import cash.z.ecc.android.sdk.exception.TransactionEncoderException
+import cash.z.ecc.android.sdk.internal.ext.ADDITIONAL_CHANGE_OUTPUT_REQUIRED
 import cash.z.ecc.android.sdk.internal.ext.BLOCK_HEIGHT_DISCONTINUITY
+import cash.z.ecc.android.sdk.internal.ext.INSUFFICIENT_BALANCE
 import cash.z.ecc.android.sdk.internal.ext.PREV_HASH_MISMATCH
 import cash.z.ecc.android.sdk.internal.ext.TREE_SIZE_MISMATCH
+import cash.z.ecc.android.sdk.internal.ext.indicatesInsufficientFunds
 import cash.z.ecc.android.sdk.internal.ext.isScanContinuityError
+import cash.z.ecc.android.sdk.internal.ext.toProposalException
 import kotlin.test.Test
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class ExceptionExtTest {
@@ -25,5 +32,85 @@ class ExceptionExtTest {
         assertFalse { RuntimeException("Text").isScanContinuityError() }
         assertFalse { RuntimeException("").isScanContinuityError() }
         assertFalse { RuntimeException(PREV_HASH_MISMATCH.drop(1)).isScanContinuityError() }
+    }
+
+    @Test
+    fun indicates_insufficient_funds() {
+        assertTrue {
+            RuntimeException("Insufficient balance (have 0, need 1510000 including fee)")
+                .indicatesInsufficientFunds()
+        }
+        assertTrue { RuntimeException(INSUFFICIENT_BALANCE.lowercase()).indicatesInsufficientFunds() }
+        assertTrue { RuntimeException(INSUFFICIENT_BALANCE.uppercase()).indicatesInsufficientFunds() }
+        assertTrue {
+            RuntimeException("$ADDITIONAL_CHANGE_OUTPUT_REQUIRED 10000 zatoshis").indicatesInsufficientFunds()
+        }
+    }
+
+    @Test
+    fun indicates_insufficient_funds_through_a_nested_cause() {
+        val root = RuntimeException(INSUFFICIENT_BALANCE)
+        val wrapped = IllegalStateException("proposal failed", RuntimeException("backend failed", root))
+
+        assertTrue { wrapped.indicatesInsufficientFunds() }
+    }
+
+    @Test
+    fun does_not_indicate_insufficient_funds() {
+        assertFalse { RuntimeException("the database is locked").indicatesInsufficientFunds() }
+        assertFalse { RuntimeException().indicatesInsufficientFunds() }
+        assertFalse { RuntimeException(INSUFFICIENT_BALANCE.drop(1)).indicatesInsufficientFunds() }
+    }
+
+    @Test
+    fun insufficient_funds_detection_terminates_on_a_cause_cycle() {
+        val first = SelfCausedException("first")
+        val second = SelfCausedException("second")
+        first.initCauseTo(second)
+        second.initCauseTo(first)
+
+        assertFalse { first.indicatesInsufficientFunds() }
+    }
+
+    @Test
+    fun insufficient_funds_detection_is_bounded_in_depth() {
+        var deepest: Throwable = RuntimeException(INSUFFICIENT_BALANCE)
+        repeat(20) { deepest = RuntimeException("wrapper", deepest) }
+
+        assertFalse { deepest.indicatesInsufficientFunds() }
+    }
+
+    @Test
+    fun to_proposal_exception_prefers_the_insufficient_funds_type() {
+        val cause = RuntimeException(INSUFFICIENT_BALANCE)
+
+        val exception = cause.toProposalException(TransactionEncoderException::ProposalFromParametersException)
+
+        assertIs<TransactionEncoderException.InsufficientFundsException>(exception)
+        assertSame(cause, exception.rootCause)
+    }
+
+    @Test
+    fun to_proposal_exception_falls_back_to_the_per_operation_wrapper() {
+        val cause = RuntimeException("the database is locked")
+
+        val exception = cause.toProposalException(TransactionEncoderException::ProposalFromUriException)
+
+        assertIs<TransactionEncoderException.ProposalFromUriException>(exception)
+        assertSame(cause, exception.rootCause)
+    }
+
+    /** A [Throwable] whose cause can be pointed at another instance, so a cycle can be constructed. */
+    private class SelfCausedException(
+        message: String
+    ) : RuntimeException(message) {
+        private var selfCause: Throwable? = null
+
+        fun initCauseTo(other: Throwable) {
+            selfCause = other
+        }
+
+        override val cause: Throwable?
+            get() = selfCause
     }
 }

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/ext/ProposalExtTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/ext/ProposalExtTest.kt
@@ -1,0 +1,40 @@
+package cash.z.ecc.android.sdk.ext
+
+import cash.z.ecc.android.sdk.exception.PcztException
+import cash.z.ecc.android.sdk.internal.ext.requireSingleStepForPczt
+import cash.z.ecc.android.sdk.internal.model.ProposalUnsafe
+import cash.z.ecc.android.sdk.model.Proposal
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+/**
+ * A PCZT carries exactly one transaction, so the step count of a proposal - not the wording of a Rust
+ * error - decides whether an external signer can fulfill it. Only TEX (ZIP-320) payments produce more
+ * than one step in this wallet.
+ */
+class ProposalExtTest {
+    @Test
+    fun single_step_proposal_passes_the_pczt_guard() {
+        proposal(transactionCount = 1).requireSingleStepForPczt()
+    }
+
+    @Test
+    fun multi_step_proposal_is_rejected_by_the_pczt_guard() {
+        assertFailsWith<PcztException.MultiStepProposalUnsupportedException> {
+            proposal(transactionCount = 2).requireSingleStepForPczt()
+        }
+    }
+
+    private fun proposal(transactionCount: Int): Proposal {
+        val proposalUnsafe = mock(ProposalUnsafe::class.java)
+        `when`(proposalUnsafe.totalFeeRequired()).thenReturn(FEE)
+        `when`(proposalUnsafe.transactionCount()).thenReturn(transactionCount)
+        return Proposal.fromUnsafe(proposalUnsafe)
+    }
+
+    private companion object {
+        const val FEE = 1_000L
+    }
+}

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/transaction/TransactionEncoderImplErrorMappingTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/transaction/TransactionEncoderImplErrorMappingTest.kt
@@ -1,0 +1,156 @@
+package cash.z.ecc.android.sdk.internal.transaction
+
+import cash.z.ecc.android.sdk.exception.TransactionEncoderException
+import cash.z.ecc.android.sdk.internal.SaplingParamFetcher
+import cash.z.ecc.android.sdk.internal.TypesafeBackend
+import cash.z.ecc.android.sdk.internal.repository.DerivedDataRepository
+import cash.z.ecc.android.sdk.model.Account
+import cash.z.ecc.android.sdk.model.AccountUuid
+import cash.z.ecc.android.sdk.model.Zatoshi
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+
+/**
+ * The upstream twin of [com.zodl.slipstream.internal.spend.SlipstreamSpendServiceErrorMappingTest]:
+ * both engines must report the Rust layer's insufficient-funds failure as the same typed exception,
+ * and keep the per-operation wrapper for everything else.
+ */
+class TransactionEncoderImplErrorMappingTest {
+    private val account = Account.new(AccountUuid.new(ByteArray(ACCOUNT_UUID_SIZE)))
+
+    private val insufficientFunds = RuntimeException("Insufficient balance (have 0, need 1510000 including fee)")
+
+    private val unrelated = RuntimeException("the database is locked")
+
+    @Test
+    fun proposeTransferMapsInsufficientBalance() =
+        runBlocking {
+            val backend = mock(TypesafeBackend::class.java)
+            `when`(backend.proposeTransfer(account, RECIPIENT, AMOUNT.value, null)).thenThrow(insufficientFunds)
+
+            val exception =
+                assertFailsWith<TransactionEncoderException.InsufficientFundsException> {
+                    encoder(backend).proposeTransfer(account, RECIPIENT, AMOUNT, null)
+                }
+
+            assertSame(insufficientFunds, exception.rootCause)
+            assertSame(insufficientFunds, exception.cause)
+        }
+
+    @Test
+    fun proposeTransferMapsOtherFailuresToTheParametersWrapper() =
+        runBlocking {
+            val backend = mock(TypesafeBackend::class.java)
+            `when`(backend.proposeTransfer(account, RECIPIENT, AMOUNT.value, null)).thenThrow(unrelated)
+
+            val exception =
+                assertFailsWith<TransactionEncoderException.ProposalFromParametersException> {
+                    encoder(backend).proposeTransfer(account, RECIPIENT, AMOUNT, null)
+                }
+
+            assertSame(unrelated, exception.rootCause)
+        }
+
+    @Test
+    fun proposeTransferFromUriMapsInsufficientBalance() =
+        runBlocking {
+            val backend = mock(TypesafeBackend::class.java)
+            `when`(backend.proposeTransferFromUri(account, URI)).thenThrow(insufficientFunds)
+
+            val exception =
+                assertFailsWith<TransactionEncoderException.InsufficientFundsException> {
+                    encoder(backend).proposeTransferFromUri(account, URI)
+                }
+
+            assertSame(insufficientFunds, exception.rootCause)
+        }
+
+    @Test
+    fun proposeTransferFromUriMapsOtherFailuresToTheUriWrapper() =
+        runBlocking {
+            val backend = mock(TypesafeBackend::class.java)
+            `when`(backend.proposeTransferFromUri(account, URI)).thenThrow(unrelated)
+
+            val exception =
+                assertFailsWith<TransactionEncoderException.ProposalFromUriException> {
+                    encoder(backend).proposeTransferFromUri(account, URI)
+                }
+
+            assertSame(unrelated, exception.rootCause)
+        }
+
+    @Test
+    fun proposeShieldingMapsInsufficientBalance() =
+        runBlocking {
+            val backend = mock(TypesafeBackend::class.java)
+            `when`(backend.proposeShielding(account, THRESHOLD.value, null, null)).thenThrow(insufficientFunds)
+
+            val exception =
+                assertFailsWith<TransactionEncoderException.InsufficientFundsException> {
+                    encoder(backend).proposeShielding(account, THRESHOLD, null, null)
+                }
+
+            assertSame(insufficientFunds, exception.rootCause)
+        }
+
+    @Test
+    fun proposeShieldingMapsOtherFailuresToTheShieldingWrapper() =
+        runBlocking {
+            val backend = mock(TypesafeBackend::class.java)
+            `when`(backend.proposeShielding(account, THRESHOLD.value, null, null)).thenThrow(unrelated)
+
+            val exception =
+                assertFailsWith<TransactionEncoderException.ProposalShieldingException> {
+                    encoder(backend).proposeShielding(account, THRESHOLD, null, null)
+                }
+
+            assertSame(unrelated, exception.rootCause)
+        }
+
+    @Test
+    fun proposeOrchardToIronwoodMigrationMapsInsufficientBalance() =
+        runBlocking {
+            val backend = mock(TypesafeBackend::class.java)
+            `when`(backend.proposeOrchardToIronwoodMigration(account)).thenThrow(insufficientFunds)
+
+            val exception =
+                assertFailsWith<TransactionEncoderException.InsufficientFundsException> {
+                    encoder(backend).proposeOrchardToIronwoodMigration(account)
+                }
+
+            assertSame(insufficientFunds, exception.rootCause)
+        }
+
+    @Test
+    fun proposeOrchardToIronwoodMigrationMapsOtherFailuresToTheParametersWrapper() =
+        runBlocking {
+            val backend = mock(TypesafeBackend::class.java)
+            `when`(backend.proposeOrchardToIronwoodMigration(account)).thenThrow(unrelated)
+
+            val exception =
+                assertFailsWith<TransactionEncoderException.ProposalFromParametersException> {
+                    encoder(backend).proposeOrchardToIronwoodMigration(account)
+                }
+
+            assertSame(unrelated, exception.rootCause)
+        }
+
+    private fun encoder(backend: TypesafeBackend): TransactionEncoderImpl =
+        TransactionEncoderImpl(
+            backend = backend,
+            saplingParamFetcher = mock(SaplingParamFetcher::class.java),
+            repository = mock(DerivedDataRepository::class.java)
+        )
+
+    private companion object {
+        const val ACCOUNT_UUID_SIZE = 16
+        const val RECIPIENT = "recipient"
+        const val URI = "zcash:recipient?amount=1"
+        val AMOUNT = Zatoshi(100_000L)
+        val THRESHOLD = Zatoshi(100_000L)
+    }
+}

--- a/slipstream-lib/src/main/java/com/zodl/slipstream/SlipstreamSynchronizer.kt
+++ b/slipstream-lib/src/main/java/com/zodl/slipstream/SlipstreamSynchronizer.kt
@@ -1006,7 +1006,12 @@ class SlipstreamSynchronizer internal constructor(
     ): Pczt {
         awaitReady()
         return runCatchingCancellable { spendService.createPcztFromProposal(accountUuid, proposal) }
-            .getOrElse { throw PcztException.CreatePcztFromProposalException(it.message, it) }
+            .getOrElse {
+                throw when (it) {
+                    is PcztException.MultiStepProposalUnsupportedException -> it
+                    else -> PcztException.CreatePcztFromProposalException(it.message, it)
+                }
+            }
     }
 
     override suspend fun redactPcztForSigner(pczt: Pczt): Pczt {

--- a/slipstream-lib/src/main/java/com/zodl/slipstream/internal/spend/SlipstreamSpendService.kt
+++ b/slipstream-lib/src/main/java/com/zodl/slipstream/internal/spend/SlipstreamSpendService.kt
@@ -2,7 +2,11 @@
 
 package com.zodl.slipstream.internal.spend
 
+import cash.z.ecc.android.sdk.exception.PcztException
+import cash.z.ecc.android.sdk.exception.TransactionEncoderException
 import cash.z.ecc.android.sdk.internal.Backend
+import cash.z.ecc.android.sdk.internal.ext.requireSingleStepForPczt
+import cash.z.ecc.android.sdk.internal.ext.toProposalException
 import cash.z.ecc.android.sdk.internal.transaction.submitTransaction
 import cash.z.ecc.android.sdk.model.Account
 import cash.z.ecc.android.sdk.model.AccountUuid
@@ -15,6 +19,7 @@ import cash.z.ecc.android.sdk.model.UnifiedSpendingKey
 import cash.z.ecc.android.sdk.model.Zatoshi
 import co.electriccoin.lightwallet.client.CombinedWalletClient
 import com.zodl.slipstream.internal.SlipstreamEngine
+import com.zodl.slipstream.internal.runCatchingCancellable
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -45,35 +50,69 @@ internal class SlipstreamSpendService(
     private val ensureSaplingParams: suspend () -> Unit,
     private val readRawTransaction: suspend (FirstClassByteArray) -> FirstClassByteArray
 ) {
+    @Throws(
+        TransactionEncoderException.InsufficientFundsException::class,
+        TransactionEncoderException.ProposalFromParametersException::class
+    )
     suspend fun proposeTransfer(
         account: Account,
         recipient: String,
         amount: Zatoshi,
         memo: String
-    ): Proposal = Proposal.fromUnsafe(backend.proposeTransfer(account.accountUuid.value, recipient, amount.value, memo.toMemoBytesOrNull()))
+    ): Proposal =
+        runCatchingCancellable {
+            Proposal.fromUnsafe(backend.proposeTransfer(account.accountUuid.value, recipient, amount.value, memo.toMemoBytesOrNull()))
+        }.getOrElse {
+            throw it.toProposalException(TransactionEncoderException::ProposalFromParametersException)
+        }
 
+    @Throws(
+        TransactionEncoderException.InsufficientFundsException::class,
+        TransactionEncoderException.ProposalFromUriException::class
+    )
     suspend fun proposeFulfillingPaymentUri(
         account: Account,
         uri: String
-    ): Proposal = Proposal.fromUnsafe(backend.proposeTransferFromUri(account.accountUuid.value, uri))
+    ): Proposal =
+        runCatchingCancellable {
+            Proposal.fromUnsafe(backend.proposeTransferFromUri(account.accountUuid.value, uri))
+        }.getOrElse {
+            throw it.toProposalException(TransactionEncoderException::ProposalFromUriException)
+        }
 
+    @Throws(
+        TransactionEncoderException.InsufficientFundsException::class,
+        TransactionEncoderException.ProposalShieldingException::class
+    )
     suspend fun proposeShielding(
         account: Account,
         shieldingThreshold: Zatoshi,
         memo: String,
         transparentReceiver: String?
     ): Proposal? =
-        backend
-            .proposeShielding(account.accountUuid.value, shieldingThreshold.value, memo.toMemoBytesOrNull(), transparentReceiver)
-            ?.let(Proposal::fromUnsafe)
+        runCatchingCancellable {
+            backend
+                .proposeShielding(account.accountUuid.value, shieldingThreshold.value, memo.toMemoBytesOrNull(), transparentReceiver)
+                ?.let(Proposal::fromUnsafe)
+        }.getOrElse {
+            throw it.toProposalException(TransactionEncoderException::ProposalShieldingException)
+        }
 
     /**
      * Proposes the one-shot Orchard to Ironwood crossing: a single transaction carrying the
      * account's entire Orchard balance, which any chain observer can read off as such. The
      * scheduled, denomination-splitting alternative is [com.zodl.slipstream.MigrationSdk].
      */
+    @Throws(
+        TransactionEncoderException.InsufficientFundsException::class,
+        TransactionEncoderException.ProposalFromParametersException::class
+    )
     suspend fun proposeOrchardToIronwoodMigration(account: Account): Proposal =
-        Proposal.fromUnsafe(backend.proposeOrchardToIronwoodMigration(account.accountUuid.value))
+        runCatchingCancellable {
+            Proposal.fromUnsafe(backend.proposeOrchardToIronwoodMigration(account.accountUuid.value))
+        }.getOrElse {
+            throw it.toProposalException(TransactionEncoderException::ProposalFromParametersException)
+        }
 
     /**
      * Store-first (S-SPEND): `create` already wrote the transactions into `data.db`, so the FIRST
@@ -95,10 +134,14 @@ internal class SlipstreamSpendService(
             engine.notifyTxChange()
         }
 
+    @Throws(PcztException.MultiStepProposalUnsupportedException::class)
     suspend fun createPcztFromProposal(
         accountUuid: AccountUuid,
         proposal: Proposal
-    ): Pczt = Pczt(backend.createPcztFromProposal(accountUuid.value, proposal.toUnsafe()))
+    ): Pczt {
+        proposal.requireSingleStepForPczt()
+        return Pczt(backend.createPcztFromProposal(accountUuid.value, proposal.toUnsafe()))
+    }
 
     suspend fun redactPcztForSigner(pczt: Pczt): Pczt = Pczt(backend.redactPcztForSigner(pczt.toByteArray()))
 

--- a/slipstream-lib/src/test/java/com/zodl/slipstream/internal/spend/SlipstreamSpendServiceErrorMappingTest.kt
+++ b/slipstream-lib/src/test/java/com/zodl/slipstream/internal/spend/SlipstreamSpendServiceErrorMappingTest.kt
@@ -1,0 +1,225 @@
+package com.zodl.slipstream.internal.spend
+
+import cash.z.ecc.android.sdk.exception.PcztException
+import cash.z.ecc.android.sdk.exception.TransactionEncoderException
+import cash.z.ecc.android.sdk.internal.Backend
+import cash.z.ecc.android.sdk.internal.model.ProposalUnsafe
+import cash.z.ecc.android.sdk.model.Account
+import cash.z.ecc.android.sdk.model.AccountUuid
+import cash.z.ecc.android.sdk.model.FirstClassByteArray
+import cash.z.ecc.android.sdk.model.Proposal
+import cash.z.ecc.android.sdk.model.SdkFlags
+import cash.z.ecc.android.sdk.model.Zatoshi
+import co.electriccoin.lightwallet.client.CombinedWalletClient
+import com.zodl.slipstream.internal.SlipstreamEngine
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.`when`
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+
+/**
+ * Pins the propose-failure mapping of [SlipstreamSpendService]: the Rust layer's untyped
+ * insufficient-funds failure becomes [TransactionEncoderException.InsufficientFundsException] no
+ * matter which propose entry point produced it, everything else keeps the per-operation wrapper the
+ * upstream `TransactionEncoderImpl` uses, and a cancellation still travels as itself. Also covers the
+ * structural TEX/multi-step guard on the PCZT path.
+ *
+ * Conventions follow [SlipstreamSpendServiceOrderingTest]: plain Mockito with exact-argument stubs
+ * (no matcher library is a project dependency), JUnit4 and `runBlocking`.
+ */
+class SlipstreamSpendServiceErrorMappingTest {
+    private val account = Account.new(AccountUuid.new(ByteArray(ACCOUNT_UUID_SIZE)))
+
+    private val insufficientFunds = RuntimeException("Insufficient balance (have 100, need 200 including fee)")
+
+    private val unrelated = RuntimeException("the database is locked")
+
+    @Test
+    fun proposeTransferMapsInsufficientBalance() =
+        runBlocking {
+            val backend = mock(Backend::class.java)
+            `when`(backend.proposeTransfer(account.accountUuid.value, RECIPIENT, AMOUNT.value, null))
+                .thenThrow(insufficientFunds)
+
+            val exception =
+                assertFailsWith<TransactionEncoderException.InsufficientFundsException> {
+                    service(backend).proposeTransfer(account, RECIPIENT, AMOUNT, "")
+                }
+
+            assertSame(insufficientFunds, exception.rootCause)
+            assertSame(insufficientFunds, exception.cause)
+        }
+
+    @Test
+    fun proposeTransferMapsOtherFailuresToTheParametersWrapper() =
+        runBlocking {
+            val backend = mock(Backend::class.java)
+            `when`(backend.proposeTransfer(account.accountUuid.value, RECIPIENT, AMOUNT.value, null))
+                .thenThrow(unrelated)
+
+            val exception =
+                assertFailsWith<TransactionEncoderException.ProposalFromParametersException> {
+                    service(backend).proposeTransfer(account, RECIPIENT, AMOUNT, "")
+                }
+
+            assertSame(unrelated, exception.rootCause)
+        }
+
+    @Test
+    fun proposeTransferPropagatesCancellation() =
+        runBlocking {
+            val cancellation = CancellationException("cancelled")
+            val backend = mock(Backend::class.java)
+            `when`(backend.proposeTransfer(account.accountUuid.value, RECIPIENT, AMOUNT.value, null))
+                .thenThrow(cancellation)
+
+            val thrown =
+                assertFailsWith<CancellationException> {
+                    service(backend).proposeTransfer(account, RECIPIENT, AMOUNT, "")
+                }
+
+            assertSame(cancellation, thrown)
+        }
+
+    @Test
+    fun proposeFulfillingPaymentUriMapsInsufficientBalance() =
+        runBlocking {
+            val backend = mock(Backend::class.java)
+            `when`(backend.proposeTransferFromUri(account.accountUuid.value, URI)).thenThrow(insufficientFunds)
+
+            val exception =
+                assertFailsWith<TransactionEncoderException.InsufficientFundsException> {
+                    service(backend).proposeFulfillingPaymentUri(account, URI)
+                }
+
+            assertSame(insufficientFunds, exception.rootCause)
+        }
+
+    @Test
+    fun proposeFulfillingPaymentUriMapsOtherFailuresToTheUriWrapper() =
+        runBlocking {
+            val backend = mock(Backend::class.java)
+            `when`(backend.proposeTransferFromUri(account.accountUuid.value, URI)).thenThrow(unrelated)
+
+            val exception =
+                assertFailsWith<TransactionEncoderException.ProposalFromUriException> {
+                    service(backend).proposeFulfillingPaymentUri(account, URI)
+                }
+
+            assertSame(unrelated, exception.rootCause)
+        }
+
+    @Test
+    fun proposeShieldingMapsInsufficientBalance() =
+        runBlocking {
+            val backend = mock(Backend::class.java)
+            `when`(backend.proposeShielding(account.accountUuid.value, THRESHOLD.value, null, null))
+                .thenThrow(insufficientFunds)
+
+            val exception =
+                assertFailsWith<TransactionEncoderException.InsufficientFundsException> {
+                    service(backend).proposeShielding(account, THRESHOLD, "", null)
+                }
+
+            assertSame(insufficientFunds, exception.rootCause)
+        }
+
+    @Test
+    fun proposeShieldingMapsOtherFailuresToTheShieldingWrapper() =
+        runBlocking {
+            val backend = mock(Backend::class.java)
+            `when`(backend.proposeShielding(account.accountUuid.value, THRESHOLD.value, null, null))
+                .thenThrow(unrelated)
+
+            val exception =
+                assertFailsWith<TransactionEncoderException.ProposalShieldingException> {
+                    service(backend).proposeShielding(account, THRESHOLD, "", null)
+                }
+
+            assertSame(unrelated, exception.rootCause)
+        }
+
+    @Test
+    fun proposeOrchardToIronwoodMigrationMapsInsufficientBalance() =
+        runBlocking {
+            val backend = mock(Backend::class.java)
+            `when`(backend.proposeOrchardToIronwoodMigration(account.accountUuid.value)).thenThrow(insufficientFunds)
+
+            val exception =
+                assertFailsWith<TransactionEncoderException.InsufficientFundsException> {
+                    service(backend).proposeOrchardToIronwoodMigration(account)
+                }
+
+            assertSame(insufficientFunds, exception.rootCause)
+        }
+
+    @Test
+    fun proposeOrchardToIronwoodMigrationMapsOtherFailuresToTheParametersWrapper() =
+        runBlocking {
+            val backend = mock(Backend::class.java)
+            `when`(backend.proposeOrchardToIronwoodMigration(account.accountUuid.value)).thenThrow(unrelated)
+
+            val exception =
+                assertFailsWith<TransactionEncoderException.ProposalFromParametersException> {
+                    service(backend).proposeOrchardToIronwoodMigration(account)
+                }
+
+            assertSame(unrelated, exception.rootCause)
+        }
+
+    @Test
+    fun createPcztFromProposalRejectsMultiStepProposalsBeforeTouchingTheBackend() =
+        runBlocking {
+            val backend = mock(Backend::class.java)
+
+            assertFailsWith<PcztException.MultiStepProposalUnsupportedException> {
+                service(backend).createPcztFromProposal(account.accountUuid, proposal(transactionCount = 2))
+            }
+
+            verifyNoInteractions(backend)
+        }
+
+    @Test
+    fun createPcztFromProposalAcceptsSingleStepProposals() =
+        runBlocking {
+            val backend = mock(Backend::class.java)
+            val proposal = proposal(transactionCount = 1)
+            val pcztBytes = byteArrayOf(7, 7, 7)
+            `when`(backend.createPcztFromProposal(account.accountUuid.value, proposal.toUnsafe()))
+                .thenReturn(pcztBytes)
+
+            val pczt = service(backend).createPcztFromProposal(account.accountUuid, proposal)
+
+            assertSame(pcztBytes, pczt.toByteArray())
+        }
+
+    private fun proposal(transactionCount: Int): Proposal {
+        val proposalUnsafe = mock(ProposalUnsafe::class.java)
+        `when`(proposalUnsafe.totalFeeRequired()).thenReturn(FEE)
+        `when`(proposalUnsafe.transactionCount()).thenReturn(transactionCount)
+        return Proposal.fromUnsafe(proposalUnsafe)
+    }
+
+    private fun service(backend: Backend): SlipstreamSpendService =
+        SlipstreamSpendService(
+            backend = backend,
+            walletClient = mock(CombinedWalletClient::class.java),
+            engine = mock(SlipstreamEngine::class.java),
+            sdkFlags = SdkFlags(isTorEnabled = false, isExchangeRateEnabled = false),
+            ensureSaplingParams = { },
+            readRawTransaction = { FirstClassByteArray(byteArrayOf()) }
+        )
+
+    private companion object {
+        const val ACCOUNT_UUID_SIZE = 16
+        const val RECIPIENT = "recipient"
+        const val URI = "zcash:recipient?amount=1"
+        const val FEE = 1_000L
+        val AMOUNT = Zatoshi(100_000L)
+        val THRESHOLD = Zatoshi(100_000L)
+    }
+}


### PR DESCRIPTION
Closes the SDK half of [MOB-1723](https://linear.app/zodl/issue/MOB-1723/android-insufficient-balance-calculation-appears-off-not-accounting): users hitting `Insufficient balance (have X, need Y including fee)` saw Zashi's technical error screen instead of the friendly Insufficient Funds sheet, because the failure was only recognizable by string-matching — and only the upstream engine wrapped it at all.

## What changed

- **New `TransactionEncoderException.InsufficientFundsException`**, thrown by **both** engines when proposal creation fails for lack of spendable funds. The Rust-message knowledge (`"Insufficient balance"`, `"The transaction requires an additional change output of"`) lives in one internal helper, `Throwable.indicatesInsufficientFunds()`. This resolves the long-standing TODO in `TransactionEncoderImpl.proposeShielding` referencing #680.
- **`SlipstreamSpendService` propose calls are no longer bare**: all four (`proposeTransfer`, `proposeFulfillingPaymentUri`, `proposeShielding`, `proposeOrchardToIronwoodMigration`) now wrap failures via `runCatchingCancellable` into the same typed exceptions the encoder produces (`CancellationException` propagates unwrapped). Previously a raw JNI `RuntimeException` escaped to consumers.
- **New `PcztException.MultiStepProposalUnsupportedException`**: both engines reject a multi-step (ZIP-320/TEX) proposal structurally — on `Proposal.transactionCount()`, before any FFI call — instead of the untyped Rust "Multi-step proposals are not yet supported for PCZT generation" error. This lets consumers (Zashi's Keystone flows) show a proper TEX-unsupported screen from a typed signal.
- `Synchronizer` interface KDoc now documents the `@throws` contracts for the propose methods and `createPcztFromProposal`.

## ⚠️ Behavior change to review (core team)

Matched insufficient-funds failures now throw the new subtype **instead of** `ProposalFromParametersException` / `ProposalFromUriException` / `ProposalShieldingException`. Consumers catching `TransactionEncoderException` broadly are unaffected; code catching the old subtypes specifically will no longer see these failures. Zashi catches broadly.

## Tests

- `SlipstreamSpendServiceErrorMappingTest` (11, slipstream-lib): per-method typed mapping, cause preservation, cancellation pass-through, multi-step PCZT rejection before any backend interaction.
- `TransactionEncoderImplErrorMappingTest` (8), `ExceptionExtTest` (+7), `ProposalExtTest` (2) in sdk-lib.
- Full suites green: sdk-lib 156/156, slipstream-lib 161/161; ktlint + detekt clean.

---

<!-- Write any additional comments here when opening the pull request -->

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [ ] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [README.md](../blob/main/README.md), [Architecture.md](../blob/main/docs/Architecture.md), etc.)
- [ ] **Run the demo app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [README.md](../blob/main/README.md), [Architecture.md](/blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the demo app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the SDK, some aspects require manual testing. If you had to manually test 
something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the demo app to look for build failures or crashes, humans running the demo app are 
more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
