### PR TITLE
Surface setupBundles' dropped dust-note count through the SDK

### DIFF
--- a/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
+++ b/backend-lib/src/androidTest/java/cash/z/ecc/android/sdk/internal/jni/VotingRustBackendTest.kt
@@ -69,6 +69,8 @@ class VotingRustBackendTest {
         private const val LARGE_BUNDLE_WEIGHT = 62_500_000L
         private const val SMALL_BUNDLE_WEIGHT = 12_500_000L
         private const val TWO_BUNDLE_ELIGIBLE_WEIGHT = 75_000_000L
+        private const val DUST_NOTE_VALUE = 100L
+        private const val BUNDLE_NOTE_SLOTS = 5
         private val EA_PK = ByteArray(FIELD_BYTES) { 3 }
         private val NC_ROOT = ByteArray(FIELD_BYTES) { 4 }
         private val NULLIFIER_IMT_ROOT = ByteArray(FIELD_BYTES) { 5 }
@@ -380,6 +382,28 @@ class VotingRustBackendTest {
             assertEquals(TWO_BUNDLE_ELIGIBLE_WEIGHT, setup.eligibleWeight)
             assertEquals(listOf(LARGE_BUNDLE_WEIGHT, SMALL_BUNDLE_WEIGHT), setup.bundleWeights)
             assertEquals(setup.eligibleWeight, setup.bundleWeights.sum())
+            assertEquals(0, setup.droppedCount)
+        }
+
+    @Test
+    fun compute_bundle_setup_reports_dropped_dust_count() =
+        runTest {
+            // One real note fills the first bundle's remaining slots with dust; the
+            // last dust note overflows into its own bundle, which falls below
+            // BALLOT_DIVISOR and is dropped.
+            val dustNotes =
+                (1..BUNDLE_NOTE_SLOTS).map { index ->
+                    note(value = DUST_NOTE_VALUE, position = index.toLong(), byteValue = index + 1)
+                }
+            val setup =
+                VotingRustBackend.new().computeBundleSetup(
+                    listOf(note(value = NOTE_VALUE, position = 0, byteValue = 1)) + dustNotes
+                )
+
+            assertEquals(1, setup.bundleCount)
+            assertEquals(SMALL_BUNDLE_WEIGHT, setup.eligibleWeight)
+            assertEquals(listOf(SMALL_BUNDLE_WEIGHT), setup.bundleWeights)
+            assertEquals(1, setup.droppedCount)
         }
 
     @Test
@@ -427,6 +451,7 @@ class VotingRustBackendTest {
                 assertEquals(TWO_BUNDLE_ELIGIBLE_WEIGHT, setup.eligibleWeight)
                 assertEquals(listOf(LARGE_BUNDLE_WEIGHT, SMALL_BUNDLE_WEIGHT), setup.bundleWeights)
                 assertEquals(setup.eligibleWeight, setup.bundleWeights.sum())
+                assertEquals(0, setup.droppedCount)
                 assertEquals(2, db.getBundleCount(ROUND_ID))
 
                 val deletedRows = db.deleteSkippedBundles(ROUND_ID, keepCount = 1)

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModels.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/voting/JniVotingModels.kt
@@ -539,10 +539,11 @@ internal const val JNI_ROUND_PHASE_VOTE_READY = 4
 data class JniBundleSetupResult(
     val bundleCount: Int,
     val eligibleWeight: Long,
-    val bundleWeights: List<Long>
+    val bundleWeights: List<Long>,
+    val droppedCount: Int
 ) {
-    internal constructor(bundleCount: Int, eligibleWeight: Long, bundleWeights: LongArray) :
-        this(bundleCount, eligibleWeight, bundleWeights.toList())
+    internal constructor(bundleCount: Int, eligibleWeight: Long, bundleWeights: LongArray, droppedCount: Int) :
+        this(bundleCount, eligibleWeight, bundleWeights.toList(), droppedCount)
 }
 
 @Keep

--- a/backend-lib/src/main/rust/voting/helpers.rs
+++ b/backend-lib/src/main/rust/voting/helpers.rs
@@ -71,8 +71,8 @@ const JNI_SHARE_DELEGATION_RECORD_CTOR_SIG: &str =
     "(Ljava/lang/String;III[Ljava/lang/String;[BZJJ)V";
 // Must match JniVotingHotkey(ByteArray, ByteArray, String) in JniVotingModels.kt.
 const JNI_VOTING_HOTKEY_CTOR_SIG: &str = "([B[BLjava/lang/String;)V";
-// Must match JniBundleSetupResult(Int, Long, LongArray) in JniVotingModels.kt.
-const JNI_BUNDLE_SETUP_RESULT_CTOR_SIG: &str = "(IJ[J)V";
+// Must match JniBundleSetupResult(Int, Long, LongArray, Int) in JniVotingModels.kt.
+const JNI_BUNDLE_SETUP_RESULT_CTOR_SIG: &str = "(IJ[JI)V";
 // Must match JniGovernancePczt(ByteArray, ByteArray, ByteArray, Int) in
 // JniVotingModels.kt.
 const JNI_GOVERNANCE_PCZT_CTOR_SIG: &str = "([B[B[BI)V";
@@ -1504,6 +1504,7 @@ pub(super) fn make_jni_bundle_setup_result<'local>(
     count: u32,
     weight: u64,
     bundle_weights: &[u64],
+    dropped_count: u32,
 ) -> anyhow::Result<jobject> {
     let class = env.find_class(JNI_BUNDLE_SETUP_RESULT)?;
     let weights = bundle_weights
@@ -1522,6 +1523,7 @@ pub(super) fn make_jni_bundle_setup_result<'local>(
             JValue::Int(u32_to_jint(count, "bundle_count")?),
             JValue::Long(u64_to_jlong(weight, "eligible_weight")?),
             JValue::Object(&weights_array_obj),
+            JValue::Int(u32_to_jint(dropped_count, "dropped_count")?),
         ],
     )?;
     Ok(obj.into_raw())
@@ -1709,9 +1711,20 @@ fn make_jni_fixed_byte_array_vec<'local>(
     })?)
 }
 
+/// Result of [`bundle_setup_from_notes`]: the voting note chunker's output in
+/// JNI-ready primitives.
+pub(super) struct NoteBundleSetup {
+    pub(super) count: u32,
+    pub(super) eligible_weight: u64,
+    pub(super) bundle_weights: Vec<u64>,
+    /// Number of notes dropped as dust (notes whose bundle fell below
+    /// `BALLOT_DIVISOR` and was discarded).
+    pub(super) dropped_count: u32,
+}
+
 /// Runs the voting note chunker and returns total count, total eligible weight,
-/// and each bundle's quantized voting weight.
-pub(super) fn bundle_setup_from_notes(notes: &[NoteInfo]) -> anyhow::Result<(u32, u64, Vec<u64>)> {
+/// each bundle's quantized voting weight, and the number of notes dropped as dust.
+pub(super) fn bundle_setup_from_notes(notes: &[NoteInfo]) -> anyhow::Result<NoteBundleSetup> {
     // zcash_voting 1.0.0 (merged-library patch) moved `chunk_notes` from `types` to
     // `note_bundling`; same `&[NoteInfo] -> ChunkResult` signature.
     let chunk_result = voting::note_bundling::chunk_notes(notes);
@@ -1726,12 +1739,14 @@ pub(super) fn bundle_setup_from_notes(notes: &[NoteInfo]) -> anyhow::Result<(u32
             Ok((total / voting::BALLOT_DIVISOR) * voting::BALLOT_DIVISOR)
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
-    Ok((
-        u32::try_from(chunk_result.bundles.len())
+    Ok(NoteBundleSetup {
+        count: u32::try_from(chunk_result.bundles.len())
             .map_err(|_| anyhow!("bundle count is too large for u32"))?,
-        chunk_result.eligible_weight,
+        eligible_weight: chunk_result.eligible_weight,
         bundle_weights,
-    ))
+        dropped_count: u32::try_from(chunk_result.dropped_count)
+            .map_err(|_| anyhow!("dropped_count is too large for u32"))?,
+    })
 }
 
 /// Recomputes deterministic note chunking and returns the requested bundle.

--- a/backend-lib/src/main/rust/voting/notes.rs
+++ b/backend-lib/src/main/rust/voting/notes.rs
@@ -111,8 +111,14 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_com
 ) -> jobject {
     let res = catch_unwind(&mut env, |env| {
         let notes = java_note_info_array(env, &notes, "notes")?;
-        let (count, weight, bundle_weights) = bundle_setup_from_notes(&notes)?;
-        make_jni_bundle_setup_result(env, count, weight, &bundle_weights)
+        let setup = bundle_setup_from_notes(&notes)?;
+        make_jni_bundle_setup_result(
+            env,
+            setup.count,
+            setup.eligible_weight,
+            &setup.bundle_weights,
+            setup.dropped_count,
+        )
     });
     unwrap_exc_or(&mut env, res, JObject::null().into_raw())
 }
@@ -263,7 +269,11 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_set
         let db = db_from_handle(db_handle)?;
         let _access_lock = db.access_lock()?;
         let notes = java_note_info_array(env, &notes, "notes")?;
-        let (expected_count, expected_weight, bundle_weights) = bundle_setup_from_notes(&notes)?;
+        // setup.dropped_count is intentionally not part of this cross-check: the DB
+        // layer's skipped-suffix recovery path (below) reports dropped_count=0 for an
+        // already-persisted round regardless of the note set's actual dust, so comparing
+        // it here against the freshly recomputed value would false-positive on that path.
+        let setup = bundle_setup_from_notes(&notes)?;
         let round_id = java_string_to_rust(env, &round_id)?;
         let layout = db
             .ensure_bundles_with_skipped_suffix_with_policy(
@@ -272,7 +282,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_set
                 voting::BundlePolicy::default(),
             )
             .map_err(|e| anyhow!("ensure_bundles_with_skipped_suffix_with_policy: {}", e))?;
-        if layout.bundle_count != expected_count || layout.eligible_weight != expected_weight {
+        if layout.bundle_count != setup.count || layout.eligible_weight != setup.eligible_weight {
             // ensure_bundles_with_skipped_suffix_with_policy has already persisted the
             // round's bundles. Treat a mismatch as an internal bug; callers must clear
             // the round before retrying.
@@ -280,15 +290,16 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend_set
                 "setup_bundles result mismatch after persisting bundles; call clearRound before retrying: db=({}, {}) chunk=({}, {})",
                 layout.bundle_count,
                 layout.eligible_weight,
-                expected_count,
-                expected_weight
+                setup.count,
+                setup.eligible_weight
             ));
         }
         make_jni_bundle_setup_result(
             env,
             layout.bundle_count,
             layout.eligible_weight,
-            &bundle_weights,
+            &setup.bundle_weights,
+            layout.dropped_count,
         )
     });
     unwrap_exc_or(&mut env, res, JObject::null().into_raw())

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/VotingSdkRoundMappers.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/VotingSdkRoundMappers.kt
@@ -29,7 +29,12 @@ internal fun JniVotingHotkey.toPublic(): VotingHotkey =
     VotingHotkey(storedSecret = storedSecret, rawAddress = rawAddress, address = address)
 
 internal fun JniBundleSetupResult.toPublic(): VotingBundleSetupResult =
-    VotingBundleSetupResult(bundleCount = bundleCount, eligibleWeight = eligibleWeight, bundleWeights = bundleWeights)
+    VotingBundleSetupResult(
+        bundleCount = bundleCount,
+        eligibleWeight = eligibleWeight,
+        bundleWeights = bundleWeights,
+        droppedCount = droppedCount
+    )
 
 // NOTE: deviates from the brief, which mapped from `JniGovernancePczt`. `TypesafeVotingDb`'s
 // `buildGovernancePczt`/`buildGovernancePcztFromSeed` (pre-existing, not part of this plan)

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/voting/VotingModels.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/model/voting/VotingModels.kt
@@ -297,11 +297,18 @@ data class VotingHotkey(
     override fun hashCode(): Int = address.hashCode()
 }
 
-/** The count/weight summary produced when a round's bundles are first laid out. */
+/**
+ * The count/weight summary produced when a round's bundles are first laid out.
+ *
+ * @param droppedCount the number of notes dropped as dust: notes that landed in a bundle
+ *  whose total value fell below the ballot divisor, so the bundle (and its notes) was
+ *  excluded from [bundleCount]/[eligibleWeight]/[bundleWeights].
+ */
 data class VotingBundleSetupResult(
     val bundleCount: Int,
     val eligibleWeight: Long,
-    val bundleWeights: List<Long>
+    val bundleWeights: List<Long>,
+    val droppedCount: Int
 )
 
 /** An unsigned governance PCZT and its extracted extraction metadata. */


### PR DESCRIPTION
zcash_voting's BundleLayout/ChunkResult already compute dropped_count
(notes whose bundle fell below BALLOT_DIVISOR and was discarded), but the
JNI layer threw it away when building JniBundleSetupResult, so callers of
computeBundleSetup/setupBundles had no way to know dust had silently
reduced their eligible voting weight. Thread it through: Rust's
bundle_setup_from_notes now returns a named NoteBundleSetup struct
(instead of a positional tuple) carrying dropped_count, the JNI ctor
signature grew an Int, and JniBundleSetupResult/VotingBundleSetupResult
gained a droppedCount field mapped straight through.

Fixes MOB-1560.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
