### PR TITLE
Fix forceDownload() silently swallowing Sapling param fetch failures

### DIFF
--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/SaplingParamFetcher.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/SaplingParamFetcher.kt
@@ -39,13 +39,10 @@ internal class SaplingParamFetcher(
             }
         }
 
-    @Suppress("TooGenericExceptionCaught")
     suspend fun forceDownload() =
         mutex.withLock {
-            try {
+            retryAndRethrow {
                 saplingParamTool.ensureParams(saplingParamTool.properties.paramsDirectory)
-            } catch (e: Exception) {
-                Twig.error(e) { "Caught exception while fetching sapling params." }
             }
         }
 
@@ -60,6 +57,25 @@ internal class SaplingParamFetcher(
                 failedAttempts++
                 if (failedAttempts == 2) return
                 delay(10.seconds)
+            }
+        }
+    }
+
+    // Unlike retryAndContinue (best-effort background prefetch), this is called synchronously
+    // right before proving/tx creation, so a download failure must propagate instead of letting
+    // the caller proceed against missing/incomplete param files (see PRO-97, MOB-1674).
+    private suspend inline fun retryAndRethrow(block: () -> Unit) {
+        var failedAttempts = 0
+        while (true) {
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                block()
+                return
+            } catch (e: Throwable) {
+                failedAttempts++
+                Twig.error(e) { "Caught exception while fetching sapling params (attempt $failedAttempts)." }
+                if (failedAttempts >= 2) throw e
+                delay(3.seconds)
             }
         }
     }


### PR DESCRIPTION
## Summary
- `SaplingParamFetcher.forceDownload()` runs synchronously right before proving/tx creation (`TransactionEncoderImpl.createProposedTransactions` / `addProofsToPczt`), but caught and logged any download failure instead of propagating it.
- That let callers proceed against missing/incomplete param files, which then failed downstream with a misleading native error (e.g. `parameter file size is not correct`) or, in the Keystone PCZT path, a contentless generic error — losing the real cause in both cases.
- Fix: give `forceDownload()` one retry (mirroring the existing background-prefetch retry in `downloadIfNeeded()`), then rethrow on final failure so callers get the actual download-failure exception.

Related to [PRO-97 / MOB-1763](https://linear.app/zodl/issue/MOB-1763/parameter-file-size-is-not-correct-please-clean-your-zcash-parameters) (also addressed by the concurrency fix in #2011) and [MOB-1674](https://linear.app/zodl/issue/MOB-1674/error-submitting-transaction-pczt-with-proofs-is-null) — this covers the plain network-failure trigger, which is a separate cause from the race condition #2011 fixes.

## Test plan
- [x] `:sdk-lib:compileDebugKotlin` and `:sdk-lib:ktlint` pass (built via the app's composite build against this branch)
- [x] Both existing callers (`createProposedTransactions`, `addProofsToPczt`) already wrap `forceDownload()` in `runCatching { ... }.getOrElse { throw <TypedException>(it.message, it.cause) }`, so the propagated exception is correctly wrapped with no caller changes needed