### PR TITLE
MOB-1765: validate numeric arguments at the RustBackend boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `proposeOrchardToIronwoodMigration` now report failures with the same `TransactionEncoderException`
   subtypes the upstream engine uses, instead of letting the raw Rust `RuntimeException` escape
   (MOB-1723).
+- The raw `Backend`/`RustBackend` API now validates numeric arguments (block heights must be
+  in the unsigned 32-bit range; indices and counts must be nonnegative) and throws
+  `IllegalArgumentException` before crossing the JNI boundary (MOB-1765).
 
 ## [3.1.0] - 2026-08-20
 

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/Backend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/Backend.kt
@@ -238,10 +238,14 @@ interface Backend {
 
     suspend fun listTransparentReceivers(accountUuid: ByteArray): List<String>
 
+    /**
+     * @throws IllegalArgumentException if [height] is outside the valid UInt range.
+     */
     fun getBranchIdForHeight(height: Long): Long
 
     /**
      * @throws RuntimeException as a common indicator of the operation failure
+     * @throws IllegalArgumentException if [outputIndex] is negative.
      */
     @Throws(RuntimeException::class)
     suspend fun getMemoAsUtf8(
@@ -252,6 +256,7 @@ interface Backend {
 
     /**
      * @throws RuntimeException as a common indicator of the operation failure
+     * @throws IllegalArgumentException if [height] is outside the valid UInt range.
      */
     @Throws(RuntimeException::class)
     suspend fun rewindToHeight(height: Long): JniRewindResult
@@ -271,6 +276,8 @@ interface Backend {
 
     /**
      * @throws RuntimeException as a common indicator of the operation failure
+     * @throws IllegalArgumentException if [saplingStartIndex], [orchardStartIndex], or
+     *         [ironwoodStartIndex] is negative.
      */
     @Throws(RuntimeException::class)
     @Suppress("LongParameterList")
@@ -285,6 +292,7 @@ interface Backend {
 
     /**
      * @throws RuntimeException as a common indicator of the operation failure
+     * @throws IllegalArgumentException if [height] is outside the valid UInt range.
      */
     @Throws(RuntimeException::class)
     suspend fun updateChainTip(height: Long)
@@ -328,6 +336,8 @@ interface Backend {
 
     /**
      * @throws RuntimeException as a common indicator of the operation failure
+     * @throws IllegalArgumentException if [fromHeight] is outside the valid UInt range, or if
+     *         [limit] is negative.
      */
     @Throws(RuntimeException::class)
     suspend fun scanBlocks(
@@ -369,14 +379,22 @@ interface Backend {
      */
     suspend fun getLatestCacheHeight(): Long?
 
+    /**
+     * @throws IllegalArgumentException if [height] is outside the valid UInt range.
+     */
     suspend fun findBlockMetadata(height: Long): JniBlockMeta?
 
+    /**
+     * @throws IllegalArgumentException if [height] is outside the valid UInt range.
+     */
     suspend fun rewindBlockMetadataToHeight(height: Long)
 
     suspend fun getTotalTransparentBalance(address: String): Long
 
     /**
      * @throws RuntimeException as a common indicator of the operation failure
+     * @throws IllegalArgumentException if [index] is negative, or if [height] is outside the
+     *         valid UInt range.
      */
     @Suppress("LongParameterList")
     @Throws(RuntimeException::class)

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/ext/NumberExt.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/ext/NumberExt.kt
@@ -3,3 +3,40 @@
 package cash.z.ecc.android.sdk.internal.ext
 
 fun Long.isInUIntRange(): Boolean = this >= 0L && this <= UInt.MAX_VALUE.toLong()
+
+/**
+ * Validates that [height] is within the unsigned 32-bit range accepted by the Rust layer
+ * before it crosses the JNI boundary.
+ *
+ * @throws IllegalArgumentException if [height] is outside the valid UInt range.
+ */
+internal fun requireValidHeight(
+    height: Long,
+    name: String
+) {
+    require(height.isInUIntRange()) { "$name $height is outside of allowed UInt range" }
+}
+
+/**
+ * Validates that [value] is nonnegative before it crosses the JNI boundary.
+ *
+ * @throws IllegalArgumentException if [value] is negative.
+ */
+internal fun requireNonNegative(
+    value: Long,
+    name: String
+) {
+    require(value >= 0) { "$name $value must be nonnegative" }
+}
+
+/**
+ * Validates that [value] is nonnegative before it crosses the JNI boundary.
+ *
+ * @throws IllegalArgumentException if [value] is negative.
+ */
+internal fun requireNonNegative(
+    value: Int,
+    name: String
+) {
+    require(value >= 0) { "$name $value must be nonnegative" }
+}

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/FakeRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/FakeRustBackend.kt
@@ -1,7 +1,8 @@
 package cash.z.ecc.android.sdk.internal.jni
 
 import cash.z.ecc.android.sdk.internal.Backend
-import cash.z.ecc.android.sdk.internal.ext.isInUIntRange
+import cash.z.ecc.android.sdk.internal.ext.requireNonNegative
+import cash.z.ecc.android.sdk.internal.ext.requireValidHeight
 import cash.z.ecc.android.sdk.internal.model.JniAccount
 import cash.z.ecc.android.sdk.internal.model.JniAccountUsk
 import cash.z.ecc.android.sdk.internal.model.JniBlockMeta
@@ -22,43 +23,6 @@ class FakeRustBackend(
 ) : Backend {
     override val dataDbFile: File
         get() = error("Intentionally not implemented yet.")
-
-    /**
-     * Validates that [height] is within the unsigned 32-bit range accepted by the Rust layer
-     * before it crosses the JNI boundary.
-     *
-     * @throws IllegalArgumentException if [height] is outside the valid UInt range.
-     */
-    private fun requireValidHeight(
-        height: Long,
-        name: String
-    ) {
-        require(height.isInUIntRange()) { "$name $height is outside of allowed UInt range" }
-    }
-
-    /**
-     * Validates that [value] is nonnegative before it crosses the JNI boundary.
-     *
-     * @throws IllegalArgumentException if [value] is negative.
-     */
-    private fun requireNonNegative(
-        value: Long,
-        name: String
-    ) {
-        require(value >= 0) { "$name $value must be nonnegative" }
-    }
-
-    /**
-     * Validates that [value] is nonnegative before it crosses the JNI boundary.
-     *
-     * @throws IllegalArgumentException if [value] is negative.
-     */
-    private fun requireNonNegative(
-        value: Int,
-        name: String
-    ) {
-        require(value >= 0) { "$name $value must be nonnegative" }
-    }
 
     override suspend fun writeBlockMetadata(blockMetadata: List<JniBlockMeta>) {
         metadata.addAll(blockMetadata)

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/FakeRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/FakeRustBackend.kt
@@ -1,11 +1,13 @@
 package cash.z.ecc.android.sdk.internal.jni
 
 import cash.z.ecc.android.sdk.internal.Backend
+import cash.z.ecc.android.sdk.internal.ext.isInUIntRange
 import cash.z.ecc.android.sdk.internal.model.JniAccount
 import cash.z.ecc.android.sdk.internal.model.JniAccountUsk
 import cash.z.ecc.android.sdk.internal.model.JniBlockMeta
 import cash.z.ecc.android.sdk.internal.model.JniRewindResult
 import cash.z.ecc.android.sdk.internal.model.JniScanRange
+import cash.z.ecc.android.sdk.internal.model.JniScanSummary
 import cash.z.ecc.android.sdk.internal.model.JniSingleUseTransparentAddress
 import cash.z.ecc.android.sdk.internal.model.JniSubtreeRoot
 import cash.z.ecc.android.sdk.internal.model.JniTransactionDataRequest
@@ -21,11 +23,49 @@ class FakeRustBackend(
     override val dataDbFile: File
         get() = error("Intentionally not implemented yet.")
 
+    /**
+     * Validates that [height] is within the unsigned 32-bit range accepted by the Rust layer
+     * before it crosses the JNI boundary.
+     *
+     * @throws IllegalArgumentException if [height] is outside the valid UInt range.
+     */
+    private fun requireValidHeight(
+        height: Long,
+        name: String
+    ) {
+        require(height.isInUIntRange()) { "$name $height is outside of allowed UInt range" }
+    }
+
+    /**
+     * Validates that [value] is nonnegative before it crosses the JNI boundary.
+     *
+     * @throws IllegalArgumentException if [value] is negative.
+     */
+    private fun requireNonNegative(
+        value: Long,
+        name: String
+    ) {
+        require(value >= 0) { "$name $value must be nonnegative" }
+    }
+
+    /**
+     * Validates that [value] is nonnegative before it crosses the JNI boundary.
+     *
+     * @throws IllegalArgumentException if [value] is negative.
+     */
+    private fun requireNonNegative(
+        value: Int,
+        name: String
+    ) {
+        require(value >= 0) { "$name $value must be nonnegative" }
+    }
+
     override suspend fun writeBlockMetadata(blockMetadata: List<JniBlockMeta>) {
         metadata.addAll(blockMetadata)
     }
 
     override suspend fun rewindToHeight(height: Long): JniRewindResult {
+        requireValidHeight(height, "height")
         metadata.removeAll { it.height > height }
         return JniRewindResult.Success(height)
     }
@@ -41,10 +81,14 @@ class FakeRustBackend(
         ironwoodStartIndex: Long,
         ironwoodRoots: List<JniSubtreeRoot>,
     ) {
+        requireNonNegative(saplingStartIndex, "saplingStartIndex")
+        requireNonNegative(orchardStartIndex, "orchardStartIndex")
+        requireNonNegative(ironwoodStartIndex, "ironwoodStartIndex")
         error("Intentionally not implemented yet.")
     }
 
     override suspend fun updateChainTip(height: Long) {
+        requireValidHeight(height, "height")
         error("Intentionally not implemented yet.")
     }
 
@@ -77,6 +121,8 @@ class FakeRustBackend(
         value: Long,
         height: Long
     ) {
+        requireNonNegative(index, "index")
+        requireValidHeight(height, "height")
         error("Intentionally not implemented yet.")
     }
 
@@ -87,9 +133,13 @@ class FakeRustBackend(
         error("Intentionally not implemented yet.")
     }
 
-    override suspend fun findBlockMetadata(height: Long): JniBlockMeta? = metadata.findLast { it.height == height }
+    override suspend fun findBlockMetadata(height: Long): JniBlockMeta? {
+        requireValidHeight(height, "height")
+        return metadata.findLast { it.height == height }
+    }
 
     override suspend fun rewindBlockMetadataToHeight(height: Long) {
+        requireValidHeight(height, "height")
         metadata.removeAll { it.height > height }
     }
 
@@ -245,6 +295,7 @@ class FakeRustBackend(
     }
 
     override fun getBranchIdForHeight(height: Long): Long {
+        requireValidHeight(height, "height")
         error("Intentionally not implemented yet.")
     }
 
@@ -253,6 +304,7 @@ class FakeRustBackend(
         protocol: Int,
         outputIndex: Int
     ): String? {
+        requireNonNegative(outputIndex, "outputIndex")
         error("Intentionally not implemented yet.")
     }
 
@@ -260,7 +312,11 @@ class FakeRustBackend(
         fromHeight: Long,
         fromState: ByteArray,
         limit: Long
-    ) = error("Intentionally not implemented in mocked FakeRustBackend implementation.")
+    ): JniScanSummary {
+        requireValidHeight(fromHeight, "fromHeight")
+        requireNonNegative(limit, "limit")
+        error("Intentionally not implemented in mocked FakeRustBackend implementation.")
+    }
 
     override suspend fun transactionDataRequests(): List<JniTransactionDataRequest> {
         error("Intentionally not implemented yet.")

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/RustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/RustBackend.kt
@@ -4,6 +4,7 @@ import cash.z.ecc.android.sdk.internal.Backend
 import cash.z.ecc.android.sdk.internal.SdkDispatchers
 import cash.z.ecc.android.sdk.internal.ext.deleteRecursivelySuspend
 import cash.z.ecc.android.sdk.internal.ext.deleteSuspend
+import cash.z.ecc.android.sdk.internal.ext.isInUIntRange
 import cash.z.ecc.android.sdk.internal.model.JniAccount
 import cash.z.ecc.android.sdk.internal.model.JniAccountUsk
 import cash.z.ecc.android.sdk.internal.model.JniBlockMeta
@@ -60,6 +61,43 @@ class RustBackend private constructor(
             }
         }
         return cacheClearResult && dataClearResult
+    }
+
+    /**
+     * Validates that [height] is within the unsigned 32-bit range accepted by the Rust layer
+     * before it crosses the JNI boundary.
+     *
+     * @throws IllegalArgumentException if [height] is outside the valid UInt range.
+     */
+    private fun requireValidHeight(
+        height: Long,
+        name: String
+    ) {
+        require(height.isInUIntRange()) { "$name $height is outside of allowed UInt range" }
+    }
+
+    /**
+     * Validates that [value] is nonnegative before it crosses the JNI boundary.
+     *
+     * @throws IllegalArgumentException if [value] is negative.
+     */
+    private fun requireNonNegative(
+        value: Long,
+        name: String
+    ) {
+        require(value >= 0) { "$name $value must be nonnegative" }
+    }
+
+    /**
+     * Validates that [value] is nonnegative before it crosses the JNI boundary.
+     *
+     * @throws IllegalArgumentException if [value] is negative.
+     */
+    private fun requireNonNegative(
+        value: Int,
+        name: String
+    ) {
+        require(value >= 0) { "$name $value must be nonnegative" }
     }
 
     //
@@ -209,6 +247,7 @@ class RustBackend private constructor(
         protocol: Int,
         outputIndex: Int
     ) = withContext(SdkDispatchers.DATABASE_IO) {
+        requireNonNegative(outputIndex, "outputIndex")
         getMemoAsUtf8(
             dataDbFile.absolutePath,
             txId,
@@ -239,6 +278,7 @@ class RustBackend private constructor(
 
     override suspend fun findBlockMetadata(height: Long) =
         withContext(SdkDispatchers.DATABASE_IO) {
+            requireValidHeight(height, "height")
             findBlockMetadata(
                 fsBlockDbRoot.absolutePath,
                 height
@@ -247,6 +287,7 @@ class RustBackend private constructor(
 
     override suspend fun rewindBlockMetadataToHeight(height: Long) =
         withContext(SdkDispatchers.DATABASE_IO) {
+            requireValidHeight(height, "height")
             rewindBlockMetadataToHeight(
                 fsBlockDbRoot.absolutePath,
                 height
@@ -264,9 +305,12 @@ class RustBackend private constructor(
 
     /**
      * Rewinds the data database to at most the given height.
+     *
+     * @throws IllegalArgumentException if [height] is outside the valid UInt range.
      */
     override suspend fun rewindToHeight(height: Long): JniRewindResult =
         withContext(SdkDispatchers.DATABASE_IO) {
+            requireValidHeight(height, "height")
             rewindToHeight(
                 dataDbFile.absolutePath,
                 height,
@@ -291,6 +335,9 @@ class RustBackend private constructor(
         ironwoodStartIndex: Long,
         ironwoodRoots: List<JniSubtreeRoot>,
     ) = withContext(SdkDispatchers.DATABASE_IO) {
+        requireNonNegative(saplingStartIndex, "saplingStartIndex")
+        requireNonNegative(orchardStartIndex, "orchardStartIndex")
+        requireNonNegative(ironwoodStartIndex, "ironwoodStartIndex")
         putSubtreeRoots(
             dataDbFile.absolutePath,
             saplingStartIndex,
@@ -305,6 +352,7 @@ class RustBackend private constructor(
 
     override suspend fun updateChainTip(height: Long) =
         withContext(SdkDispatchers.DATABASE_IO) {
+            requireValidHeight(height, "height")
             updateChainTip(
                 dataDbFile.absolutePath,
                 height,
@@ -364,6 +412,8 @@ class RustBackend private constructor(
         limit: Long
     ): JniScanSummary =
         withContext(SdkDispatchers.DATABASE_IO) {
+            requireValidHeight(fromHeight, "fromHeight")
+            requireNonNegative(limit, "limit")
             scanBlocks(
                 fsBlockDbRoot.absolutePath,
                 dataDbFile.absolutePath,
@@ -530,6 +580,8 @@ class RustBackend private constructor(
         value: Long,
         height: Long
     ) = withContext(SdkDispatchers.DATABASE_IO) {
+        requireNonNegative(index, "index")
+        requireValidHeight(height, "height")
         putUtxo(
             dataDbFile.absolutePath,
             txId,
@@ -561,7 +613,10 @@ class RustBackend private constructor(
 
     override fun isValidTexAddr(addr: String) = isValidTexAddress(addr, networkId = networkId)
 
-    override fun getBranchIdForHeight(height: Long): Long = branchIdForHeight(height, networkId = networkId)
+    override fun getBranchIdForHeight(height: Long): Long {
+        requireValidHeight(height, "height")
+        return branchIdForHeight(height, networkId = networkId)
+    }
 
     /**
      * Exposes all of the librustzcash functions along with helpers for loading the static library.

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/RustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/RustBackend.kt
@@ -4,7 +4,8 @@ import cash.z.ecc.android.sdk.internal.Backend
 import cash.z.ecc.android.sdk.internal.SdkDispatchers
 import cash.z.ecc.android.sdk.internal.ext.deleteRecursivelySuspend
 import cash.z.ecc.android.sdk.internal.ext.deleteSuspend
-import cash.z.ecc.android.sdk.internal.ext.isInUIntRange
+import cash.z.ecc.android.sdk.internal.ext.requireNonNegative
+import cash.z.ecc.android.sdk.internal.ext.requireValidHeight
 import cash.z.ecc.android.sdk.internal.model.JniAccount
 import cash.z.ecc.android.sdk.internal.model.JniAccountUsk
 import cash.z.ecc.android.sdk.internal.model.JniBlockMeta
@@ -61,43 +62,6 @@ class RustBackend private constructor(
             }
         }
         return cacheClearResult && dataClearResult
-    }
-
-    /**
-     * Validates that [height] is within the unsigned 32-bit range accepted by the Rust layer
-     * before it crosses the JNI boundary.
-     *
-     * @throws IllegalArgumentException if [height] is outside the valid UInt range.
-     */
-    private fun requireValidHeight(
-        height: Long,
-        name: String
-    ) {
-        require(height.isInUIntRange()) { "$name $height is outside of allowed UInt range" }
-    }
-
-    /**
-     * Validates that [value] is nonnegative before it crosses the JNI boundary.
-     *
-     * @throws IllegalArgumentException if [value] is negative.
-     */
-    private fun requireNonNegative(
-        value: Long,
-        name: String
-    ) {
-        require(value >= 0) { "$name $value must be nonnegative" }
-    }
-
-    /**
-     * Validates that [value] is nonnegative before it crosses the JNI boundary.
-     *
-     * @throws IllegalArgumentException if [value] is negative.
-     */
-    private fun requireNonNegative(
-        value: Int,
-        name: String
-    ) {
-        require(value >= 0) { "$name $value must be nonnegative" }
     }
 
     //

--- a/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/jni/FakeRustBackendValidationTest.kt
+++ b/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/jni/FakeRustBackendValidationTest.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 
 /**
  * Exercises the [Backend][cash.z.ecc.android.sdk.internal.Backend] boundary argument validation
@@ -52,6 +53,209 @@ class FakeRustBackendValidationTest {
                     value = 0L,
                     height = 0L
                 )
+            }
+        }
+
+    @Test
+    fun negative_put_utxo_height_throws() =
+        runTest {
+            val backend = newBackend()
+
+            assertFailsWith<IllegalArgumentException> {
+                backend.putUtxo(
+                    txId = ByteArray(32),
+                    index = 0,
+                    script = ByteArray(0),
+                    value = 0L,
+                    height = -1L
+                )
+            }
+        }
+
+    @Test
+    fun above_uint_range_put_utxo_height_throws() =
+        runTest {
+            val backend = newBackend()
+
+            assertFailsWith<IllegalArgumentException> {
+                backend.putUtxo(
+                    txId = ByteArray(32),
+                    index = 0,
+                    script = ByteArray(0),
+                    value = 0L,
+                    height = 0x1_0000_0000L
+                )
+            }
+        }
+
+    @Test
+    fun negative_branch_id_height_throws() {
+        val backend = newBackend()
+
+        assertFailsWith<IllegalArgumentException> { backend.getBranchIdForHeight(-1L) }
+    }
+
+    @Test
+    fun above_uint_range_branch_id_height_throws() {
+        val backend = newBackend()
+
+        assertFailsWith<IllegalArgumentException> { backend.getBranchIdForHeight(0x1_0000_0000L) }
+    }
+
+    @Test
+    fun negative_update_chain_tip_height_throws() =
+        runTest {
+            val backend = newBackend()
+
+            assertFailsWith<IllegalArgumentException> { backend.updateChainTip(-1L) }
+        }
+
+    @Test
+    fun above_uint_range_update_chain_tip_height_throws() =
+        runTest {
+            val backend = newBackend()
+
+            assertFailsWith<IllegalArgumentException> { backend.updateChainTip(0x1_0000_0000L) }
+        }
+
+    @Test
+    fun negative_find_block_metadata_height_throws() =
+        runTest {
+            val backend = newBackend()
+
+            assertFailsWith<IllegalArgumentException> { backend.findBlockMetadata(-1L) }
+        }
+
+    @Test
+    fun above_uint_range_find_block_metadata_height_throws() =
+        runTest {
+            val backend = newBackend()
+
+            assertFailsWith<IllegalArgumentException> { backend.findBlockMetadata(0x1_0000_0000L) }
+        }
+
+    @Test
+    fun boundary_find_block_metadata_heights_are_accepted() =
+        runTest {
+            val backend = newBackend()
+
+            assertNull(backend.findBlockMetadata(0L))
+            assertNull(backend.findBlockMetadata(0xFFFF_FFFFL))
+        }
+
+    @Test
+    fun negative_rewind_block_metadata_height_throws() =
+        runTest {
+            val backend = newBackend()
+
+            assertFailsWith<IllegalArgumentException> { backend.rewindBlockMetadataToHeight(-1L) }
+        }
+
+    @Test
+    fun above_uint_range_rewind_block_metadata_height_throws() =
+        runTest {
+            val backend = newBackend()
+
+            assertFailsWith<IllegalArgumentException> { backend.rewindBlockMetadataToHeight(0x1_0000_0000L) }
+        }
+
+    @Test
+    fun boundary_rewind_block_metadata_heights_are_accepted() =
+        runTest {
+            val backend = newBackend()
+
+            backend.rewindBlockMetadataToHeight(0L)
+            backend.rewindBlockMetadataToHeight(0xFFFF_FFFFL)
+        }
+
+    @Test
+    fun negative_scan_blocks_from_height_throws() =
+        runTest {
+            val backend = newBackend()
+
+            assertFailsWith<IllegalArgumentException> {
+                backend.scanBlocks(fromHeight = -1L, fromState = ByteArray(0), limit = 0L)
+            }
+        }
+
+    @Test
+    fun above_uint_range_scan_blocks_from_height_throws() =
+        runTest {
+            val backend = newBackend()
+
+            assertFailsWith<IllegalArgumentException> {
+                backend.scanBlocks(fromHeight = 0x1_0000_0000L, fromState = ByteArray(0), limit = 0L)
+            }
+        }
+
+    @Test
+    fun negative_scan_blocks_limit_throws() =
+        runTest {
+            val backend = newBackend()
+
+            assertFailsWith<IllegalArgumentException> {
+                backend.scanBlocks(fromHeight = 0L, fromState = ByteArray(0), limit = -1L)
+            }
+        }
+
+    @Test
+    fun negative_sapling_start_index_throws() =
+        runTest {
+            val backend = newBackend()
+
+            assertFailsWith<IllegalArgumentException> {
+                backend.putSubtreeRoots(
+                    saplingStartIndex = -1L,
+                    saplingRoots = emptyList(),
+                    orchardStartIndex = 0L,
+                    orchardRoots = emptyList(),
+                    ironwoodStartIndex = 0L,
+                    ironwoodRoots = emptyList()
+                )
+            }
+        }
+
+    @Test
+    fun negative_orchard_start_index_throws() =
+        runTest {
+            val backend = newBackend()
+
+            assertFailsWith<IllegalArgumentException> {
+                backend.putSubtreeRoots(
+                    saplingStartIndex = 0L,
+                    saplingRoots = emptyList(),
+                    orchardStartIndex = -1L,
+                    orchardRoots = emptyList(),
+                    ironwoodStartIndex = 0L,
+                    ironwoodRoots = emptyList()
+                )
+            }
+        }
+
+    @Test
+    fun negative_ironwood_start_index_throws() =
+        runTest {
+            val backend = newBackend()
+
+            assertFailsWith<IllegalArgumentException> {
+                backend.putSubtreeRoots(
+                    saplingStartIndex = 0L,
+                    saplingRoots = emptyList(),
+                    orchardStartIndex = 0L,
+                    orchardRoots = emptyList(),
+                    ironwoodStartIndex = -1L,
+                    ironwoodRoots = emptyList()
+                )
+            }
+        }
+
+    @Test
+    fun negative_memo_output_index_throws() =
+        runTest {
+            val backend = newBackend()
+
+            assertFailsWith<IllegalArgumentException> {
+                backend.getMemoAsUtf8(txId = ByteArray(32), protocol = 0, outputIndex = -1)
             }
         }
 }

--- a/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/jni/FakeRustBackendValidationTest.kt
+++ b/backend-lib/src/test/java/cash/z/ecc/android/sdk/internal/jni/FakeRustBackendValidationTest.kt
@@ -1,0 +1,57 @@
+package cash.z.ecc.android.sdk.internal.jni
+
+import cash.z.ecc.android.sdk.internal.model.JniRewindResult
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+/**
+ * Exercises the [Backend][cash.z.ecc.android.sdk.internal.Backend] boundary argument validation
+ * against [FakeRustBackend], which is constructible without the native library.
+ */
+class FakeRustBackendValidationTest {
+    private fun newBackend() = FakeRustBackend(networkId = 0, metadata = mutableListOf())
+
+    @Test
+    fun negative_height_throws() =
+        runTest {
+            val backend = newBackend()
+
+            assertFailsWith<IllegalArgumentException> { backend.rewindToHeight(-1L) }
+        }
+
+    @Test
+    fun max_uint_height_is_accepted() =
+        runTest {
+            val backend = newBackend()
+
+            val result = backend.rewindToHeight(0xFFFF_FFFFL)
+
+            assertIs<JniRewindResult.Success>(result)
+        }
+
+    @Test
+    fun above_uint_range_height_throws() =
+        runTest {
+            val backend = newBackend()
+
+            assertFailsWith<IllegalArgumentException> { backend.rewindToHeight(0x1_0000_0000L) }
+        }
+
+    @Test
+    fun negative_index_throws() =
+        runTest {
+            val backend = newBackend()
+
+            assertFailsWith<IllegalArgumentException> {
+                backend.putUtxo(
+                    txId = ByteArray(32),
+                    index = -1,
+                    script = ByteArray(0),
+                    value = 0L,
+                    height = 0L
+                )
+            }
+        }
+}


### PR DESCRIPTION
## Summary

- Adds argument-range validation at the raw Kotlin `Backend`/`RustBackend` boundary
  (`backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/Backend.kt` and
  `.../internal/jni/RustBackend.kt`) so out-of-range values throw `IllegalArgumentException`
  at the call site, before crossing the JNI boundary.
- Mirrors the same checks in `FakeRustBackend` so the fake and real implementations behave
  identically.

### Layered-defense rationale

- The typed `TypesafeBackend` path in `sdk-lib` is already safe: its `BlockHeight` model
  `require`s the UInt32 range in `init`.
- The gap was the raw surface in `backend-lib`: `Backend`/`RustBackend` take plain
  `Long`/`Int` with no validation before crossing JNI. `backend-lib` cannot depend on
  `sdk-lib`'s model type, so a new shared type wasn't an option — `require(...)` at the
  Kotlin entry points is the chosen fix.
- This PR adds the **first line of defense** at the Kotlin/JNI boundary. The Rust-side checks
  from #2197 (MOB-1694) and the parallel MOB-1764 sweep remain the **second line of defense**
  inside the Rust layer itself.

### Methods covered

Block heights (must be in `0..0xFFFF_FFFFL`): `getBranchIdForHeight`, `rewindToHeight`,
`updateChainTip`, `findBlockMetadata`, `rewindBlockMetadataToHeight`, `putUtxo` (height),
`scanBlocks` (fromHeight).

Indices/counts (must be nonnegative): `putUtxo` (index), `putSubtreeRoots` (sapling/orchard/
ironwood start indices), `getMemoAsUtf8` (outputIndex), `scanBlocks` (limit).

## Test plan

- [x] `./gradlew ktlint` — passes
- [x] `./gradlew detektAll` — passes
- [x] `./gradlew :backend-lib:compileDebugKotlin` — compiles
- [x] `./gradlew :backend-lib:testDebugUnitTest` — full suite green, including the new
      `FakeRustBackendValidationTest` (negative height throws, `0xFFFF_FFFFL` accepted,
      `0x1_0000_0000L` throws, negative index throws)

Linear: https://linear.app/zodl/issue/MOB-1765/validate-heightcount-arguments-at-the-rustbackend-kotlin-boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)