### PR TITLE
[MOB-1689] Harden secret-key handling across the JNI boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   subtypes the upstream engine uses, instead of letting the raw Rust `RuntimeException` escape
   (MOB-1723).
 
+### Security
+- Hardened key handling across the JNI boundary: on the Rust side, transit buffers carrying spending
+  and metadata key material are now zeroized on drop; on the Kotlin side, transient copies of that key
+  material created while crossing the JNI boundary are zeroed as soon as they are no longer needed.
+  This is defense-in-depth and best-effort only - the JVM may retain unreachable copies (GC
+  compaction, JIT) that cannot be cleared from application code - and it makes no changes to the
+  public API (MOB-1689).
+
 ## [3.1.0] - 2026-08-20
 
 ### Added

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/ext/ByteArrayExt.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/ext/ByteArrayExt.kt
@@ -12,7 +12,14 @@ fun ByteArray.clearContents() {
 
 /**
  * Runs [block] with this array and zeroes it afterwards, including when [block]
- * throws. The array must not be retained past [block]'s return.
+ * throws.
+ *
+ * [block] must not retain the array past its return - no assigning it to a field, closing
+ * over it in a callback, handing it to another coroutine, or returning it as (part of) [R].
+ * This array is zeroed unconditionally once [block] returns or throws, so any alias [block]
+ * kept escapes with its contents silently wiped out from under it. There is no runtime check
+ * for this: the no-aliasing contract is convention-only, enforced by caller discipline, not by
+ * this function.
  */
 inline fun <R> ByteArray.useAndClear(block: (ByteArray) -> R): R =
     try {

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/ext/ByteArrayExt.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/ext/ByteArrayExt.kt
@@ -1,0 +1,22 @@
+@file:Suppress("ktlint:standard:filename")
+
+package cash.z.ecc.android.sdk.internal.ext
+
+/**
+ * Overwrites this array with zeros. Best effort only: the JVM may hold unreachable
+ * copies (GC compaction, JIT) that cannot be cleared from here.
+ */
+fun ByteArray.clearContents() {
+    fill(0)
+}
+
+/**
+ * Runs [block] with this array and zeroes it afterwards, including when [block]
+ * throws. The array must not be retained past [block]'s return.
+ */
+inline fun <R> ByteArray.useAndClear(block: (ByteArray) -> R): R =
+    try {
+        block(this)
+    } finally {
+        fill(0)
+    }

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/JniMetadataKey.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/JniMetadataKey.kt
@@ -19,11 +19,13 @@ class JniMetadataKey(
 ) {
     init {
         require(sk.size == JNI_METADATA_KEY_SK_SIZE) {
-            "Account UUID must be 32 bytes"
+            "Metadata key sk must be 32 bytes"
         }
 
         require(chainCode.size == JNI_METADATA_KEY_CHAIN_CODE_SIZE) {
-            "Seed fingerprint must be 32 bytes"
+            "Metadata key chain code must be 32 bytes"
         }
     }
+
+    override fun toString() = "JniMetadataKey(sk=***, chainCode=***)"
 }

--- a/backend-lib/src/main/rust/lib.rs
+++ b/backend-lib/src/main/rust/lib.rs
@@ -2932,12 +2932,14 @@ fn encode_metadata_key<'a>(
     env: &mut JNIEnv<'a>,
     key: zip32::registered::SecretKey,
 ) -> anyhow::Result<JObject<'a>> {
+    let sk = SecretVec::new(key.data().to_vec());
+    let chain_code = SecretVec::new(key.chain_code().as_bytes().to_vec());
     Ok(env.new_object(
         "cash/z/ecc/android/sdk/internal/model/JniMetadataKey",
         "([B[B)V",
         &[
-            (&env.byte_array_from_slice(key.data())?).into(),
-            (&env.byte_array_from_slice(key.chain_code().as_bytes())?).into(),
+            (&env.byte_array_from_slice(sk.expose_secret())?).into(),
+            (&env.byte_array_from_slice(chain_code.expose_secret())?).into(),
         ],
     )?)
 }
@@ -2989,20 +2991,22 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustDerivationTool_de
 ) -> jobjectArray {
     let res = catch_unwind(&mut env, |env| {
         let _span = tracing::info_span!("RustDerivationTool.derivePrivateUseMetadataKey").entered();
-        let account_metadata_key_sk = utils::java_bytes_to_rust(env, &account_metadata_key_sk)?;
-        let account_metadata_key_c = utils::java_bytes_to_rust(env, &account_metadata_key_c)?;
+        let account_metadata_key_sk = secret_from_jni(env, account_metadata_key_sk)?;
+        let account_metadata_key_c = secret_from_jni(env, account_metadata_key_c)?;
         let ufvk_string = utils::java_nullable_string_to_rust(env, &ufvk_string)?;
         let private_use_subject = utils::java_bytes_to_rust(env, &private_use_subject)?;
         let network = parse_network(network_id as u32)?;
 
         let account_metadata_key = {
             let sk = account_metadata_key_sk
+                .expose_secret()
                 .as_slice()
                 .try_into()
                 .map_err(|_| anyhow!("Incorrect length for account_metadata_key_sk"))?;
 
             let chain_code = ChainCode::new(
                 account_metadata_key_c
+                    .expose_secret()
                     .as_slice()
                     .try_into()
                     .map_err(|_| anyhow!("Incorrect length for account_metadata_key_c"))?,
@@ -3054,7 +3058,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustDerivationTool_de
 
         Ok(
             utils::rust_vec_to_java(env, private_use_keys, "[B", |env, key| {
-                utils::rust_bytes_to_java(env, key.data())
+                let key_bytes = SecretVec::new(key.data().to_vec());
+                utils::rust_bytes_to_java(env, key_bytes.expose_secret())
             })?
             .into_raw(),
         )
@@ -3079,8 +3084,9 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustDerivationTool_de
 
         let key =
             zip32::arbitrary::SecretKey::from_path(&context_string, seed.expose_secret(), &[]);
+        let key_bytes = SecretVec::new(key.data().to_vec());
 
-        Ok(utils::rust_bytes_to_java(&env, key.data())?.into_raw())
+        Ok(utils::rust_bytes_to_java(&env, key_bytes.expose_secret())?.into_raw())
     });
     unwrap_exc_or(&mut env, res, ptr::null_mut())
 }
@@ -3113,8 +3119,9 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_RustDerivationTool_de
                 ChildIndex::hardened(account.into()),
             ],
         );
+        let key_bytes = SecretVec::new(key.data().to_vec());
 
-        Ok(utils::rust_bytes_to_java(&env, key.data())?.into_raw())
+        Ok(utils::rust_bytes_to_java(&env, key_bytes.expose_secret())?.into_raw())
     });
     unwrap_exc_or(&mut env, res, ptr::null_mut())
 }

--- a/backend-lib/src/main/rust/utils.rs
+++ b/backend-lib/src/main/rust/utils.rs
@@ -59,6 +59,12 @@ pub(crate) fn java_nullable_string_to_rust(
         .transpose()
 }
 
+/// Copies `data` into a new Java byte array.
+///
+/// If `data` is confidential material, the caller must own it in a `SecretVec`
+/// (or similarly zeroize-on-drop buffer) so that the transit copy is wiped when
+/// the caller's buffer is dropped; this function's `data.len()`-sized copy on the
+/// JVM heap is outside Rust's control regardless.
 pub(crate) fn rust_bytes_to_java<'a>(env: &JNIEnv<'a>, data: &[u8]) -> JNIResult<JByteArray<'a>> {
     // SAFETY: jbyte (i8) has the same size and alignment as u8, and a well-defined
     // twos-complement representation with no "trap representations".

--- a/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/ext/ByteArrayExtTest.kt
+++ b/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/ext/ByteArrayExtTest.kt
@@ -1,0 +1,51 @@
+package cash.z.ecc.android.sdk.internal.ext
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class ByteArrayExtTest {
+    @Test
+    fun clearContents_zeroes_the_array() {
+        val bytes = byteArrayOf(1, 2, 3, 4, 5)
+
+        bytes.clearContents()
+
+        assertContentEquals(ByteArray(5), bytes)
+    }
+
+    @Test
+    fun useAndClear_zeroes_the_array_after_returning_the_block_result() {
+        val bytes = byteArrayOf(1, 2, 3, 4, 5)
+
+        val result = bytes.useAndClear { it.sum() }
+
+        assertEquals(15, result)
+        assertContentEquals(ByteArray(5), bytes)
+    }
+
+    @Test
+    fun useAndClear_zeroes_the_array_when_the_block_throws() {
+        val bytes = byteArrayOf(1, 2, 3, 4, 5)
+
+        assertFailsWith(IllegalStateException::class) {
+            bytes.useAndClear { error("boom") }
+        }
+
+        assertContentEquals(ByteArray(5), bytes)
+    }
+
+    @Test
+    fun useAndClear_exposes_the_receiver_to_the_block() {
+        val bytes = byteArrayOf(1, 2, 3)
+        var sawOriginalContents = false
+
+        bytes.useAndClear {
+            sawOriginalContents = it.contentEquals(byteArrayOf(1, 2, 3))
+        }
+
+        assertTrue(sawOriginalContents)
+    }
+}

--- a/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/model/JniMetadataKeyTest.kt
+++ b/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/model/JniMetadataKeyTest.kt
@@ -1,0 +1,42 @@
+package cash.z.ecc.android.sdk.internal.model
+
+import cash.z.ecc.android.sdk.internal.jni.JNI_METADATA_KEY_CHAIN_CODE_SIZE
+import cash.z.ecc.android.sdk.internal.jni.JNI_METADATA_KEY_SK_SIZE
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class JniMetadataKeyTest {
+    @Test
+    fun attributes_within_constraints() {
+        val instance =
+            JniMetadataKey(
+                sk = ByteArray(JNI_METADATA_KEY_SK_SIZE) { 1 },
+                chainCode = ByteArray(JNI_METADATA_KEY_CHAIN_CODE_SIZE) { 2 }
+            )
+
+        assertTrue(instance.sk.all { it == 1.toByte() })
+    }
+
+    @Test
+    fun attributes_not_in_constraints() {
+        assertFailsWith(IllegalArgumentException::class) {
+            JniMetadataKey(
+                sk = ByteArray(JNI_METADATA_KEY_SK_SIZE - 1),
+                chainCode = ByteArray(JNI_METADATA_KEY_CHAIN_CODE_SIZE)
+            )
+        }
+    }
+
+    @Test
+    fun toString_does_not_leak_key_material() {
+        val instance =
+            JniMetadataKey(
+                sk = ByteArray(JNI_METADATA_KEY_SK_SIZE) { 0x42 },
+                chainCode = ByteArray(JNI_METADATA_KEY_CHAIN_CODE_SIZE) { 0x43 }
+            )
+
+        assertEquals("JniMetadataKey(sk=***, chainCode=***)", instance.toString())
+    }
+}

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/DerivationToolExt.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/DerivationToolExt.kt
@@ -1,5 +1,7 @@
 package cash.z.ecc.android.sdk.internal
 
+import cash.z.ecc.android.sdk.internal.ext.clearContents
+import cash.z.ecc.android.sdk.internal.ext.useAndClear
 import cash.z.ecc.android.sdk.internal.model.JniMetadataKey
 import cash.z.ecc.android.sdk.internal.model.JniUnifiedSpendingKey
 import cash.z.ecc.android.sdk.model.AccountMetadataKey
@@ -24,24 +26,28 @@ fun Derivation.deriveUnifiedSpendingKey(
     network: ZcashNetwork,
     accountIndex: Zip32AccountIndex
 ): UnifiedSpendingKey =
-    UnifiedSpendingKey(
-        JniUnifiedSpendingKey(
-            bytes = deriveUnifiedSpendingKey(seed, network.id, accountIndex.index)
-        )
-    )
+    deriveUnifiedSpendingKey(seed, network.id, accountIndex.index).useAndClear {
+        UnifiedSpendingKey(JniUnifiedSpendingKey(bytes = it))
+    }
 
 fun Derivation.deriveUnifiedFullViewingKey(
     usk: UnifiedSpendingKey,
     network: ZcashNetwork
-): UnifiedFullViewingKey =
-    UnifiedFullViewingKey(
-        deriveUnifiedFullViewingKey(
-            JniUnifiedSpendingKey(
-                bytes = usk.copyBytes()
-            ),
-            network.id
+): UnifiedFullViewingKey {
+    val uskBytes = usk.copyBytes()
+    return try {
+        UnifiedFullViewingKey(
+            deriveUnifiedFullViewingKey(
+                JniUnifiedSpendingKey(
+                    bytes = uskBytes
+                ),
+                network.id
+            )
         )
-    )
+    } finally {
+        uskBytes.clearContents()
+    }
+}
 
 fun Derivation.deriveUnifiedFullViewingKeysTypesafe(
     seed: ByteArray,
@@ -65,7 +71,15 @@ fun Derivation.derivePrivateUseMetadataKeyTypesafe(
     ufvk: String?,
     network: ZcashNetwork,
     privateUseSubject: ByteArray
-): Array<ByteArray> = derivePrivateUseMetadataKey(accountMetadataKey.toUnsafe(), ufvk, network.id, privateUseSubject)
+): Array<ByteArray> {
+    val jniMetadataKey = accountMetadataKey.toUnsafe()
+    return try {
+        derivePrivateUseMetadataKey(jniMetadataKey, ufvk, network.id, privateUseSubject)
+    } finally {
+        jniMetadataKey.sk.clearContents()
+        jniMetadataKey.chainCode.clearContents()
+    }
+}
 
 fun Derivation.deriveArbitraryWalletKeyTypesafe(
     contextString: ByteArray,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
@@ -37,6 +37,7 @@ import cash.z.ecc.android.sdk.TransferProposal
 import cash.z.ecc.android.sdk.TransferResult
 import cash.z.ecc.android.sdk.UnsignedPreparationPczt
 import cash.z.ecc.android.sdk.internal.db.DatabaseCoordinator
+import cash.z.ecc.android.sdk.internal.ext.clearContents
 import cash.z.ecc.android.sdk.internal.ext.toHexReversed
 import cash.z.ecc.android.sdk.internal.jni.RustBackend
 import cash.z.ecc.android.sdk.internal.model.LazyTorClient
@@ -379,14 +380,19 @@ internal class OrchardMigrationSdkImpl(
             logged("submitNoteSplit.prepare") {
                 val dbDataPath = dbDataPath()
                 val account = account ?: noAccountAvailable()
+                val uskBytes = usk.copyBytes()
                 val signed =
-                    migrationBackend.signNoteSplit(
-                        dbDataPath,
-                        network,
-                        account,
-                        proposal.proposalHandle,
-                        usk.copyBytes(),
-                    )
+                    try {
+                        migrationBackend.signNoteSplit(
+                            dbDataPath,
+                            network,
+                            account,
+                            proposal.proposalHandle,
+                            uskBytes,
+                        )
+                    } finally {
+                        uskBytes.clearContents()
+                    }
                 PreparedBroadcast(
                     dbDataPath = dbDataPath,
                     account = account,
@@ -549,13 +555,18 @@ internal class OrchardMigrationSdkImpl(
         logged("signAndStoreMigrationSchedule") {
             val dbDataPath = dbDataPath()
             val account = account ?: noAccountAvailable()
-            migrationBackend.signAndStoreMigrationSchedule(
-                dbDataPath,
-                network,
-                account,
-                schedule.proposalHandle,
-                usk.copyBytes(),
-            )
+            val uskBytes = usk.copyBytes()
+            try {
+                migrationBackend.signAndStoreMigrationSchedule(
+                    dbDataPath,
+                    network,
+                    account,
+                    schedule.proposalHandle,
+                    uskBytes,
+                )
+            } finally {
+                uskBytes.clearContents()
+            }
         }
 
     // ── Background execution ─────────────────────────────────────────────────

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImpl.kt
@@ -2,6 +2,7 @@ package cash.z.ecc.android.sdk.internal
 
 import cash.z.ecc.android.sdk.exception.InitializeException
 import cash.z.ecc.android.sdk.exception.RustLayerException
+import cash.z.ecc.android.sdk.internal.ext.clearContents
 import cash.z.ecc.android.sdk.internal.model.JniBlockMeta
 import cash.z.ecc.android.sdk.internal.model.JniSubtreeRoot
 import cash.z.ecc.android.sdk.internal.model.RewindResult
@@ -45,8 +46,8 @@ internal class TypesafeBackendImpl(
         seed: FirstClassByteArray,
         treeState: TreeState,
         recoverUntil: BlockHeight?
-    ): AccountUsk =
-        AccountUsk.new(
+    ): AccountUsk {
+        val jniAccountUsk =
             backend.createAccount(
                 accountName = accountName,
                 keySource = keySource,
@@ -54,7 +55,12 @@ internal class TypesafeBackendImpl(
                 treeState = treeState.encoded,
                 recoverUntil = recoverUntil?.value
             )
-        )
+        return try {
+            AccountUsk.new(jniAccountUsk)
+        } finally {
+            jniAccountUsk.bytes.clearContents()
+        }
+    }
 
     override suspend fun importAccountUfvk(
         recoverUntil: BlockHeight?,
@@ -150,12 +156,18 @@ internal class TypesafeBackendImpl(
     override suspend fun createProposedTransactions(
         proposal: Proposal,
         usk: UnifiedSpendingKey
-    ): List<FirstClassByteArray> =
-        backend
-            .createProposedTransactions(
-                proposal.toUnsafe(),
-                usk.copyBytes()
-            ).map { FirstClassByteArray(it) }
+    ): List<FirstClassByteArray> {
+        val uskBytes = usk.copyBytes()
+        return try {
+            backend
+                .createProposedTransactions(
+                    proposal.toUnsafe(),
+                    uskBytes
+                ).map { FirstClassByteArray(it) }
+        } finally {
+            uskBytes.clearContents()
+        }
+    }
 
     override suspend fun createPcztFromProposal(
         account: Account,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeDerivationToolImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeDerivationToolImpl.kt
@@ -1,5 +1,6 @@
 package cash.z.ecc.android.sdk.internal
 
+import cash.z.ecc.android.sdk.internal.ext.clearContents
 import cash.z.ecc.android.sdk.model.AccountMetadataKey
 import cash.z.ecc.android.sdk.model.UnifiedFullViewingKey
 import cash.z.ecc.android.sdk.model.UnifiedSpendingKey
@@ -42,7 +43,15 @@ internal class TypesafeDerivationToolImpl(
         seed: ByteArray,
         network: ZcashNetwork,
         accountIndex: Zip32AccountIndex
-    ): AccountMetadataKey = AccountMetadataKey(derivation.deriveAccountMetadataKeyTypesafe(seed, network, accountIndex))
+    ): AccountMetadataKey {
+        val jniMetadataKey = derivation.deriveAccountMetadataKeyTypesafe(seed, network, accountIndex)
+        return try {
+            AccountMetadataKey(jniMetadataKey)
+        } finally {
+            jniMetadataKey.sk.clearContents()
+            jniMetadataKey.chainCode.clearContents()
+        }
+    }
 
     override suspend fun derivePrivateUseMetadataKey(
         accountMetadataKey: AccountMetadataKey,

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/AccountCreateSetup.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/AccountCreateSetup.kt
@@ -15,4 +15,6 @@ data class AccountCreateSetup(
     val accountName: String,
     val keySource: String?,
     val seed: FirstClassByteArray,
-)
+) {
+    override fun toString() = "AccountCreateSetup(accountName=$accountName, keySource=$keySource, seed=***)"
+}

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/AccountMetadataKey.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/AccountMetadataKey.kt
@@ -56,5 +56,5 @@ class AccountMetadataKey private constructor(
     /**
      * Exposes the type-unsafe variant for passing across the JNI.
      */
-    fun toUnsafe(): JniMetadataKey = JniMetadataKey(sk.byteArray, chainCode.byteArray)
+    fun toUnsafe(): JniMetadataKey = JniMetadataKey(sk.byteArray.copyOf(), chainCode.byteArray.copyOf())
 }

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/FirstClassByteArray.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/FirstClassByteArray.kt
@@ -2,6 +2,11 @@ package cash.z.ecc.android.sdk.model
 
 import cash.z.ecc.android.sdk.ext.toHex
 
+/**
+ * [toString] hex-dumps [byteArray], which is appropriate for non-secret data (transaction
+ * ids, raw transactions, and the like). Types that embed secret material in a
+ * [FirstClassByteArray] must override [toString] themselves to redact it.
+ */
 class FirstClassByteArray(
     val byteArray: ByteArray
 ) {

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/tool/DerivationTool.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/tool/DerivationTool.kt
@@ -132,7 +132,8 @@ interface DerivationTool {
      *
      * @param contextString a globally-unique non-empty sequence of at most 252 bytes that
      *        identifies the desired context.
-     * @return an array of 32 bytes.
+     * @return an array of 32 bytes. This array is secret key material; callers should zero
+     *         it (e.g. via `ByteArray.fill(0)`) once they are done with it.
      */
     suspend fun deriveArbitraryWalletKey(
         contextString: ByteArray,
@@ -148,7 +149,8 @@ interface DerivationTool {
      *        identifies the desired context.
      * @param seed the seed from which to derive the arbitrary key.
      * @param accountIndex the ZIP 32 account index for which to derive the arbitrary key.
-     * @return an array of 32 bytes.
+     * @return an array of 32 bytes. This array is secret key material; callers should zero
+     *         it (e.g. via `ByteArray.fill(0)`) once they are done with it.
      */
     suspend fun deriveArbitraryAccountKey(
         contextString: ByteArray,

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/DerivationToolExtTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/DerivationToolExtTest.kt
@@ -1,0 +1,36 @@
+package cash.z.ecc.android.sdk.internal
+
+import cash.z.ecc.android.sdk.model.ZcashNetwork
+import cash.z.ecc.android.sdk.model.Zip32AccountIndex
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+
+class DerivationToolExtTest {
+    @Test
+    fun deriveUnifiedSpendingKey_wipes_the_transient_jni_copy() {
+        val seed = ByteArray(32) { it.toByte() }
+        val network = ZcashNetwork.Testnet
+        val accountIndex = Zip32AccountIndex.new(0)
+        val expectedKeyBytes = ByteArray(64) { (it + 1).toByte() }
+        val jniReturnedBytes = expectedKeyBytes.copyOf()
+
+        val derivation = mock(Derivation::class.java)
+        `when`(derivation.deriveUnifiedSpendingKey(seed, network.id, accountIndex.index))
+            .thenReturn(jniReturnedBytes)
+
+        val usk = derivation.deriveUnifiedSpendingKey(seed, network, accountIndex)
+
+        assertContentEquals(
+            expectedKeyBytes,
+            usk.copyBytes(),
+            "the derived key must be preserved in the returned UnifiedSpendingKey"
+        )
+        assertContentEquals(
+            ByteArray(64),
+            jniReturnedBytes,
+            "the transient JNI-returned array must be wiped after use"
+        )
+    }
+}

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImplTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/TypesafeBackendImplTest.kt
@@ -1,0 +1,64 @@
+package cash.z.ecc.android.sdk.internal
+
+import cash.z.ecc.android.sdk.internal.model.JniUnifiedSpendingKey
+import cash.z.ecc.android.sdk.model.Proposal
+import cash.z.ecc.android.sdk.model.UnifiedSpendingKey
+import kotlinx.coroutines.runBlocking
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertNotNull
+
+class TypesafeBackendImplTest {
+    @Test
+    fun createProposedTransactions_wipes_the_transient_usk_copy() =
+        runBlocking {
+            val keyBytes = ByteArray(32) { (it + 1).toByte() }
+            val usk = UnifiedSpendingKey(JniUnifiedSpendingKey(bytes = keyBytes.copyOf()))
+            val proposal = Proposal.fromByteArray(fakeProposalBytes())
+
+            var capturedUskBytes: ByteArray? = null
+            val backend = mock(Backend::class.java)
+            `when`(backend.createProposedTransactions(eq(proposal.toUnsafe()), any()))
+                .thenAnswer { invocation ->
+                    val passedBytes = invocation.getArgument<ByteArray>(1)
+                    capturedUskBytes = passedBytes
+                    assertContentEquals(keyBytes, passedBytes, "the derived key must reach the backend intact")
+                    listOf(byteArrayOf(9))
+                }
+
+            TypesafeBackendImpl(backend).createProposedTransactions(proposal, usk)
+
+            val wipedBytes = assertNotNull(capturedUskBytes)
+            assertContentEquals(ByteArray(32), wipedBytes, "the transient usk copy must be wiped after use")
+        }
+
+    /**
+     * A minimal, hand-encoded `cash.z.wallet.sdk.ffi.Proposal` protobuf message — see
+     * `OrchardMigrationSdkImplTest.fakeProposalBytes` for the full rationale. Just field 2
+     * (`feeRule`) set to `Zip317` (3), with no steps, which is enough to round-trip through
+     * `Proposal.fromByteArray`.
+     */
+    private fun fakeProposalBytes(): ByteArray {
+        val fieldNumber = 2
+        val wireTypeVarint = 0
+        val tag = (fieldNumber shl 3) or wireTypeVarint
+        val feeRuleZip317 = 3
+        return byteArrayOf(tag.toByte(), feeRuleZip317.toByte())
+    }
+
+    /**
+     * `ArgumentMatchers.eq`/`.any` return `null` (they're platform-typed Java statics that only
+     * register a matcher as a side effect). Kotlin inserts a not-null assertion when that `null`
+     * flows into a non-null-typed Kotlin parameter, so these wrappers register the real matcher
+     * and hand back a value Kotlin already knows is non-null.
+     */
+    private fun <T> eq(value: T): T = ArgumentMatchers.eq(value) ?: value
+
+    private fun <T> any(): T {
+        @Suppress("UNCHECKED_CAST")
+        return ArgumentMatchers.any<T>() ?: (null as T)
+    }
+}

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/model/AccountCreateSetupTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/model/AccountCreateSetupTest.kt
@@ -1,0 +1,26 @@
+package cash.z.ecc.android.sdk.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class AccountCreateSetupTest {
+    @Test
+    fun toString_does_not_leak_seed_hex() {
+        val seedBytes = ByteArray(64) { 0x11 }
+        val setup =
+            AccountCreateSetup(
+                accountName = "test-account",
+                keySource = "test-source",
+                seed = FirstClassByteArray(seedBytes)
+            )
+
+        val text = setup.toString()
+
+        assertEquals(
+            "AccountCreateSetup(accountName=test-account, keySource=test-source, seed=***)",
+            text
+        )
+        assertFalse(text.contains("11111111"))
+    }
+}

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/model/AccountMetadataKeyTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/model/AccountMetadataKeyTest.kt
@@ -1,0 +1,45 @@
+package cash.z.ecc.android.sdk.model
+
+import cash.z.ecc.android.sdk.internal.model.JniMetadataKey
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertNotSame
+
+class AccountMetadataKeyTest {
+    @Test
+    fun toUnsafe_returns_fresh_arrays_each_call() {
+        val key =
+            AccountMetadataKey(
+                JniMetadataKey(
+                    sk = ByteArray(32) { 1 },
+                    chainCode = ByteArray(32) { 2 }
+                )
+            )
+
+        val first = key.toUnsafe()
+        val second = key.toUnsafe()
+
+        assertNotSame(first.sk, second.sk)
+        assertNotSame(first.chainCode, second.chainCode)
+    }
+
+    @Test
+    fun zeroing_one_toUnsafe_copy_does_not_affect_the_next() {
+        val key =
+            AccountMetadataKey(
+                JniMetadataKey(
+                    sk = ByteArray(32) { 1 },
+                    chainCode = ByteArray(32) { 2 }
+                )
+            )
+
+        val first = key.toUnsafe()
+        first.sk.fill(0)
+        first.chainCode.fill(0)
+
+        val second = key.toUnsafe()
+
+        assertContentEquals(ByteArray(32) { 1 }, second.sk)
+        assertContentEquals(ByteArray(32) { 2 }, second.chainCode)
+    }
+}

--- a/slipstream-lib/src/main/java/com/zodl/slipstream/internal/spend/SlipstreamBroadcaster.kt
+++ b/slipstream-lib/src/main/java/com/zodl/slipstream/internal/spend/SlipstreamBroadcaster.kt
@@ -4,6 +4,7 @@ package com.zodl.slipstream.internal.spend
 
 import cash.z.ecc.android.sdk.Broadcaster
 import cash.z.ecc.android.sdk.internal.Backend
+import cash.z.ecc.android.sdk.internal.ext.clearContents
 import cash.z.ecc.android.sdk.internal.transaction.submitTransaction
 import cash.z.ecc.android.sdk.model.CreatedTransaction
 import cash.z.ecc.android.sdk.model.FirstClassByteArray
@@ -51,7 +52,13 @@ internal class SlipstreamBroadcaster(
         usk: UnifiedSpendingKey
     ): List<CreatedTransaction> {
         SaplingParams.ensureDownloaded(saplingParamsDir)
-        val txIds = backend.createProposedTransactions(proposal.toUnsafe(), usk.copyBytes())
+        val uskBytes = usk.copyBytes()
+        val txIds =
+            try {
+                backend.createProposedTransactions(proposal.toUnsafe(), uskBytes)
+            } finally {
+                uskBytes.clearContents()
+            }
         val created = txIds.map { txId -> storeAsAwaitingSubmission(FirstClassByteArray(txId)) }
         engine.notifyTxChange()
         return created

--- a/slipstream-lib/src/main/java/com/zodl/slipstream/internal/spend/SlipstreamBroadcaster.kt
+++ b/slipstream-lib/src/main/java/com/zodl/slipstream/internal/spend/SlipstreamBroadcaster.kt
@@ -45,13 +45,18 @@ internal class SlipstreamBroadcaster(
     private val engine: SlipstreamEngine,
     private val planStore: SubmitPlanStore,
     private val saplingParamsDir: File,
-    private val transactionReader: SlipstreamTransactionReader
+    private val transactionReader: SlipstreamTransactionReader,
+    /**
+     * Production: `{ SaplingParams.ensureDownloaded(saplingParamsDir) }`. Injected so tests never
+     * trigger a real download.
+     */
+    private val ensureSaplingParams: suspend () -> Unit = { SaplingParams.ensureDownloaded(saplingParamsDir) }
 ) : Broadcaster {
     override suspend fun createProposedTransactions(
         proposal: Proposal,
         usk: UnifiedSpendingKey
     ): List<CreatedTransaction> {
-        SaplingParams.ensureDownloaded(saplingParamsDir)
+        ensureSaplingParams()
         val uskBytes = usk.copyBytes()
         val txIds =
             try {

--- a/slipstream-lib/src/main/java/com/zodl/slipstream/internal/spend/SlipstreamSpendService.kt
+++ b/slipstream-lib/src/main/java/com/zodl/slipstream/internal/spend/SlipstreamSpendService.kt
@@ -5,6 +5,7 @@ package com.zodl.slipstream.internal.spend
 import cash.z.ecc.android.sdk.exception.PcztException
 import cash.z.ecc.android.sdk.exception.TransactionEncoderException
 import cash.z.ecc.android.sdk.internal.Backend
+import cash.z.ecc.android.sdk.internal.ext.clearContents
 import cash.z.ecc.android.sdk.internal.ext.requireSingleStepForPczt
 import cash.z.ecc.android.sdk.internal.ext.toProposalException
 import cash.z.ecc.android.sdk.internal.transaction.submitTransaction
@@ -125,7 +126,13 @@ internal class SlipstreamSpendService(
     ): Flow<TransactionSubmitResult> =
         flow {
             ensureSaplingParams()
-            val txIds = backend.createProposedTransactions(proposal.toUnsafe(), usk.copyBytes())
+            val uskBytes = usk.copyBytes()
+            val txIds =
+                try {
+                    backend.createProposedTransactions(proposal.toUnsafe(), uskBytes)
+                } finally {
+                    uskBytes.clearContents()
+                }
             engine.notifyTxChange()
             for (txId in txIds) {
                 val txIdBytes = FirstClassByteArray(txId)

--- a/slipstream-lib/src/test/java/com/zodl/slipstream/internal/spend/SlipstreamBroadcasterTest.kt
+++ b/slipstream-lib/src/test/java/com/zodl/slipstream/internal/spend/SlipstreamBroadcasterTest.kt
@@ -1,0 +1,120 @@
+package com.zodl.slipstream.internal.spend
+
+import cash.z.ecc.android.sdk.internal.Backend
+import cash.z.ecc.android.sdk.internal.model.ProposalUnsafe
+import cash.z.ecc.android.sdk.model.CreatedTransaction
+import cash.z.ecc.android.sdk.model.FirstClassByteArray
+import cash.z.ecc.android.sdk.model.Proposal
+import cash.z.ecc.android.sdk.model.SdkFlags
+import cash.z.ecc.android.sdk.model.UnifiedSpendingKey
+import cash.z.ecc.android.sdk.util.WalletClientFactory
+import com.zodl.slipstream.internal.SlipstreamEngine
+import com.zodl.slipstream.internal.db.SlipstreamTransactionReader
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.io.File
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+
+/**
+ * Regression coverage for the [SlipstreamBroadcaster.createProposedTransactions] USK wipe (MOB-1689) -
+ * mirrors [SlipstreamSpendServiceOrderingTest]'s wipe assertion, which is the identical fix in the
+ * sibling send path. Conventions follow that test: plain Mockito with exact-argument stubs (no
+ * matcher library is a project dependency), JUnit4 and `runBlocking`.
+ *
+ * [SlipstreamBroadcaster] does not take the same injected `readRawTransaction` seam
+ * [SlipstreamSpendService] does for its whole flow, so [SubmitPlanStore] and [SlipstreamTransactionReader]
+ * are mocked directly instead. `ensureSaplingParams` is injectable here too (added alongside this
+ * test, same reasoning as the sibling class: tests must never trigger a real sapling-params download).
+ */
+class SlipstreamBroadcasterTest {
+    @Test
+    fun createProposedTransactionsWipesTheTransientUskCopy() =
+        runBlocking {
+            val fixture = Fixture()
+            val created =
+                CreatedTransaction(
+                    txId = FirstClassByteArray(TX_ID),
+                    raw = FirstClassByteArray(RAW),
+                    expiryHeight = null
+                )
+            `when`(fixture.backend.createProposedTransactions(fixture.proposalUnsafe, fixture.uskBytes))
+                .thenReturn(listOf(TX_ID))
+            `when`(fixture.transactionReader.readCreatedTransaction(FirstClassByteArray(TX_ID))).thenReturn(created)
+
+            val results = fixture.broadcaster.createProposedTransactions(fixture.proposal, fixture.usk)
+
+            assertEquals(listOf(created), results)
+            assertContentEquals(
+                ByteArray(fixture.uskBytes.size),
+                fixture.uskBytes,
+                "the transient usk copy must be wiped after use"
+            )
+        }
+
+    @Test
+    fun createProposedTransactionsWipesTheTransientUskCopyEvenWhenTheBackendThrows() =
+        runBlocking {
+            val fixture = Fixture()
+            val failure = RuntimeException("the backend blew up")
+            `when`(fixture.backend.createProposedTransactions(fixture.proposalUnsafe, fixture.uskBytes))
+                .thenThrow(failure)
+
+            val thrown =
+                assertFailsWith<RuntimeException> {
+                    fixture.broadcaster.createProposedTransactions(fixture.proposal, fixture.usk)
+                }
+
+            assertSame(failure, thrown)
+            assertContentEquals(
+                ByteArray(fixture.uskBytes.size),
+                fixture.uskBytes,
+                "the transient usk copy must be wiped even when the backend throws"
+            )
+        }
+
+    /**
+     * Shared mocks/fixtures for both tests above, wired the same way
+     * [SlipstreamSpendServiceOrderingTest] wires its own.
+     */
+    private class Fixture {
+        val backend: Backend = mock(Backend::class.java)
+        val engine: SlipstreamEngine = mock(SlipstreamEngine::class.java)
+        val planStore: SubmitPlanStore = mock(SubmitPlanStore::class.java)
+        val transactionReader: SlipstreamTransactionReader = mock(SlipstreamTransactionReader::class.java)
+
+        val proposalUnsafe: ProposalUnsafe =
+            mock(ProposalUnsafe::class.java).also {
+                `when`(it.totalFeeRequired()).thenReturn(FEE)
+            }
+        val proposal: Proposal = Proposal.fromUnsafe(proposalUnsafe)
+
+        val uskBytes: ByteArray = byteArrayOf(5, 6, 7, 8)
+        val usk: UnifiedSpendingKey =
+            mock(UnifiedSpendingKey::class.java).also {
+                `when`(it.copyBytes()).thenReturn(uskBytes)
+            }
+
+        val broadcaster: SlipstreamBroadcaster =
+            SlipstreamBroadcaster(
+                backend = backend,
+                walletClientFactory = mock(WalletClientFactory::class.java),
+                sdkFlags = SdkFlags(isTorEnabled = false, isExchangeRateEnabled = false),
+                engine = engine,
+                planStore = planStore,
+                saplingParamsDir = File("unused"),
+                transactionReader = transactionReader,
+                ensureSaplingParams = { }
+            )
+    }
+
+    private companion object {
+        const val FEE = 1_000L
+        val TX_ID = byteArrayOf(1, 2, 3)
+        val RAW = byteArrayOf(9, 9, 9)
+    }
+}

--- a/slipstream-lib/src/test/java/com/zodl/slipstream/internal/spend/SlipstreamSpendServiceOrderingTest.kt
+++ b/slipstream-lib/src/test/java/com/zodl/slipstream/internal/spend/SlipstreamSpendServiceOrderingTest.kt
@@ -17,6 +17,7 @@ import org.junit.Test
 import org.mockito.Mockito.inOrder
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
+import kotlin.test.assertContentEquals
 
 /**
  * `SDK_ADAPTER_PLAN.md` T8's "failing test first": pins the store-first law - `createProposedTransactions`
@@ -41,7 +42,7 @@ class SlipstreamSpendServiceOrderingTest {
             val proposal = Proposal.fromUnsafe(proposalUnsafe)
 
             val usk = mock(UnifiedSpendingKey::class.java)
-            val uskBytes = ByteArray(0)
+            val uskBytes = byteArrayOf(5, 6, 7, 8)
             `when`(usk.copyBytes()).thenReturn(uskBytes)
 
             val txId = byteArrayOf(1, 2, 3)
@@ -67,6 +68,7 @@ class SlipstreamSpendServiceOrderingTest {
 
             kotlin.test.assertEquals(1, results.size)
             kotlin.test.assertTrue(ensureCalled)
+            assertContentEquals(ByteArray(uskBytes.size), uskBytes, "the transient usk copy must be wiped after use")
 
             val order = inOrder(engine, walletClient)
             order.verify(engine).notifyTxChange()


### PR DESCRIPTION
## Summary

Hardening for the Least Authority audit finding tracked as [MOB-1689](https://linear.app/zodl/issue/MOB-1689/b-high-privilege-keys-exposed-across-jni-boundary) ("High-Privilege Keys Exposed Across JNI Boundary"): JNI exports that derive spending and ZIP-325 metadata keys returned them to Kotlin as raw `byte[]`, leaving unwiped copies of `UnifiedSpendingKey` bytes and metadata keys on the JVM heap, outside Rust's secrecy controls.

**No public API changes.** This PR shrinks the exposure window at every point the SDK controls:

- **Rust (`backend-lib/src/main/rust`)**: all outbound key material now travels through `secrecy::SecretVec`-owned buffers that zeroize on drop (`encode_metadata_key`, private-use metadata keys, arbitrary wallet/account keys — matching the pattern `encode_usk`/`deriveSpendingKey` already used), and the inbound metadata-key halves of `derivePrivateUseMetadataKey` now go through `secret_from_jni` instead of an unprotected `Vec<u8>`. No `Cargo.toml` changes.
- **Kotlin**: new internal `ByteArray.clearContents()`/`useAndClear()` utility; every transient SDK-created copy of key material is zeroed in a `finally` once the JNI call completes — spending-key derivation, full-viewing-key derivation, metadata-key derivation, `createProposedTransactions`, `createAccountAndGetSpendingKey` (previously the returned `JniAccountUsk` bytes were abandoned to the GC), and both Orchard-migration signing paths. Caller-supplied seed arrays and arrays returned to the consumer are never touched.
- **Disclosure fixes**: `JniMetadataKey` gains the redacted `toString()` every other JNI key model already had (plus corrected `require` messages); `AccountMetadataKey.toUnsafe()` now returns defensive copies instead of its live internal arrays; `AccountCreateSetup.toString()` no longer hex-dumps the seed via `FirstClassByteArray`; KDoc added on `deriveArbitraryWalletKey`/`deriveArbitraryAccountKey` advising callers to zero returned bytes.

### Honest limitations (stated deliberately)

- JVM-side wiping is **best-effort**: GC compaction and JIT can leave unreachable copies that application code cannot clear.
- The upstream `zip32` key structs themselves are not zeroized on drop; the `SecretVec` wrappers cover the owned transit buffers.
- The seed and derived keys still cross the JNI boundary by API design. Full elimination — opaque key handles held in a Rust-side registry (modeled on the existing `migration_plan_cache.rs` pattern) so keys never enter the JVM heap — is a breaking API change deferred to a follow-up.
- The Slipstream call sites (`SlipstreamSpendService.createProposedTransactions`, `SlipstreamBroadcaster.createProposedTransactions`) were in scope on this PR's base, `maint/v3.1.x`, today — not a hypothetical future backport — and are now fixed with the same `clearContents()` pattern used elsewhere in this PR.

## Test plan

- `cargo fmt --check`, `cargo clippy --all-targets`, `cargo test` (backend-lib): clean; 74 passed, 15 ignored (env-gated), 0 failed.
- `cargo tree -d`: no duplicated `zcash_*`/`orchard`/`sapling-crypto`/`rusqlite` crates; `Cargo.lock` untouched.
- `./gradlew ktlint detektAll lint`: clean (detekt report empty; only pre-existing baseline lint warnings).
- `./gradlew :backend-lib:testDebugUnitTest :sdk-lib:testDebugUnitTest`: 205 tests, 0 failures — including new unit tests for the wipe utility, redacted `toString()`s, `toUnsafe()` defensive copies, and transient-wipe assertions on `TypesafeBackendImpl.createProposedTransactions` / `DerivationToolExt.deriveUnifiedSpendingKey` via capturing fakes.
- `./gradlew :backend-lib:assembleDebug`: Rust cross-compile green for arm/arm64/x86/x86_64.
- androidTest (connected) suites not run locally — no device attached; CI covers them. The seed-non-mutation contract (`create_spending_key_does_not_mutate_passed_bytes`) is preserved by design (caller arrays are never wiped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

