### PR TITLE
Cascade Orchard migration fixes from maint/v3.1.x into candidate/v4.0.0

### DIFF
--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/MigrationRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/MigrationRustBackend.kt
@@ -480,12 +480,12 @@ class MigrationRustBackend private constructor() {
 
     /**
      * The zatoshi value below which a leftover post-migration Orchard balance is treated as dust
-     * rather than a residual worth migrating in its own transfer — see
-     * `MIGRATION_DUST_THRESHOLD_ZATOSHI` in `migration.rs`. A fixed protocol-level constant, not
-     * derived from any wallet/account state — [SdkDispatchers.CPU_BOUND] (2026-08-07 blocking-
-     * without-reason audit), not [SdkDispatchers.DATABASE_IO]: this never touches a database, so
-     * routing it through the SDK's single shared DB-IO thread bought nothing but contention with
-     * genuine migration DB reads/writes.
+     * rather than a residual worth migrating in its own transfer — `2 * MARGINAL_FEE`, see
+     * `migration_dust_threshold_zatoshi()` in `migration.rs`. Not derived from any wallet/account
+     * state — [SdkDispatchers.CPU_BOUND] (2026-08-07 blocking-without-reason audit), not
+     * [SdkDispatchers.DATABASE_IO]: this never touches a database, so routing it through the SDK's
+     * single shared DB-IO thread bought nothing but contention with genuine migration DB reads/
+     * writes.
      */
     @Throws(RuntimeException::class)
     suspend fun migrationDustThresholdZatoshi(): Long =

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/MigrationRustBackend.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/jni/MigrationRustBackend.kt
@@ -494,6 +494,23 @@ class MigrationRustBackend private constructor() {
         }
 
     /**
+     * Kris Nuttycombe's per-note "is the leftover balance worth prompting to migrate" total:
+     * `sum(value - MARGINAL_FEE)` over every spendable Orchard note whose value exceeds
+     * `MARGINAL_FEE` — see `migratableOrchardTotalNative` in `migration.rs` for the full doc.
+     * Compare this against [migrationDustThresholdZatoshi] (already `2 * MARGINAL_FEE`), not the
+     * raw aggregate Orchard balance.
+     */
+    @Throws(RuntimeException::class)
+    suspend fun migratableOrchardTotal(
+        dbDataPath: String,
+        networkId: Int,
+        accountUuidBytes: ByteArray
+    ): Long =
+        withContext(SdkDispatchers.DATABASE_IO) {
+            migratableOrchardTotalNative(dbDataPath, networkId, accountUuidBytes)
+        }
+
+    /**
      * Lists every account's UUID in the wallet database, independent of any live `Synchronizer`.
      */
     @Throws(RuntimeException::class)
@@ -932,6 +949,14 @@ class MigrationRustBackend private constructor() {
         @JvmStatic
         @Throws(RuntimeException::class)
         private external fun migrationDustThresholdZatoshiNative(): Long
+
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        private external fun migratableOrchardTotalNative(
+            dbDataPath: String,
+            networkId: Int,
+            accountUuidBytes: ByteArray
+        ): Long
 
         @JvmStatic
         @Throws(RuntimeException::class)

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -46,11 +46,12 @@ use rusqlite::Connection;
 use std::num::NonZeroUsize;
 use std::ptr;
 
-use zcash_client_backend::data_api::wallet::input_selection::LockFilter;
+use zcash_client_backend::data_api::wallet::input_selection::{LockFilter, LockedInputPolicy};
 use zcash_client_backend::data_api::{InputSource, OutputLockStore, WalletRead};
 use zcash_client_backend::wallet::{LockOwner, OutputRef};
 use zcash_client_sqlite::AccountUuid;
 use zcash_client_sqlite::util::SystemClock;
+use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
 use zcash_protocol::consensus::{
     BLOCKS_PER_HOUR, BlockHeight, Network, NetworkConstants, Parameters,
 };
@@ -3346,6 +3347,63 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     _: JClass<'local>,
 ) -> jlong {
     MIGRATION_DUST_THRESHOLD_ZATOSHI as jlong
+}
+
+/// Kris Nuttycombe's per-note "is the leftover balance actually worth prompting to migrate"
+/// total (Zcash Foundation Slack, MOB-1750 follow-up, 2026-08): `sum(value - MARGINAL_FEE)` over
+/// every spendable Orchard note whose value exceeds `MARGINAL_FEE`. Notes at or below
+/// `MARGINAL_FEE` cost more to spend than they're worth, so summing net-of-fee value only across
+/// notes actually worth spending answers "how much would the user actually receive if they
+/// migrated everything right now" — replacing the raw aggregate Orchard balance the Kotlin call
+/// site compared against [`MIGRATION_DUST_THRESHOLD_ZATOSHI`] before this.
+///
+/// [`InputSource::select_unspent_notes`] already applies the `value > MARGINAL_FEE` filter at the
+/// SQL layer (`zcash_client_sqlite::wallet::common::select_unspent_notes`), so every note this
+/// call sees already qualifies for the sum — no re-filtering needed here.
+///
+/// `LockFilter::Policy(&LockedInputPolicy::Exclude)` matches `migration_engine::Backend`'s own
+/// `spendable_orchard()` (the migration engine's real note-selection view), not the `Unfiltered`
+/// view [`lockRemainingOrchardBalanceNative`] uses — this answers "what could a NEW migration
+/// actually move", so notes already locked by a prior "Lock balance" tap or an in-flight proposal
+/// correctly don't count toward it.
+///
+/// The threshold this total is compared against (`migratable_total > 2 * MARGINAL_FEE`) is left
+/// to the caller: [`MIGRATION_DUST_THRESHOLD_ZATOSHI`] already equals `2 * MARGINAL_FEE`
+/// (10,000 zatoshi), so no new threshold constant is needed — only the total this compares.
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_migratableOrchardTotalNative<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+    db_data: JString<'local>,
+    network_id: jint,
+    account_uuid: JByteArray<'local>,
+) -> jlong {
+    let res = catch_unwind(&mut env, |env| {
+        let (_network, wallet, _store_conn) = open(env, db_data, network_id)?;
+        let account = crate::account_id_from_jni(env, account_uuid)?;
+        let target = target_height(&wallet)?;
+
+        let received = wallet
+            .select_unspent_notes(
+                account,
+                &[ShieldedPool::Orchard],
+                target.into(),
+                &[],
+                LockFilter::Policy(&LockedInputPolicy::Exclude),
+            )
+            .map_err(|e| anyhow!("Error reading migratable Orchard total: {}", e))?;
+
+        let marginal_fee = u64::from(MARGINAL_FEE);
+        let total: u64 = received
+            .orchard()
+            .iter()
+            .map(|rn| rn.note().value().inner().saturating_sub(marginal_fee))
+            .sum();
+        Ok(total as jlong)
+    });
+    unwrap_exc_or(&mut env, res, 0)
 }
 
 // ----- External signer (Keystone hardware wallet) -----

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -51,7 +51,7 @@ use zcash_client_backend::data_api::{InputSource, OutputLockStore, WalletRead};
 use zcash_client_backend::wallet::{LockOwner, OutputRef};
 use zcash_client_sqlite::AccountUuid;
 use zcash_client_sqlite::util::SystemClock;
-use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
+use zcash_primitives::transaction::fees::{FeeRule, zip317::MARGINAL_FEE};
 use zcash_protocol::consensus::{
     BLOCKS_PER_HOUR, BlockHeight, Network, NetworkConstants, Parameters,
 };
@@ -3388,7 +3388,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     account_uuid: JByteArray<'local>,
 ) -> jlong {
     let res = catch_unwind(&mut env, |env| {
-        let (_network, wallet, _store_conn) = open(env, db_data, network_id)?;
+        let (network, wallet, _store_conn) = open(env, db_data, network_id)?;
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let target = target_height(&wallet)?;
 
@@ -3402,12 +3402,22 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
             )
             .map_err(|e| anyhow!("Error reading migratable Orchard total: {}", e))?;
 
-        let marginal_fee = u64::from(MARGINAL_FEE);
+        let fee_rule = zcash_primitives::transaction::fees::zip317::FeeRule::standard();
+        let fee = fee_rule
+            .fee_required(&network, target, [], [], 0, 0, received.orchard().len(), 0)
+            .map_err(|_| {
+                anyhow!(
+                    "Unable to compute fee for {} Orchard notes.",
+                    received.orchard().len()
+                )
+            })?;
+
         let total: u64 = received
             .orchard()
             .iter()
-            .map(|rn| rn.note().value().inner().saturating_sub(marginal_fee))
-            .sum();
+            .map(|rn| rn.note().value().inner())
+            .sum::<u64>()
+            .saturating_sub(fee.into_u64());
         Ok(total as jlong)
     });
     unwrap_exc_or(&mut env, res, 0)

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -43,6 +43,7 @@ use jni::{
 use prost::Message;
 use rand::rngs::OsRng;
 use rusqlite::Connection;
+use std::num::NonZeroUsize;
 use std::ptr;
 
 use zcash_client_backend::data_api::wallet::input_selection::LockFilter;
@@ -61,12 +62,13 @@ use zcash_pool_migration::{
     engine::{
         self, MigrationCrypto, MigrationPlan, MigrationState, MigrationTransaction,
         MigrationTransferId, MigrationTxKind, MigrationTxState, PoolMigrationRead,
-        PoolMigrationWrite, ProveError,
+        PoolMigrationWrite, ProveError, RunSizing,
     },
-    preparation::{PrepInput, PreparationPlan},
+    preparation::{PrepInput, PreparationPlan, default_portfolio},
     satisfiability::{
         AdvanceConfig, DuenessTargets, ReorgSettleDepth, ReplanThreshold, advance_migration,
     },
+    signing_rounds::RunSigningCapacity,
     state::{AdvanceStep, NextAction, StepKind},
 };
 
@@ -109,6 +111,63 @@ const JNI_KEYSTONE_BATCH_SIGNED_PCZTS: &str =
 /// transfer. 100,000 zatoshi = 0.001 ZEC. A fixed protocol-level constant, not derived from wallet
 /// or account state, so it needs no database access to read.
 pub const MIGRATION_DUST_THRESHOLD_ZATOSHI: u64 = 100_000;
+
+/// The per-run prepared-note cap for zodl's own in-process signer, well above the crate's
+/// [`MIGRATION_MAX_PREPARED_NOTES_PER_RUN`](zcash_pool_migration::denomination::MIGRATION_MAX_PREPARED_NOTES_PER_RUN)
+/// default of 50. That default exists to bound a run's transaction/proving cost for a signer that
+/// must sign it within a per-round action budget (Keystone); zodl's own signer has no such round
+/// to bound, so a larger cap just means fewer runs (and so fewer background sync/broadcast
+/// campaigns) for the same wallet, at the cost of a longer single planning/proving pass.
+const ZODL_MAX_PREPARED_NOTES_PER_RUN: NonZeroUsize = match NonZeroUsize::new(200) {
+    Some(v) => v,
+    None => panic!("nonzero"),
+};
+
+/// The single knob that decides how a migration run is sized, shared by every caller that plans
+/// or previews one (`compute_plan`, `estimateMigrationRunCountNative`) so the two can never drift
+/// apart — see those callers' own docs for why a mismatch between the previewed run count and the
+/// actually-planned run is a real, silent-failure-mode bug, not just a cosmetic inconsistency.
+///
+/// Keystone signs one round per manual QR scan (minutes of user time), so a Keystone run is sized
+/// to fit one round (96 actions) rather than a fixed note count — a run's action count follows the
+/// wallet's fragmentation, so a note cap alone cannot promise that (see
+/// `zcash_pool_migration::signing_rounds` module doc). zodl's own in-process signer has no such
+/// per-round cost, so it keeps a note-cap sizing instead — just a much larger cap than the crate's
+/// Keystone-oriented 50-note default (see [`ZODL_MAX_PREPARED_NOTES_PER_RUN`]).
+fn run_sizing_for(is_keystone: bool) -> RunSizing {
+    if is_keystone {
+        RunSizing::Signer(RunSigningCapacity::KEYSTONE)
+    } else {
+        RunSizing::Notes(ZODL_MAX_PREPARED_NOTES_PER_RUN)
+    }
+}
+
+#[cfg(test)]
+mod run_sizing_for_tests {
+    use super::*;
+
+    // No wallet fixture needed — this pins the exact mapping `compute_plan` and
+    // `estimateMigrationRunCountNative` both delegate to, so a future edit that swaps
+    // `RunSigningCapacity::KEYSTONE` for a different capacity, or reuses `RunSizing::Notes` for a
+    // Keystone account, fails here immediately instead of silently compiling and passing the rest
+    // of the suite (see the MOB-1760 code-review finding this test was added to close).
+
+    #[test]
+    fn keystone_accounts_use_signer_capacity() {
+        assert_eq!(
+            run_sizing_for(true),
+            RunSizing::Signer(RunSigningCapacity::KEYSTONE)
+        );
+    }
+
+    #[test]
+    fn non_keystone_accounts_use_the_zodl_note_cap() {
+        assert_eq!(
+            run_sizing_for(false),
+            RunSizing::Notes(ZODL_MAX_PREPARED_NOTES_PER_RUN)
+        );
+    }
+}
 
 pub(crate) type Wallet = zcash_client_sqlite::WalletDb<Connection, Network, SystemClock, OsRng>;
 
@@ -305,6 +364,8 @@ fn natural_anchor_height(wallet: &Wallet) -> anyhow::Result<BlockHeight> {
 /// JNI-free — see `open_at`'s doc comment. Every `MIGRATION_DIAG` log line this crate has needed
 /// so far to diagnose a live bug (anchor/witness resolution, schedule spread, note-split
 /// detection) came from here or `migration_finalize`, both callable directly from `cargo test`.
+///
+/// Run sizing branches on `Backend::is_keystone` (see [`run_sizing_for`]'s doc for why).
 fn compute_plan(
     network: &Network,
     wallet: &Wallet,
@@ -313,8 +374,14 @@ fn compute_plan(
 ) -> anyhow::Result<(MigrationPlan, BlockHeight)> {
     let backend = Backend::new(wallet, account, store_conn, *wallet.params())?;
     let mut rng = OsRng;
-    let migration_plan = engine::plan_migration(network, &backend, &mut rng)
-        .map_err(|e| anyhow!("Error planning migration: {:?}", e))?;
+    let migration_plan = engine::plan_migration_sized_with(
+        &default_portfolio(),
+        run_sizing_for(backend.is_keystone()),
+        network,
+        &backend,
+        &mut rng,
+    )
+    .map_err(|e| anyhow!("Error planning migration: {:?}", e))?;
     let prep = migration_plan.preparation();
     tracing::debug!(
         "MIGRATION_DIAG plan: preparation has {} layer(s), {} prep transaction(s) total, {} \
@@ -1794,8 +1861,9 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     unwrap_exc_or(&mut env, res, JNI_FALSE)
 }
 
-/// How many successive migration runs (see `engine::estimate_migration_runs`'s doc) the account's
-/// current Orchard balance would need, given the engine's per-run note cap. Purely a stateless
+/// How many successive migration runs (see `engine::estimate_migration_runs_sized_with`'s doc) the
+/// account's current Orchard balance would need, sized by [`run_sizing_for`] exactly as
+/// `compute_plan` sizes the run it actually plans. Purely a stateless
 /// preview — it has no memory of prior calls or rounds already committed, so callers must call this
 /// fresh every time they need it rather than caching the result across a multi-round campaign (see
 /// zashi-android's `docs/superpowers/specs/2026-07-22-keystone-multi-round-migration-continuation-design.md`).
@@ -1814,8 +1882,14 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
         let account = crate::account_id_from_jni(env, account_uuid)?;
         let backend = Backend::new(&wallet, account, &mut store_conn, *wallet.params())?;
         let mut rng = OsRng;
-        let estimate = engine::estimate_migration_runs(&network, &backend, &mut rng)
-            .map_err(|e| anyhow!("Error estimating migration runs: {:?}", e))?;
+        let estimate = engine::estimate_migration_runs_sized_with(
+            &default_portfolio(),
+            run_sizing_for(backend.is_keystone()),
+            &network,
+            &backend,
+            &mut rng,
+        )
+        .map_err(|e| anyhow!("Error estimating migration runs: {:?}", e))?;
         Ok(estimate.run_count() as jint)
     });
     unwrap_exc_or(&mut env, res, 0)
@@ -4217,8 +4291,15 @@ mod live_wallet_edge_case_tests {
     /// Creates a second, synthetic, permanently-unfunded account in `wallet` — not derived from
     /// the real test seed, and never scanned for funds — purely to have a second `AccountUuid` in
     /// the same wallet DB. `seed_byte` just needs to differ per call so two synthetic accounts in
-    /// one test don't collide with each other.
-    fn create_synthetic_account(wallet: &mut Wallet, seed_byte: u8, name: &str) -> AccountUuid {
+    /// one test don't collide with each other. `key_source` is stamped on the account row exactly
+    /// as `AccountDataSource.importKeystoneAccount` (zashi-android `ui-lib`) does for a real
+    /// Keystone import — pass `Some("keystone")` to make `Backend::is_keystone()` read `true`.
+    fn create_synthetic_account(
+        wallet: &mut Wallet,
+        seed_byte: u8,
+        name: &str,
+        key_source: Option<&str>,
+    ) -> AccountUuid {
         let tip = wallet
             .chain_height()
             .expect("chain height")
@@ -4227,7 +4308,7 @@ mod live_wallet_edge_case_tests {
             AccountBirthday::from_parts(ChainState::empty(tip, BlockHash([0; 32])), None);
         let seed = SecretVec::new(vec![seed_byte; 32]);
         let (account, _usk) = wallet
-            .create_account(name, &seed, &birthday, None)
+            .create_account(name, &seed, &birthday, key_source)
             .expect("create synthetic account");
         account
     }
@@ -4269,7 +4350,7 @@ mod live_wallet_edge_case_tests {
         let network = Network::TestNetwork;
         let (mut wallet, mut store_conn) = open_at(&db_path, network).expect("open wallet");
         let account_a = first_account(&wallet);
-        let account_b = create_synthetic_account(&mut wallet, 0x42, "edge-case-account-b");
+        let account_b = create_synthetic_account(&mut wallet, 0x42, "edge-case-account-b", None);
         assert_ne!(account_a, account_b);
 
         // Plan + commit an (unsigned) migration for account A only — account B is never touched.
@@ -4776,16 +4857,60 @@ mod live_wallet_edge_case_tests {
         let db_path = fresh_test_db_copy(&fixture_db_path());
         let network = Network::TestNetwork;
         let (mut wallet, mut store_conn) = open_at(&db_path, network).expect("open wallet");
-        let account_b = create_synthetic_account(&mut wallet, 0x43, "edge-case-empty-account");
+        let account_b =
+            create_synthetic_account(&mut wallet, 0x43, "edge-case-empty-account", None);
 
-        let backend = Backend::new(&wallet, account_b, &mut store_conn, network)
-            .expect("account exists for migration store");
-        let mut rng = OsRng;
-        let result = engine::plan_migration(&network, &backend, &mut rng);
+        // Through `compute_plan`, not a raw `engine::plan_migration` call: every real planning
+        // call site is `is_keystone`-aware (`run_sizing_for`), and this was the last place in the
+        // file still bypassing it — harmless here only because a zero-note account hits
+        // NothingToMigrate before any sizing knob matters, but a bad precedent for anyone copying
+        // this test's shape against a funded account later.
+        let result = compute_plan(&network, &wallet, account_b, &mut store_conn);
+        let err = result.expect_err("an account with zero spendable Orchard notes must error");
         assert!(
-            matches!(result, Err(engine::MigrationError::NothingToMigrate)),
-            "an account with zero spendable Orchard notes must fail cleanly with \
-             NothingToMigrate, not panic or return a bogus plan: got {result:?}"
+            format!("{err:?}").contains("NothingToMigrate"),
+            "must fail cleanly with NothingToMigrate, not some other error: got {err:?}"
+        );
+    }
+
+    /// `Backend::is_keystone` — the signal `compute_plan`/`estimateMigrationRunCountNative` use to
+    /// pick signer-capacity sizing over the plain note-cap default — must read the account's
+    /// `key_source` exactly as `AccountDataSource.importKeystoneAccount` (zashi-android `ui-lib`)
+    /// stamps it: `"keystone"`, case-insensitively; anything else (including no key_source at
+    /// all, zodl's own accounts) must read `false`.
+    #[test]
+    #[ignore = "requires MIGRATION_TEST_WALLET_DB"]
+    fn backend_is_keystone_reflects_the_accounts_key_source() {
+        let db_path = fresh_test_db_copy(&fixture_db_path());
+        let network = Network::TestNetwork;
+        let (mut wallet, mut store_conn) = open_at(&db_path, network).expect("open wallet");
+        let keystone_account =
+            create_synthetic_account(&mut wallet, 0x44, "keystone-account", Some("Keystone"));
+        let zodl_account =
+            create_synthetic_account(&mut wallet, 0x45, "zodl-account", Some("zashi"));
+        let unspecified_account =
+            create_synthetic_account(&mut wallet, 0x46, "unspecified-account", None);
+
+        let keystone_backend = Backend::new(&wallet, keystone_account, &mut store_conn, network)
+            .expect("account exists for migration store");
+        assert!(
+            keystone_backend.is_keystone(),
+            "key_source \"Keystone\" (mixed case) must read as a Keystone account"
+        );
+
+        let zodl_backend = Backend::new(&wallet, zodl_account, &mut store_conn, network)
+            .expect("account exists for migration store");
+        assert!(
+            !zodl_backend.is_keystone(),
+            "key_source \"zashi\" must not read as a Keystone account"
+        );
+
+        let unspecified_backend =
+            Backend::new(&wallet, unspecified_account, &mut store_conn, network)
+                .expect("account exists for migration store");
+        assert!(
+            !unspecified_backend.is_keystone(),
+            "an account with no key_source must not read as a Keystone account"
         );
     }
 }

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -109,9 +109,17 @@ const JNI_KEYSTONE_BATCH_SIGNED_PCZTS: &str =
 
 /// The zatoshi value below which a leftover post-migration Orchard balance is treated as dust
 /// rather than a residual worth migrating in its own (non-round-number, more identifiable)
-/// transfer. 10,000 zatoshi = 0.0001 ZEC. A fixed protocol-level constant, not derived from wallet
-/// or account state, so it needs no database access to read.
-pub const MIGRATION_DUST_THRESHOLD_ZATOSHI: u64 = 10_000;
+/// transfer. Defined as `2 * MARGINAL_FEE` per Kris Nuttycombe's migratable-total algorithm (team
+/// Slack, 2026-08): currently 10,000 zatoshi (0.0001 ZEC), but this now tracks `MARGINAL_FEE`
+/// rather than being a bare literal, so it moves automatically if ZIP-317's marginal fee ever
+/// changes. Not derived from wallet or account state, so it needs no database access to read.
+///
+/// A plain fn, not a `const`, only because [`Zatoshis::into_u64`] (which `u64::from(MARGINAL_FEE)`
+/// goes through) isn't a `const fn` — this is still fixed/deterministic, just recomputed (cheaply)
+/// on every read instead of baked in at compile time.
+fn migration_dust_threshold_zatoshi() -> u64 {
+    u64::from(MARGINAL_FEE) * 2
+}
 
 /// The per-run prepared-note cap for zodl's own in-process signer, well above the crate's
 /// [`MIGRATION_MAX_PREPARED_NOTES_PER_RUN`](zcash_pool_migration::denomination::MIGRATION_MAX_PREPARED_NOTES_PER_RUN)
@@ -3335,10 +3343,9 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     unwrap_exc_or(&mut env, res, ptr::null_mut())
 }
 
-/// A pure constant read — [`MIGRATION_DUST_THRESHOLD_ZATOSHI`] is a fixed protocol-level value,
-/// not derived from any wallet or account state, so unlike every other export in this file this
-/// needs no `db_data`/`network_id`/account argument and can't fail or panic (no `catch_unwind` /
-/// `unwrap_exc_or` needed).
+/// A fixed protocol-level value (`2 * MARGINAL_FEE`), not derived from any wallet or account
+/// state, so unlike every other export in this file this needs no `db_data`/`network_id`/account
+/// argument and can't fail or panic (no `catch_unwind` / `unwrap_exc_or` needed).
 #[unsafe(no_mangle)]
 pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_migrationDustThresholdZatoshiNative<
     'local,
@@ -3346,7 +3353,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     _env: JNIEnv<'local>,
     _: JClass<'local>,
 ) -> jlong {
-    MIGRATION_DUST_THRESHOLD_ZATOSHI as jlong
+    migration_dust_threshold_zatoshi() as jlong
 }
 
 /// Kris Nuttycombe's per-note "is the leftover balance actually worth prompting to migrate"
@@ -3355,7 +3362,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
 /// `MARGINAL_FEE` cost more to spend than they're worth, so summing net-of-fee value only across
 /// notes actually worth spending answers "how much would the user actually receive if they
 /// migrated everything right now" — replacing the raw aggregate Orchard balance the Kotlin call
-/// site compared against [`MIGRATION_DUST_THRESHOLD_ZATOSHI`] before this.
+/// site compared against [`migration_dust_threshold_zatoshi`] before this.
 ///
 /// [`InputSource::select_unspent_notes`] already applies the `value > MARGINAL_FEE` filter at the
 /// SQL layer (`zcash_client_sqlite::wallet::common::select_unspent_notes`), so every note this
@@ -3368,8 +3375,8 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
 /// correctly don't count toward it.
 ///
 /// The threshold this total is compared against (`migratable_total > 2 * MARGINAL_FEE`) is left
-/// to the caller: [`MIGRATION_DUST_THRESHOLD_ZATOSHI`] already equals `2 * MARGINAL_FEE`
-/// (10,000 zatoshi), so no new threshold constant is needed — only the total this compares.
+/// to the caller: [`migration_dust_threshold_zatoshi`] already computes `2 * MARGINAL_FEE`, so no
+/// separate threshold is needed here — only the total this compares.
 #[unsafe(no_mangle)]
 pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_migratableOrchardTotalNative<
     'local,

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -108,9 +108,9 @@ const JNI_KEYSTONE_BATCH_SIGNED_PCZTS: &str =
 
 /// The zatoshi value below which a leftover post-migration Orchard balance is treated as dust
 /// rather than a residual worth migrating in its own (non-round-number, more identifiable)
-/// transfer. 100,000 zatoshi = 0.001 ZEC. A fixed protocol-level constant, not derived from wallet
+/// transfer. 10,000 zatoshi = 0.0001 ZEC. A fixed protocol-level constant, not derived from wallet
 /// or account state, so it needs no database access to read.
-pub const MIGRATION_DUST_THRESHOLD_ZATOSHI: u64 = 100_000;
+pub const MIGRATION_DUST_THRESHOLD_ZATOSHI: u64 = 10_000;
 
 /// The per-run prepared-note cap for zodl's own in-process signer, well above the crate's
 /// [`MIGRATION_MAX_PREPARED_NOTES_PER_RUN`](zcash_pool_migration::denomination::MIGRATION_MAX_PREPARED_NOTES_PER_RUN)

--- a/backend-lib/src/main/rust/migration_engine.rs
+++ b/backend-lib/src/main/rust/migration_engine.rs
@@ -47,6 +47,20 @@ use crate::migration::Wallet;
 
 type SpendableNote = (OrchardNote, Position, u64);
 
+/// The `key_source` value (case-insensitive) `AccountDataSource.importKeystoneAccount`
+/// (zashi-android `ui-lib/.../datasource/AccountDataSource.kt`, `KEYSTONE_KEYSOURCE` constant)
+/// stamps on a Keystone-imported account — the ONLY signal this crate has to tell a
+/// hardware-QR-signed account from zodl's own in-process one; see [`Backend::is_keystone`].
+///
+/// There is no compiler-enforced link between this constant and the app-side one: if the app ever
+/// renames/retypes `KEYSTONE_KEYSOURCE`, or a new Keystone-import path stamps a differently-spelled
+/// value, `is_keystone()` silently returns `false` for a real Keystone account and
+/// `migration.rs::run_sizing_for` silently falls through to the 200-note zodl sizing instead of
+/// the 96-action-per-round signer cap — reproducing the exact multi-round-signing bug MOB-1760
+/// exists to fix, with no compile error or test failure to surface it. If this string ever needs
+/// to change, grep BOTH repos for `KEYSTONE_KEYSOURCE` first.
+const KEYSTONE_KEY_SOURCE: &str = "keystone";
+
 /// The migration adapter's `Backend`/`MigrationCrypto`/`PoolMigrationRead`/`PoolMigrationWrite`
 /// error type. Everything is folded into `anyhow::Error` (matching the rest of this JNI glue's
 /// idiom) rather than the parameterized error type `WalletMigration` uses, since this adapter is
@@ -62,6 +76,12 @@ pub struct Backend<'a, W> {
     /// Orchard component. Resolved once at construction because `MigrationCrypto::orchard_fvk` is
     /// infallible and hands out a borrow.
     orchard_fvk: Option<FullViewingKey>,
+    /// Whether the account's `key_source` matches [`KEYSTONE_KEY_SOURCE`] — see that constant's
+    /// doc for the cross-repo string-matching risk. Only Keystone signing has a per-round
+    /// QR-scanning cost; zodl's own accounts sign everything in one pass regardless of action
+    /// count, so sizing a run for them by a signing-round budget would only shrink runs for no
+    /// benefit — see `is_keystone`'s use in `migration.rs::run_sizing_for`.
+    is_keystone: bool,
     /// The store carries the network parameters and a clock because, as of
     /// `zcash_client_sqlite 0.22.0`, `PoolMigrationWrite::store_proved_transaction` finalizes
     /// a proved migration transaction into the wallet's own transaction tables: it recovers the
@@ -94,22 +114,32 @@ where
         conn: &'a mut Connection,
         params: Network,
     ) -> Result<Self, EngineError> {
-        let orchard_fvk = wallet
+        let account_row = wallet
             .get_account(account)
             .map_err(|e| anyhow::anyhow!("account lookup failed: {e}"))?
-            .ok_or_else(|| anyhow::anyhow!("unknown account"))?
-            .ufvk()
-            .and_then(|ufvk| ufvk.orchard())
-            .cloned();
+            .ok_or_else(|| anyhow::anyhow!("unknown account"))?;
+        let orchard_fvk = account_row.ufvk().and_then(|ufvk| ufvk.orchard()).cloned();
+        let is_keystone = account_row
+            .source()
+            .key_source()
+            .is_some_and(|s| s.eq_ignore_ascii_case(KEYSTONE_KEY_SOURCE));
         let store = PoolMigrations::for_account(params, SystemClock, conn, account)
             .map_err(|e| anyhow::anyhow!("opening pool-migration store failed: {e:?}"))?;
         Ok(Self {
             wallet,
             account,
             orchard_fvk,
+            is_keystone,
             store,
             spendable: std::cell::RefCell::new(None),
         })
+    }
+
+    /// Whether this account is signed via Keystone (see the `is_keystone` field's doc) — the
+    /// signal `migration.rs::compute_plan`/`estimateMigrationRunCountNative` use to decide
+    /// whether a run must fit one QR-scanned signing round.
+    pub fn is_keystone(&self) -> bool {
+        self.is_keystone
     }
 
     /// Cancels this account's migration via the real store-level primitive

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
@@ -1028,6 +1028,16 @@ interface OrchardMigrationSdk {
     suspend fun migrationDustThresholdZatoshi(): Long
 
     /**
+     * Kris Nuttycombe's per-note "is the leftover balance actually worth prompting to migrate"
+     * total: `sum(value - MARGINAL_FEE)` over every spendable Orchard note whose value exceeds
+     * `MARGINAL_FEE` — notes at or below `MARGINAL_FEE` cost more to spend than they're worth, so
+     * this is "how much the user would actually receive if they migrated everything right now",
+     * not the raw aggregate Orchard balance. Compare against [migrationDustThresholdZatoshi]
+     * (already `2 * MARGINAL_FEE`) rather than a raw wallet-balance total.
+     */
+    suspend fun migratableOrchardTotal(): Long
+
+    /**
      * Marks whatever Orchard balance remains after migration (dust below the migratable
      * threshold, or an opted-out residual) as unspendable, so it can't later be swept into a
      * transaction that reveals its specific — and therefore identifying — amount.

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
@@ -1020,10 +1020,12 @@ interface OrchardMigrationSdk {
     /**
      * The zatoshi value below which a remaining post-migration Orchard balance counts as dust
      * (as opposed to a residual too large to ignore) — e.g. for the Migration Complete screen's
-     * "is the leftover balance negligible" gate. 10,000 zatoshi (0.0001 ZEC) as of this writing.
-     * A fixed protocol-level constant (`MIGRATION_DUST_THRESHOLD_ZATOSHI` in `migration.rs`), not
-     * derived from any wallet/account state — callers should still call this rather than hardcode
-     * the value, so the app and the Rust engine can't drift apart on what counts as dust.
+     * "is the leftover balance negligible" gate. `2 * MARGINAL_FEE` (10,000 zatoshi / 0.0001 ZEC
+     * as of this writing) per Kris Nuttycombe's migratable-total algorithm — see
+     * `migration_dust_threshold_zatoshi()` in `migration.rs`. Not a bare literal: it tracks
+     * `MARGINAL_FEE`, so it moves automatically if ZIP-317's marginal fee ever changes. Not derived
+     * from any wallet/account state — callers should still call this rather than hardcode the
+     * value, so the app and the Rust engine can't drift apart on what counts as dust.
      */
     suspend fun migrationDustThresholdZatoshi(): Long
 

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
@@ -731,7 +731,7 @@ interface OrchardMigrationSdk {
      *
      * [includeResidual] — when the spendable balance leaves a leftover too small to form a whole
      * migratable note but too large to be dust (see the Rust bridge's `residual_after_migration()`
-     * threshold, ~0.001 ZEC), that leftover is excluded from the schedule by default: migrating it
+     * threshold, ~0.0001 ZEC), that leftover is excluded from the schedule by default: migrating it
      * requires one extra, non-round-number transfer, which is more identifiable on-chain than the
      * power-of-ten crossings (a privacy/completeness trade-off — see ProposalA.md's "sub-1-ZEC"
      * open point). Pass `true` only once the app exposes this as an explicit user choice; **for
@@ -1020,7 +1020,7 @@ interface OrchardMigrationSdk {
     /**
      * The zatoshi value below which a remaining post-migration Orchard balance counts as dust
      * (as opposed to a residual too large to ignore) — e.g. for the Migration Complete screen's
-     * "is the leftover balance negligible" gate. 100,000 zatoshi (0.001 ZEC) as of this writing.
+     * "is the leftover balance negligible" gate. 10,000 zatoshi (0.0001 ZEC) as of this writing.
      * A fixed protocol-level constant (`MIGRATION_DUST_THRESHOLD_ZATOSHI` in `migration.rs`), not
      * derived from any wallet/account state — callers should still call this rather than hardcode
      * the value, so the app and the Rust engine can't drift apart on what counts as dust.

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
@@ -1141,6 +1141,13 @@ internal class OrchardMigrationSdkImpl(
             migrationBackend.migrationDustThresholdZatoshi()
         }
 
+    override suspend fun migratableOrchardTotal(): Long =
+        loggedRead("migratableOrchardTotal") {
+            val dbDataPath = dbDataPath()
+            val account = account ?: noAccountAvailable()
+            migrationBackend.migratableOrchardTotal(dbDataPath, network, account)
+        }
+
     override suspend fun lockRemainingOrchardBalance() =
         logged("lockRemainingOrchardBalance") {
             val dbDataPath = dbDataPath()

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackend.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackend.kt
@@ -293,6 +293,18 @@ internal interface TypesafeMigrationBackend {
      */
     suspend fun migrationDustThresholdZatoshi(): Long
 
+    /**
+     * Kris Nuttycombe's per-note "is the leftover balance worth prompting to migrate" total:
+     * `sum(value - MARGINAL_FEE)` over every spendable Orchard note whose value exceeds
+     * `MARGINAL_FEE`. Compare against [migrationDustThresholdZatoshi] (already `2 * MARGINAL_FEE`),
+     * not the raw aggregate Orchard balance.
+     */
+    suspend fun migratableOrchardTotal(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): Long
+
     // ----- External signer (Keystone hardware wallet) -----
 
     suspend fun createUnsignedNoteSplitPczt(

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackendImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/TypesafeMigrationBackendImpl.kt
@@ -242,6 +242,12 @@ internal class TypesafeMigrationBackendImpl(
 
     override suspend fun migrationDustThresholdZatoshi(): Long = rustBackend().migrationDustThresholdZatoshi()
 
+    override suspend fun migratableOrchardTotal(
+        dbDataPath: String,
+        network: ZcashNetwork,
+        account: AccountUuid
+    ): Long = rustBackend().migratableOrchardTotal(dbDataPath, network.id, account.value)
+
     override suspend fun createUnsignedNoteSplitPczt(
         dbDataPath: String,
         network: ZcashNetwork,

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImplTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImplTest.kt
@@ -1372,6 +1372,12 @@ class OrchardMigrationSdkImplTest {
 
         override suspend fun migrationDustThresholdZatoshi(): Long = migrationDustThresholdZatoshiResult
 
+        override suspend fun migratableOrchardTotal(
+            dbDataPath: String,
+            network: ZcashNetwork,
+            account: AccountUuid
+        ): Long = error("Unused")
+
         override suspend fun migrationState(
             dbDataPath: String,
             network: ZcashNetwork,

--- a/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImplTest.kt
+++ b/sdk-lib/src/test/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImplTest.kt
@@ -190,7 +190,7 @@ class OrchardMigrationSdkImplTest {
 
     /**
      * `migrationDustThresholdZatoshi()` is a pure pass-through to the Rust-side
-     * `MIGRATION_DUST_THRESHOLD_ZATOSHI` constant (100,000 zatoshi / 0.001 ZEC) — no account or
+     * `MIGRATION_DUST_THRESHOLD_ZATOSHI` constant (10,000 zatoshi / 0.0001 ZEC) — no account or
      * database state involved. This just pins down that the value round-trips through the
      * typesafe backend unchanged.
      */
@@ -200,7 +200,7 @@ class OrchardMigrationSdkImplTest {
             val account = AccountUuid.new(ByteArray(16) { it.toByte() })
             val fakeBackend =
                 FakeTypesafeMigrationBackend(
-                    migrationDustThresholdZatoshiResult = 100_000L
+                    migrationDustThresholdZatoshiResult = 10_000L
                 )
             val sdk =
                 OrchardMigrationSdkImpl(
@@ -215,7 +215,7 @@ class OrchardMigrationSdkImplTest {
 
             val result = sdk.migrationDustThresholdZatoshi()
 
-            assertEquals(100_000L, result)
+            assertEquals(10_000L, result)
         }
 
     /**
@@ -1324,7 +1324,7 @@ class OrchardMigrationSdkImplTest {
     @Suppress("TooManyFunctions", "LongParameterList")
     private class FakeTypesafeMigrationBackend(
         private val proposeImmediateSendMaxResult: ByteArray = ByteArray(0),
-        private val migrationDustThresholdZatoshiResult: Long = 100_000L,
+        private val migrationDustThresholdZatoshiResult: Long = 10_000L,
         private val migrationSummaryResult: LongArray = LongArray(0),
         private val hasOverdueTransfersResult: Boolean = false,
         private val nextStepResult: LongArray? = null,


### PR DESCRIPTION
## Summary

Forward-cascades the Orchard migration bugfixes from `maint/v3.1.x` onto the new `candidate/v4.0.0` line (cut from `main` after #2209 merged `maint/v3.0.x` and removed Slipstream), ahead of the 4.0.0 release tracked in #2204.

Carries:
- `d4753efe` [MOB-1760] Size Keystone migration runs by signing-round capacity, not note count
- `094bb99e` MOB-1750: lower the Orchard migration dust threshold to 0.0001 ZEC
- `e4be0926` Add `migratableOrchardTotal()`: per-note dust total per Kris Nuttycombe's formula
- `0324548a` Derive `MIGRATION_DUST_THRESHOLD_ZATOSHI` from `MARGINAL_FEE` instead of a bare literal
- `da9aef46` Fix `FakeTypesafeMigrationBackend` missing `migratableOrchardTotal` override

## What was intentionally left out

`maint/v3.1.x` also carries `77961391` (adapt to `zcash_pool_migration` 0.1.0 stable's `MigrationCrypto` shape). Not cherry-picked here — `main`/`candidate/v4.0.0` already contains an equivalent, independently-written adaptation to the same 0.1.0 API (infallible `orchard_fvk()`, no spending key held on `Backend`) from the librustzcash bump that landed as part of #2209. Picking it would have reintroduced the old shape and conflicted with the current one.

The rest of `maint/v3.1.x`'s delta over `main` (PRO-97 Sapling params race fix, MOB-1764/1765 JNI hardening, MOB-1723 typed insufficient-funds) is unrelated to migration and intentionally not included in this PR.

## Conflict resolution

One conflict, in `backend-lib/src/main/rust/migration_engine.rs`: MOB-1760's `is_keystone` needs the `account_row` binding that `main`'s independently-adapted `Backend::new` had inlined away. Resolved by keeping the `account_row` binding and deriving both `orchard_fvk` and `is_keystone` from it, ahead of the (unchanged) `PoolMigrations::for_account` store setup.

## Verification

- `cargo check` on `backend-lib` passes clean.
- `cargo test --lib migration` — 55 passed, 0 failed (15 ignored, require a real wallet DB), including `run_sizing_for_tests::keystone_accounts_use_signer_capacity` / `non_keystone_accounts_use_the_zodl_note_cap`.
- No Slipstream dependency in any of the picked commits (confirmed via diff inspection) — safe to carry onto the Slipstream-free `main`/`candidate/v4.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)