### PR TITLE
MOB-1751: Add Rust-backed cross-chain payment URI parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `PaymentUriParser`, a Rust-backed API that validates Bitcoin, Ethereum, Litecoin, and Solana
+  payment URIs and returns typed payment request models without floating-point amount conversion.
 - Shielded voting: `voteSubmission(roundId, bundleIndex, proposalId)` returns `JniVoteSubmission`,
   the chain-ready fields needed to resend a cast-vote transaction before it confirms, without the
   helper-share payloads that go stale once the tree position is recorded.

--- a/backend-lib/Cargo.lock
+++ b/backend-lib/Cargo.lock
@@ -1503,8 +1503,7 @@ dependencies = [
 [[package]]
 name = "eip681"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3c9c0416f224ce25ea2b710bf8abd4e5e41e41fe8e75685ae1519d5d5d2276"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3460a6a7be8d3e86b7556b38738e05e95a940f68#3460a6a7be8d3e86b7556b38738e05e95a940f68"
 dependencies = [
  "base64",
  "ens-normalize-rs",
@@ -3400,6 +3399,18 @@ name = "pastey"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
+name = "payment_uri"
+version = "0.1.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3460a6a7be8d3e86b7556b38738e05e95a940f68#3460a6a7be8d3e86b7556b38738e05e95a940f68"
+dependencies = [
+ "bech32",
+ "bs58",
+ "eip681",
+ "percent-encoding",
+ "serde_json",
+]
 
 [[package]]
 name = "pbkdf2"
@@ -7534,6 +7545,7 @@ dependencies = [
  "orchard",
  "paranoid-android",
  "pasta_curves",
+ "payment_uri",
  "pczt",
  "prost 0.14.4",
  "rand 0.8.7",

--- a/backend-lib/Cargo.toml
+++ b/backend-lib/Cargo.toml
@@ -59,7 +59,8 @@ zcash_proofs = "0.30"
 zcash_protocol = "0.10"
 zcash_script = "0.4"
 zip32 = "0.2"
-eip681 = "0.1.0"
+eip681 = { git = "https://github.com/zcash/librustzcash.git", rev = "3460a6a7be8d3e86b7556b38738e05e95a940f68" }
+payment_uri = { git = "https://github.com/zcash/librustzcash.git", rev = "3460a6a7be8d3e86b7556b38738e05e95a940f68", features = ["json"] }
 # Used by migration_finalize.rs to read `ShardTreeError`/`QueryError` variants when checking
 # note-witness availability at a migration transaction's anchor boundary.
 shardtree = "0.7"

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/PaymentUri.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/PaymentUri.kt
@@ -1,0 +1,7 @@
+package cash.z.ecc.android.sdk.internal
+
+/** Internal bridge for Rust-backed cross-chain payment URI parsing. */
+interface PaymentUri {
+    /** Returns the validated payment request encoded for the Kotlin boundary. */
+    fun parse(uri: String): String
+}

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/RustPaymentUriTool.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/RustPaymentUriTool.kt
@@ -1,0 +1,18 @@
+package cash.z.ecc.android.sdk.internal.jni
+
+import cash.z.ecc.android.sdk.internal.PaymentUri
+
+class RustPaymentUriTool private constructor() : PaymentUri {
+    @Throws(RuntimeException::class)
+    override fun parse(uri: String): String = parsePaymentUri(uri)
+
+    companion object {
+        suspend fun new(): PaymentUri {
+            RustBackend.loadLibrary()
+            return RustPaymentUriTool()
+        }
+
+        @JvmStatic
+        private external fun parsePaymentUri(input: String): String
+    }
+}

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -107,6 +107,7 @@ use crate::utils::{
 };
 
 mod eip681;
+mod payment_uri;
 mod migration;
 mod migration_engine;
 mod migration_keystone;

--- a/backend-lib/src/main/rust/payment_uri.rs
+++ b/backend-lib/src/main/rust/payment_uri.rs
@@ -1,0 +1,25 @@
+use jni::{
+    JNIEnv,
+    objects::{JClass, JString},
+    sys::jstring,
+};
+use payment_uri::parse_to_json;
+
+use crate::utils::{catch_unwind, exception::unwrap_exc_or, java_string_to_rust};
+
+/// Parses a supported payment URI and returns an internal JSON envelope.
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustPaymentUriTool_parsePaymentUri<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    input: JString<'local>,
+) -> jstring {
+    let result = catch_unwind(&mut env, |env| {
+        let input = java_string_to_rust(env, &input)?;
+        let json = parse_to_json(&input).map_err(|_| anyhow::anyhow!("Invalid payment URI"))?;
+        Ok(env.new_string(json)?.into_raw())
+    });
+    unwrap_exc_or(&mut env, result, std::ptr::null_mut())
+}

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/PaymentUriParserTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/PaymentUriParserTest.kt
@@ -63,4 +63,26 @@ class PaymentUriParserTest {
                 parser.parse("bitcoin:not-an-address")
             }
         }
+
+    @Test
+    @SmallTest
+    fun parsesSolanaTransactionLink() =
+        runTest {
+            val parser = PaymentUriParser.new()
+            val transaction =
+                assertIs<PaymentUriRequest.SolanaTransaction>(
+                    parser.parse("solana:https%3A%2F%2Fexample.com%2Fsolana-pay%3Forder%3D12345")
+                )
+            assertEquals("https://example.com/solana-pay?order=12345", transaction.link.value)
+        }
+
+    @Test
+    @SmallTest
+    fun rejectsUnencodedSolanaTransactionLink() =
+        runTest {
+            val parser = PaymentUriParser.new()
+            assertFailsWith<InvalidPaymentUriException> {
+                parser.parse("solana:https://example.com/solana-pay?order=12345")
+            }
+        }
 }

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/PaymentUriParserTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/PaymentUriParserTest.kt
@@ -1,0 +1,66 @@
+package cash.z.ecc.android.sdk
+
+import androidx.test.filters.SmallTest
+import cash.z.ecc.android.sdk.model.Eip681PaymentRequest
+import cash.z.ecc.android.sdk.model.InvalidPaymentUriException
+import cash.z.ecc.android.sdk.model.PaymentUriRequest
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+class PaymentUriParserTest {
+    @Test
+    @SmallTest
+    fun parsesSupportedPaymentRequests() =
+        runTest {
+            val parser = PaymentUriParser.new()
+
+            val bitcoin =
+                assertIs<PaymentUriRequest.Bitcoin>(
+                    parser.parse(
+                        "bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?amount=20.3&label=Luke-Jr"
+                    )
+                )
+            assertEquals("20.3", bitcoin.request.amount?.value)
+            assertEquals("Luke-Jr", bitcoin.request.label)
+
+            val litecoin =
+                assertIs<PaymentUriRequest.Litecoin>(
+                    parser.parse(
+                        "litecoin:LT2KVaAy1ppRuxRgrS5RNU3vBsy7RibPeA?amount=1.25&message=Coffee"
+                    )
+                )
+            assertEquals("1.25", litecoin.request.amount?.value)
+
+            val solana =
+                assertIs<PaymentUriRequest.SolanaTransfer>(
+                    parser.parse(
+                        "solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?amount=0.01" +
+                            "&spl-token=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                    )
+                )
+            assertEquals("0.01", solana.request.amount?.value)
+
+            val ethereum =
+                assertIs<PaymentUriRequest.Ethereum>(
+                    parser.parse(
+                        "ethereum:0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359?value=1e18"
+                    )
+                )
+            val native = assertIs<Eip681PaymentRequest.Native>(ethereum.request)
+            assertEquals("0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359", native.recipientAddress.value)
+            assertEquals("0xde0b6b3a7640000", native.valueHex)
+        }
+
+    @Test
+    @SmallTest
+    fun rejectsMalformedRequest() =
+        runTest {
+            val parser = PaymentUriParser.new()
+            assertFailsWith<InvalidPaymentUriException> {
+                parser.parse("bitcoin:not-an-address")
+            }
+        }
+}

--- a/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/PaymentUriParserTest.kt
+++ b/sdk-lib/src/androidTest/java/cash/z/ecc/android/sdk/PaymentUriParserTest.kt
@@ -3,12 +3,14 @@ package cash.z.ecc.android.sdk
 import androidx.test.filters.SmallTest
 import cash.z.ecc.android.sdk.model.Eip681PaymentRequest
 import cash.z.ecc.android.sdk.model.InvalidPaymentUriException
+import cash.z.ecc.android.sdk.model.PaymentUriNetwork
 import cash.z.ecc.android.sdk.model.PaymentUriRequest
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 
 class PaymentUriParserTest {
     @Test
@@ -23,6 +25,8 @@ class PaymentUriParserTest {
                         "bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?amount=20.3&label=Luke-Jr"
                     )
                 )
+            assertEquals("1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo", bitcoin.request.address.value)
+            assertEquals(PaymentUriNetwork.Mainnet, bitcoin.request.network)
             assertEquals("20.3", bitcoin.request.amount?.value)
             assertEquals("Luke-Jr", bitcoin.request.label)
 
@@ -32,7 +36,10 @@ class PaymentUriParserTest {
                         "litecoin:LT2KVaAy1ppRuxRgrS5RNU3vBsy7RibPeA?amount=1.25&message=Coffee"
                     )
                 )
+            assertEquals("LT2KVaAy1ppRuxRgrS5RNU3vBsy7RibPeA", litecoin.request.address.value)
+            assertEquals(PaymentUriNetwork.Mainnet, litecoin.request.network)
             assertEquals("1.25", litecoin.request.amount?.value)
+            assertEquals("Coffee", litecoin.request.message)
 
             val solana =
                 assertIs<PaymentUriRequest.SolanaTransfer>(
@@ -41,17 +48,76 @@ class PaymentUriParserTest {
                             "&spl-token=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
                     )
                 )
+            assertEquals("mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN", solana.request.recipient.value)
             assertEquals("0.01", solana.request.amount?.value)
+            assertEquals("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", solana.request.splToken?.value)
 
             val ethereum =
                 assertIs<PaymentUriRequest.Ethereum>(
                     parser.parse(
-                        "ethereum:0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359?value=1e18"
+                        "ethereum:0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359@42161?value=2.014e18" +
+                            "&gasLimit=21000&gasPrice=50"
                     )
                 )
             val native = assertIs<Eip681PaymentRequest.Native>(ethereum.request)
             assertEquals("0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359", native.recipientAddress.value)
-            assertEquals("0xde0b6b3a7640000", native.valueHex)
+            assertEquals("0x1bf32a5451a30000", native.valueHex)
+            assertEquals("42161", native.chainId)
+            assertEquals("0x5208", native.gasLimitHex)
+            assertEquals("0x32", native.gasPriceHex)
+        }
+
+    @Test
+    @SmallTest
+    fun parsesEthereumErc20Request() =
+        runTest {
+            val parser = PaymentUriParser.new()
+            val contract = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+            val recipient = "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"
+
+            val ethereum =
+                assertIs<PaymentUriRequest.Ethereum>(
+                    parser.parse("ethereum:$contract/transfer?address=$recipient&uint256=1000000")
+                )
+            val erc20 = assertIs<Eip681PaymentRequest.Erc20>(ethereum.request)
+            assertEquals(contract, erc20.tokenContractAddress.value)
+            assertEquals(recipient, erc20.recipientAddress.value)
+            assertEquals("0xf4240", erc20.valueHex)
+            assertNull(erc20.chainId)
+        }
+
+    @Test
+    @SmallTest
+    fun parsesUnrecognisedEip681Request() =
+        runTest {
+            val parser = PaymentUriParser.new()
+            val contract = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+            val recipient = "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"
+
+            val ethereum =
+                assertIs<PaymentUriRequest.Ethereum>(
+                    parser.parse("ethereum:$contract/approve?address=$recipient")
+                )
+            assertIs<Eip681PaymentRequest.Unrecognised>(ethereum.request)
+        }
+
+    @Test
+    @SmallTest
+    fun parsesTestnetAndRegtestNetworks() =
+        runTest {
+            val parser = PaymentUriParser.new()
+
+            val testnet =
+                assertIs<PaymentUriRequest.Bitcoin>(
+                    parser.parse("bitcoin:tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx")
+                )
+            assertEquals(PaymentUriNetwork.Testnet, testnet.request.network)
+
+            val regtest =
+                assertIs<PaymentUriRequest.Bitcoin>(
+                    parser.parse("bitcoin:bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080")
+                )
+            assertEquals(PaymentUriNetwork.Regtest, regtest.request.network)
         }
 
     @Test

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/PaymentUriParser.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/PaymentUriParser.kt
@@ -13,7 +13,18 @@ import cash.z.ecc.android.sdk.model.SolanaPayTransferRequest
 import cash.z.ecc.android.sdk.model.UtxoPaymentUriRequest
 import org.json.JSONObject
 
-/** Rust-backed parser for supported cross-chain payment request URIs. */
+/**
+ * Rust-backed parser for supported cross-chain payment request URIs, backed by librustzcash's
+ * `payment_uri` crate. Covers Bitcoin/Litecoin on-chain transfers (the on-chain subset of
+ * [BIP 321](https://github.com/bitcoin/bips/blob/master/bip-0321.mediawiki) / legacy
+ * [BIP 21](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki)), EIP-681 Ethereum
+ * requests (native and ERC-20 transfers; other ABI calls decode as
+ * [Eip681PaymentRequest.Unrecognised]), and
+ * [Solana Pay](https://github.com/solana-foundation/solana-pay/blob/master/SPEC.md)
+ * native/SPL-token transfers and interactive transaction-request links. All actual protocol
+ * parsing and validation happens in the Rust crate; this class only decodes its versioned JSON
+ * result into these Kotlin types.
+ */
 class PaymentUriParser private constructor(
     private val paymentUri: PaymentUri
 ) {

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/PaymentUriParser.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/PaymentUriParser.kt
@@ -1,0 +1,129 @@
+package cash.z.ecc.android.sdk
+
+import cash.z.ecc.android.sdk.internal.PaymentUri
+import cash.z.ecc.android.sdk.internal.jni.RustPaymentUriTool
+import cash.z.ecc.android.sdk.model.Eip681PaymentRequest
+import cash.z.ecc.android.sdk.model.InvalidPaymentUriException
+import cash.z.ecc.android.sdk.model.PaymentUriAddress
+import cash.z.ecc.android.sdk.model.PaymentUriAmount
+import cash.z.ecc.android.sdk.model.PaymentUriLink
+import cash.z.ecc.android.sdk.model.PaymentUriNetwork
+import cash.z.ecc.android.sdk.model.PaymentUriRequest
+import cash.z.ecc.android.sdk.model.SolanaPayTransferRequest
+import cash.z.ecc.android.sdk.model.UtxoPaymentUriRequest
+import org.json.JSONObject
+
+/** Rust-backed parser for supported cross-chain payment request URIs. */
+class PaymentUriParser private constructor(
+    private val paymentUri: PaymentUri
+) {
+    /** Parses and validates a Bitcoin, Ethereum, Litecoin, or Solana payment URI. */
+    fun parse(input: String): PaymentUriRequest =
+        try {
+            JSONObject(paymentUri.parse(input)).toPaymentRequest()
+        } catch (_: Exception) {
+            throw InvalidPaymentUriException()
+        }
+
+    private fun JSONObject.toPaymentRequest(): PaymentUriRequest {
+        if (getInt("version") != ENCODED_VERSION) throw InvalidPaymentUriException()
+        return when (getString("type")) {
+            "bitcoin" -> {
+                PaymentUriRequest.Bitcoin(toUtxoRequest())
+            }
+
+            "ethereum_native" -> {
+                PaymentUriRequest.Ethereum(toEthereumNativeRequest())
+            }
+
+            "ethereum_erc20" -> {
+                PaymentUriRequest.Ethereum(toEthereumErc20Request())
+            }
+
+            "ethereum_unrecognised" -> {
+                PaymentUriRequest.Ethereum(Eip681PaymentRequest.Unrecognised)
+            }
+
+            "litecoin" -> {
+                PaymentUriRequest.Litecoin(toUtxoRequest())
+            }
+
+            "solana_transfer" -> {
+                PaymentUriRequest.SolanaTransfer(toSolanaTransfer())
+            }
+
+            "solana_transaction" -> {
+                PaymentUriRequest.SolanaTransaction(
+                    PaymentUriLink(getString("link"))
+                )
+            }
+
+            else -> {
+                throw InvalidPaymentUriException()
+            }
+        }
+    }
+
+    private fun JSONObject.toUtxoRequest() =
+        UtxoPaymentUriRequest(
+            address = PaymentUriAddress(getString("address")),
+            network = getString("network").toPaymentUriNetwork(),
+            amount = optionalString("amount")?.let(::PaymentUriAmount),
+            label = optionalString("label"),
+            message = optionalString("message")
+        )
+
+    private fun JSONObject.toSolanaTransfer() =
+        SolanaPayTransferRequest(
+            recipient = PaymentUriAddress(getString("recipient")),
+            amount = optionalString("amount")?.let(::PaymentUriAmount),
+            splToken = optionalString("spl_token")?.let(::PaymentUriAddress),
+            references =
+                getJSONArray("references").let { values ->
+                    List(values.length()) { PaymentUriAddress(values.getString(it)) }
+                },
+            label = optionalString("label"),
+            message = optionalString("message"),
+            memo = optionalString("memo")
+        )
+
+    private fun JSONObject.toEthereumNativeRequest() =
+        Eip681PaymentRequest.Native(
+            schemaPrefix = getString("schema_prefix"),
+            hasPay = getBoolean("has_pay"),
+            chainId = optionalString("chain_id"),
+            recipientAddress = PaymentUriAddress(getString("recipient_address")),
+            valueHex = optionalString("value_hex"),
+            gasLimitHex = optionalString("gas_limit_hex"),
+            gasPriceHex = optionalString("gas_price_hex")
+        )
+
+    private fun JSONObject.toEthereumErc20Request() =
+        Eip681PaymentRequest.Erc20(
+            schemaPrefix = getString("schema_prefix"),
+            hasPay = getBoolean("has_pay"),
+            chainId = optionalString("chain_id"),
+            tokenContractAddress = PaymentUriAddress(getString("token_contract_address")),
+            recipientAddress = PaymentUriAddress(getString("recipient_address")),
+            valueHex = getString("value_hex")
+        )
+
+    private fun JSONObject.optionalString(name: String): String? =
+        if (isNull(name)) null else getString(name)
+
+    private fun String.toPaymentUriNetwork() =
+        when (this) {
+            "mainnet" -> PaymentUriNetwork.Mainnet
+            "testnet" -> PaymentUriNetwork.Testnet
+            "regtest" -> PaymentUriNetwork.Regtest
+            else -> throw InvalidPaymentUriException()
+        }
+
+    companion object {
+        private const val ENCODED_VERSION = 1
+
+        /** Loads the native library and creates a parser. */
+        suspend fun new(): PaymentUriParser =
+            PaymentUriParser(paymentUri = RustPaymentUriTool.new())
+    }
+}

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/PaymentUriRequest.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/PaymentUriRequest.kt
@@ -1,0 +1,103 @@
+package cash.z.ecc.android.sdk.model
+
+/** Address text validated by the Rust payment URI parser. */
+@JvmInline
+value class PaymentUriAddress internal constructor(
+    val value: String
+)
+
+/** Exact non-negative decimal amount without floating-point conversion. */
+@JvmInline
+value class PaymentUriAmount internal constructor(
+    val value: String
+)
+
+/** HTTPS transaction-request link validated by the Rust parser. */
+@JvmInline
+value class PaymentUriLink internal constructor(
+    val value: String
+)
+
+/** Network encoded by a Bitcoin or Litecoin address. */
+enum class PaymentUriNetwork {
+    Mainnet,
+    Testnet,
+    Regtest
+}
+
+/** Validated Bitcoin or Litecoin payment request. */
+@ConsistentCopyVisibility
+data class UtxoPaymentUriRequest internal constructor(
+    val address: PaymentUriAddress,
+    val network: PaymentUriNetwork,
+    val amount: PaymentUriAmount?,
+    val label: String?,
+    val message: String?
+)
+
+/** Validated Solana Pay transfer request. */
+@ConsistentCopyVisibility
+data class SolanaPayTransferRequest internal constructor(
+    val recipient: PaymentUriAddress,
+    val amount: PaymentUriAmount?,
+    val splToken: PaymentUriAddress?,
+    val references: List<PaymentUriAddress>,
+    val label: String?,
+    val message: String?,
+    val memo: String?
+)
+
+/** Parsed EIP-681 payment request. */
+sealed interface Eip681PaymentRequest {
+    /** Native ETH or chain-token transfer. */
+    @ConsistentCopyVisibility
+    data class Native internal constructor(
+        val schemaPrefix: String,
+        val hasPay: Boolean,
+        val chainId: String?,
+        val recipientAddress: PaymentUriAddress,
+        val valueHex: String?,
+        val gasLimitHex: String?,
+        val gasPriceHex: String?
+    ) : Eip681PaymentRequest
+
+    /** ERC-20 `transfer(address,uint256)` request. */
+    @ConsistentCopyVisibility
+    data class Erc20 internal constructor(
+        val schemaPrefix: String,
+        val hasPay: Boolean,
+        val chainId: String?,
+        val tokenContractAddress: PaymentUriAddress,
+        val recipientAddress: PaymentUriAddress,
+        val valueHex: String
+    ) : Eip681PaymentRequest
+
+    /** Valid EIP-681 request that is not a recognized transfer. */
+    data object Unrecognised : Eip681PaymentRequest
+}
+
+/** Parsed and validated cross-chain payment request. */
+sealed interface PaymentUriRequest {
+    data class Bitcoin(
+        val request: UtxoPaymentUriRequest
+    ) : PaymentUriRequest
+
+    data class Ethereum(
+        val request: Eip681PaymentRequest
+    ) : PaymentUriRequest
+
+    data class Litecoin(
+        val request: UtxoPaymentUriRequest
+    ) : PaymentUriRequest
+
+    data class SolanaTransfer(
+        val request: SolanaPayTransferRequest
+    ) : PaymentUriRequest
+
+    data class SolanaTransaction(
+        val link: PaymentUriLink
+    ) : PaymentUriRequest
+}
+
+/** Raised when a payment URI is malformed or unsupported. */
+class InvalidPaymentUriException : IllegalArgumentException("Invalid payment URI")


### PR DESCRIPTION
## Summary

- expose one PaymentUriParser API for Bitcoin, Ethereum, Litecoin, and Solana
- decode the shared versioned librustzcash result for every supported scheme
- preserve the existing EIP-681 result shape and the upstream eip681 parser logic
- preserve exact decimal amounts as strings
- keep the JNI bridge to a single shared parse_to_json call

## Dependency

- https://github.com/zcash/librustzcash/pull/2989

## Testing

- ./scripts/ci-local.sh quick passed
- managed Pixel 2 API 36 sdk-lib instrumentation suite passed: 129 tests executed
- PaymentUriParser instrumentation verifies Ethereum recipient and atomic-value output from the common path

AI disclosure: Implemented with OpenAI Codex assistance.