### PR TITLE
MOB-1694: reject out-of-range block heights at the JNI boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   subtypes the upstream engine uses, instead of letting the raw Rust `RuntimeException` escape
   (MOB-1723).
 
+### Fixed
+- The JNI entry points `branchIdForHeight` and `putUtxo` now reject negative or out-of-range
+  block heights with an exception instead of silently wrapping them to a `u32`, which could
+  select an incorrect consensus branch id or persist a bogus UTXO height (MOB-1694).
+
 ## [3.1.0] - 2026-08-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,13 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (MOB-1723).
 
 ### Fixed
-- The JNI entry points `branchIdForHeight` and `putUtxo` now reject negative or out-of-range
-  block heights with an exception instead of silently wrapping them to a `u32`, which could
-  select an incorrect consensus branch id or persist a bogus UTXO height (MOB-1694).
+- The JNI entry points `branchIdForHeight`, `putUtxo`, and the pool-migration entry points
+  `recordTransferResultNative`, `hasOverdueTransfersNative`, `nextDueTransferNative`, and
+  `nextStepNative` now reject negative or out-of-range block heights with an exception instead
+  of silently wrapping them to a `u32`, which could select an incorrect consensus branch id,
+  persist a bogus UTXO height, or misjudge migration transfer timing. The migration commit and
+  Keystone QR entry points' plan-handle and fragment-length parameters got the same treatment
+  (MOB-1694).
 
 ## [3.1.0] - 2026-08-20
 

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -2091,7 +2091,10 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_putUtxo<'
                     .map_err(|_| anyhow!("Invalid UTXO value"))?,
                 script_pubkey,
             },
-            Some(BlockHeight::try_from(height)?),
+            Some(
+                BlockHeight::try_from(height)
+                    .map_err(|_| anyhow!("Invalid block height: {}", height))?,
+            ),
             // This JNI entry point has no account context to attribute the UTXO to.
             None,
             None,

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -2091,7 +2091,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_putUtxo<'
                     .map_err(|_| anyhow!("Invalid UTXO value"))?,
                 script_pubkey,
             },
-            Some(BlockHeight::from(height as u32)),
+            Some(BlockHeight::try_from(height)?),
             // This JNI entry point has no account context to attribute the UTXO to.
             None,
             None,
@@ -2752,7 +2752,9 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustBackend_branchIdF
     let res = panic::catch_unwind(|| {
         let _span = tracing::info_span!("RustBackend.branchIdForHeight").entered();
         let network = parse_network(network_id as u32)?;
-        let branch: BranchId = BranchId::for_height(&network, BlockHeight::from(height as u32));
+        let height = BlockHeight::try_from(height)
+            .map_err(|_| anyhow!("Invalid block height: {}", height))?;
+        let branch: BranchId = BranchId::for_height(&network, height);
         let branch_id: u32 = u32::from(branch);
         debug!(
             "For height {} found consensus branch {:?} with id {}",

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -410,6 +410,15 @@ fn target_height(wallet: &Wallet) -> anyhow::Result<BlockHeight> {
     Ok(tip + 1)
 }
 
+/// Converts a non-negative `jlong` tip height reported by a caller into a [`BlockHeight`],
+/// erroring instead of silently truncating a value above the `u32` range into a different
+/// height. Callers own any negative-sentinel handling ("no estimate available") themselves —
+/// this only decodes the case where the caller has already established the value is meant to
+/// be taken literally.
+fn decode_tip_height(height: jlong) -> anyhow::Result<BlockHeight> {
+    BlockHeight::try_from(height).map_err(|_| anyhow!("Invalid tip height: {}", height))
+}
+
 /// The wallet's real, currently-witnessable anchor height (the same one ordinary, non-migration
 /// sends use, via `get_target_and_anchor_heights`) — NOT just "chain tip minus one", which isn't
 /// necessarily checkpointed (confirmed live: `root_at_checkpoint_id` returned `None` for a raw
@@ -747,6 +756,12 @@ fn decode_transfer_id(id: jlong) -> anyhow::Result<MigrationTransferId> {
     Ok(MigrationTransferId::new(idx))
 }
 
+/// Decodes the `proposalHandle` field Kotlin echoes back into a cache lookup key, rejecting a
+/// negative handle rather than reinterpreting its bit pattern as a large `u64`.
+fn decode_plan_handle(handle: jlong) -> anyhow::Result<crate::migration_plan_cache::PlanHandle> {
+    u64::try_from(handle).map_err(|_| anyhow!("Invalid proposal handle: {}", handle))
+}
+
 /// One preparation (note-split) transaction entry, ready to encode into [`JniPreparationStep`].
 ///
 /// - `id` is the stable [`MigrationTransferId`] the engine assigns at commit time (same ordinal as
@@ -1061,7 +1076,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     let res = catch_unwind(&mut env, |env| {
         let (_network, wallet, _store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
-        let plan_handle = proposal_handle as u64;
+        let plan_handle = decode_plan_handle(proposal_handle)?;
         let migration_plan = crate::migration_plan_cache::get(account, plan_handle)?;
         let tip = wallet
             .chain_height()
@@ -1392,7 +1407,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                 store_conn: &mut store_conn,
                 target,
             },
-            proposal_handle as u64,
+            decode_plan_handle(proposal_handle)?,
             |network, target, backend, migration_plan, rng| {
                 let state = engine::commit_preparation(
                     network,
@@ -1585,7 +1600,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                     .map_err(|e| anyhow!("Error reading migration state: {:?}", e))?
                     .ok_or_else(|| anyhow!("No migration in progress"))?;
                 let tip = if observed_tip >= 0 {
-                    BlockHeight::from_u32(observed_tip as u32)
+                    decode_tip_height(observed_tip)?
                 } else {
                     target_height(&wallet)? - 1
                 };
@@ -2002,7 +2017,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let scanned_tip = target_height(&wallet)? - 1;
         let effective_tip = if estimated_tip >= 0 {
-            std::cmp::max(scanned_tip, BlockHeight::from(estimated_tip as u32))
+            std::cmp::max(scanned_tip, decode_tip_height(estimated_tip)?)
         } else {
             scanned_tip
         };
@@ -2080,7 +2095,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                 store_conn: &mut store_conn,
                 target,
             },
-            proposal_handle as u64,
+            decode_plan_handle(proposal_handle)?,
             |network, target, backend, migration_plan, rng| {
                 let state = engine::commit_preparation(
                     network,
@@ -2570,7 +2585,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let scanned_tip = target_height(&wallet)? - 1;
         let effective_tip = if estimated_tip >= 0 {
-            std::cmp::max(scanned_tip, BlockHeight::from(estimated_tip as u32))
+            std::cmp::max(scanned_tip, decode_tip_height(estimated_tip)?)
         } else {
             scanned_tip
         };
@@ -3475,7 +3490,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                 store_conn: &mut store_conn,
                 target,
             },
-            proposal_handle as u64,
+            decode_plan_handle(proposal_handle)?,
             |network, target, backend, migration_plan, rng| {
                 let (state, unsigned) = engine::build_preparation_unsigned(
                     network,
@@ -3605,7 +3620,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                 store_conn: &mut store_conn,
                 target,
             },
-            proposal_handle as u64,
+            decode_plan_handle(proposal_handle)?,
             |network, target, backend, migration_plan, rng| {
                 let (state, unsigned) = engine::build_preparation_unsigned(
                     network,
@@ -3699,7 +3714,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                 store_conn: &mut store_conn,
                 target,
             },
-            proposal_handle as u64,
+            decode_plan_handle(proposal_handle)?,
             |network, target, backend, migration_plan, rng| {
                 let (state, unsigned) = engine::build_preparation_unsigned(
                     network,
@@ -3813,6 +3828,16 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
 // Pure PCZT/UR operations over caller-held bytes — no wallet database, no migration engine.
 // Unaffected by this rewire.
 
+/// Decodes the Keystone QR-fragmenting `maxFragmentLen` parameter into a `usize`, rejecting a
+/// non-positive value (zero or negative bytes per fragment cannot produce any QR parts) rather
+/// than truncating it into an unrelated fragment size.
+fn decode_max_fragment_len(max_fragment_len: jint) -> anyhow::Result<usize> {
+    usize::try_from(max_fragment_len)
+        .ok()
+        .filter(|&len| len > 0)
+        .ok_or_else(|| anyhow!("Invalid max fragment length: {}", max_fragment_len))
+}
+
 fn decode_byte_array_list(env: &mut JNIEnv, list: &JObjectArray) -> anyhow::Result<Vec<Vec<u8>>> {
     let count = env.get_array_length(list)?;
     let mut out = Vec::with_capacity(count as usize);
@@ -3845,7 +3870,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
             request_id,
             split_unsigned.as_deref(),
             &transfer_unsigned,
-            max_fragment_len as usize,
+            decode_max_fragment_len(max_fragment_len)?,
         )
         .map_err(|e| anyhow!("Error building Keystone sign-batch QR parts: {}", e))?;
         Ok(
@@ -7721,7 +7746,9 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let estimated = if estimated_tip < 0 {
             scanned
         } else {
-            std::cmp::max(scanned, BlockHeight::from_u32(estimated_tip as u32) + 1)
+            // `Add<u32> for BlockHeight` saturates, so a decoded `u32::MAX` cannot wrap or panic
+            // here — it just clamps `estimated` at the maximum representable height.
+            std::cmp::max(scanned, decode_tip_height(estimated_tip)? + 1)
         };
         let mut backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let Some(mut state) = backend

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -419,6 +419,45 @@ fn decode_tip_height(height: jlong) -> anyhow::Result<BlockHeight> {
     BlockHeight::try_from(height).map_err(|_| anyhow!("Invalid tip height: {}", height))
 }
 
+#[cfg(test)]
+mod decode_tip_height_tests {
+    use super::*;
+
+    #[test]
+    fn negative_height_is_error() {
+        assert!(decode_tip_height(-1).is_err());
+    }
+
+    #[test]
+    fn zero_height_succeeds() {
+        assert_eq!(
+            decode_tip_height(0).expect("zero is a valid height"),
+            BlockHeight::from_u32(0)
+        );
+    }
+
+    #[test]
+    fn typical_height_succeeds() {
+        assert_eq!(
+            decode_tip_height(2_500_000).expect("typical height is valid"),
+            BlockHeight::from_u32(2_500_000)
+        );
+    }
+
+    #[test]
+    fn max_u32_height_succeeds() {
+        assert_eq!(
+            decode_tip_height(u32::MAX as i64).expect("u32::MAX is the largest valid height"),
+            BlockHeight::from_u32(u32::MAX)
+        );
+    }
+
+    #[test]
+    fn one_above_max_u32_height_is_error() {
+        assert!(decode_tip_height(u32::MAX as i64 + 1).is_err());
+    }
+}
+
 /// The wallet's real, currently-witnessable anchor height (the same one ordinary, non-migration
 /// sends use, via `get_target_and_anchor_heights`) — NOT just "chain tip minus one", which isn't
 /// necessarily checkpointed (confirmed live: `root_at_checkpoint_id` returned `None` for a raw
@@ -760,6 +799,34 @@ fn decode_transfer_id(id: jlong) -> anyhow::Result<MigrationTransferId> {
 /// negative handle rather than reinterpreting its bit pattern as a large `u64`.
 fn decode_plan_handle(handle: jlong) -> anyhow::Result<crate::migration_plan_cache::PlanHandle> {
     u64::try_from(handle).map_err(|_| anyhow!("Invalid proposal handle: {}", handle))
+}
+
+#[cfg(test)]
+mod decode_plan_handle_tests {
+    use super::*;
+
+    #[test]
+    fn negative_handle_is_error() {
+        assert!(decode_plan_handle(-1).is_err());
+    }
+
+    #[test]
+    fn zero_handle_succeeds() {
+        assert_eq!(decode_plan_handle(0).expect("zero is a valid handle"), 0);
+    }
+
+    #[test]
+    fn typical_handle_succeeds() {
+        assert_eq!(decode_plan_handle(42).expect("typical handle is valid"), 42);
+    }
+
+    #[test]
+    fn max_jlong_handle_succeeds() {
+        assert_eq!(
+            decode_plan_handle(i64::MAX).expect("i64::MAX is the largest representable jlong"),
+            i64::MAX as u64
+        );
+    }
 }
 
 /// One preparation (note-split) transaction entry, ready to encode into [`JniPreparationStep`].
@@ -3836,6 +3903,37 @@ fn decode_max_fragment_len(max_fragment_len: jint) -> anyhow::Result<usize> {
         .ok()
         .filter(|&len| len > 0)
         .ok_or_else(|| anyhow!("Invalid max fragment length: {}", max_fragment_len))
+}
+
+#[cfg(test)]
+mod decode_max_fragment_len_tests {
+    use super::*;
+
+    #[test]
+    fn negative_len_is_error() {
+        assert!(decode_max_fragment_len(-1).is_err());
+    }
+
+    #[test]
+    fn zero_len_is_error() {
+        assert!(decode_max_fragment_len(0).is_err());
+    }
+
+    #[test]
+    fn typical_len_succeeds() {
+        assert_eq!(
+            decode_max_fragment_len(90).expect("typical fragment length is valid"),
+            90
+        );
+    }
+
+    #[test]
+    fn max_i32_len_succeeds() {
+        assert_eq!(
+            decode_max_fragment_len(i32::MAX).expect("i32::MAX is the largest representable jint"),
+            i32::MAX as usize
+        );
+    }
 }
 
 fn decode_byte_array_list(env: &mut JNIEnv, list: &JObjectArray) -> anyhow::Result<Vec<Vec<u8>>> {


### PR DESCRIPTION
## What
The JNI entry points `branchIdForHeight` and `putUtxo` converted an incoming `jlong` block height with `height as u32`. Negative values two's-complement-wrap (e.g. -1 -> 4294967295) and values above `u32::MAX` truncate. The same unchecked-cast pattern was also present in `migration.rs`'s pool-migration entry points (`recordTransferResultNative`, `hasOverdueTransfersNative`, `nextDueTransferNative`, `nextStepNative` for block heights; the `proposal_handle` parameter shared by several commit entry points; and `buildKeystoneSignBatchQrPartsNative`'s `max_fragment_len`), which are now fixed here too.

## Why it matters
- `branchIdForHeight`: `BranchId::for_height` could silently select the wrong consensus branch id for a malformed height.
- `putUtxo`: a wrapped/truncated height would be persisted into the wallet DB as a bogus UTXO height.
- The migration entry points could similarly misjudge transfer timing, or misinterpret a `proposal_handle`/fragment length as an unrelated value.

To be clear about severity: this is defense-in-depth at the raw `Backend`/`MigrationRustBackend` JNI boundary, not a fix for a currently-reachable app crash or misbehavior. The Kotlin `TypesafeBackend` layer already rejects out-of-range heights before they reach these entry points, via `BlockHeight`'s `require(...)` range check, so the app itself cannot currently trigger this path with a bad value.

This is Least Authority audit finding MOB-1694 (parent MOB-1687, label I-SECURITY, risk: High): https://linear.app/zodl/issue/MOB-1694/g-block-height-cast-to-u32-allows-wrap-and-truncation-and-misbinds

## Fix
All these call sites now use the checked `BlockHeight::try_from(height)` conversion (or the equivalent checked conversion for the handle/length parameters), matching the idiom already used elsewhere in these files. An out-of-range value now propagates through the existing anyhow + `unwrap_exc_or` plumbing and surfaces to Kotlin as a thrown `RuntimeException` instead of silently producing a wrong result. No Kotlin-side changes were needed - `RustBackend.getBranchIdForHeight` just forwards the `Long`.

`putUtxo` has no Linear ticket of its own but is the same bug class under parent MOB-1687; included here per reviewer/user decision. The `migration.rs` sibling sites were flagged by reviewer noop-sk on this PR and are fixed in the same branch.

## Out of scope
The smaller `index as u32` outpoint cast in `putUtxo` is a different field (not a height) and is left as a possible follow-up. The `parse_network(network_id as u32)` cast sites in both `lib.rs` and `migration.rs` are intentionally left alone here - they're covered by the separate `bugfix/MOB-1764-jni-cast-sweep` branch, and fixing them here would create a merge collision.

## Testing
`cargo check` passes in `backend-lib` with zero `Cargo.lock` diff. No new Rust unit tests: these JNI functions require a live `JNIEnv` and have no existing Rust unit-test harness in `lib.rs`/`migration.rs`; the conversion itself is upstream `zcash_protocol` behavior already exercised there. CI's existing gates cover compilation across targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
