### PR TITLE
Derive migration minedness from the engine, and surface unsatisfiableKind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `MigrationTransferState.unsatisfiableKind` (`MigrationUnsatisfiableKind`) now carries why a
+  pool-migration transaction can never execute. The kind is a separate field because
+  `MigrationBlocker.UNSATISFIABLE` carries no payload, and the two are independent: a marked
+  transaction may report a different blocker.
+
 ### Changed
 
 - Whether a pool-migration transaction has been mined is now derived from the wallet's own scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this library adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Whether a pool-migration transaction has been mined is now derived from the wallet's own scan
+  data by the migration engine, instead of being observed by the SDK and recorded with an explicit
+  mark. A migration transaction is promoted to mined only once the wallet has scanned to the height
+  carrying it, so the promotion can no longer outlive a rollback of the block that justified it.
+- A pool-migration transfer whose expiry has probably passed — at or above the wallet's fully
+  scanned height, but below its estimate of the chain tip — is now withheld from the broadcast and
+  prove queues rather than offered. This is protective and reversible: nothing is recorded and no
+  artifact is discarded, and such a transfer becomes available again if the wallet's own scan shows
+  that it remains executable.
+
 ## [3.0.0] - 2026-08-25
 
 ### Added

--- a/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/migration/JniMigrationModels.kt
+++ b/backend-lib/src/main/java/cash/z/ecc/android/sdk/internal/model/migration/JniMigrationModels.kt
@@ -164,6 +164,16 @@ class JniMigrationTransferState(
      * 7 expiry imminent, 8 awaiting reevaluation, 9 unsatisfiable.
      */
     val blocker: Int,
+    /**
+     * Why this transaction can never execute, when the engine has marked it: 0 not marked,
+     * 1 inputs spent, 2 inputs invalidated, 3 anchor invalidated, 4 inherited (dead only through
+     * a dependency), 5 a cause this boundary does not name yet.
+     *
+     * Independent of [blocker] in both directions — the mark carries the cause, the blocker
+     * carries no payload — so a marked transaction may report a higher-precedence blocker while
+     * still answering here.
+     */
+    val unsatisfiableKind: Int,
     /** The engine-persisted crossing value (`transfer_crossing_value`); -1 for preparations. */
     val amountZatoshi: Long,
     /** Preparation layer/index within the note-split tree; -1/-1 for transfers. */

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -65,7 +65,8 @@ use zcash_pool_migration::{
     },
     preparation::{PrepInput, PreparationPlan},
     satisfiability::{
-        AdvanceConfig, DuenessTargets, ReorgSettleDepth, ReplanThreshold, advance_migration,
+        AdvanceConfig, DuenessTargets, ReorgSettleDepth, ReplanThreshold, UnsatisfiableKind,
+        advance_migration,
     },
     state::{AdvanceStep, NextAction, StepKind},
 };
@@ -2632,6 +2633,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
             bool,
             i32,
             i32,
+            i32,
             i64,
             i32,
             i32,
@@ -2654,6 +2656,23 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                         | MigrationTxState::Broadcast { .. }
                         | MigrationTxState::Mined { .. }
                 );
+                // Read from the transaction's own persisted mark, not from the blocker: the
+                // blocker carries no payload, and the two are independent — a row can be marked
+                // while a higher-precedence blocker is what it reports.
+                let unsatisfiable_kind = match t.unsatisfiable_kind() {
+                    None => UNSATISFIABLE_KIND_NONE,
+                    Some(UnsatisfiableKind::InputsSpent) => UNSATISFIABLE_KIND_INPUTS_SPENT,
+                    Some(UnsatisfiableKind::InputsInvalidated) => {
+                        UNSATISFIABLE_KIND_INPUTS_INVALIDATED
+                    }
+                    Some(UnsatisfiableKind::AnchorInvalidated) => {
+                        UNSATISFIABLE_KIND_ANCHOR_INVALIDATED
+                    }
+                    Some(UnsatisfiableKind::Inherited) => UNSATISFIABLE_KIND_INHERITED,
+                    // `#[non_exhaustive]`: a cause added upstream reads as "marked, kind not yet
+                    // surfaced here" rather than as "not marked", which would be a lie.
+                    Some(_) => UNSATISFIABLE_KIND_OTHER,
+                };
                 let (ready, action, blocker) = {
                     let action = match status.action() {
                         Some(zcash_pool_migration::state::NextAction::Prove) => ACTION_PROVE,
@@ -2713,6 +2732,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                     ready,
                     action,
                     blocker,
+                    unsatisfiable_kind,
                     amount_zatoshi,
                     prep_layer,
                     prep_index,
@@ -2738,6 +2758,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                 ready,
                 action,
                 blocker,
+                unsatisfiable_kind,
                 amount_zatoshi,
                 prep_layer,
                 prep_index,
@@ -2749,7 +2770,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                 env.set_long_array_region(&jdeps, 0, &depends_on)?;
                 env.new_object(
                     JNI_MIGRATION_TRANSFER_STATE,
-                    "(JZZZJJZIIJII[JJJ)V",
+                    "(JZZZJJZIIIJII[JJJ)V",
                     &[
                         JValue::Long(encode_transfer_id(id)),
                         JValue::Bool(is_transfer as jboolean),
@@ -2760,6 +2781,7 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
                         JValue::Bool(ready as jboolean),
                         JValue::Int(action),
                         JValue::Int(blocker),
+                        JValue::Int(unsatisfiable_kind),
                         JValue::Long(amount_zatoshi),
                         JValue::Int(prep_layer),
                         JValue::Int(prep_index),
@@ -7459,6 +7481,19 @@ const BLOCKER_AWAITING_REEVALUATION: i32 = 8;
 /// The transaction can never mine — marked unsatisfiable, or stranded behind one that is. The
 /// remedy is a migration-level replan, never more syncing. New in `zcash_pool_migration 0.1.0-rc.6`.
 const BLOCKER_UNSATISFIABLE: i32 = 9;
+
+// The cause recorded beside a transaction's unsatisfiability mark, surfaced as its own field
+// because `Blocker::Unsatisfiable` carries no payload. The mark is orthogonal to both the blocker
+// and the lifecycle state: a marked row keeps its `Proved`/`Broadcast` state, and can report a
+// different (higher-precedence) blocker while still carrying its cause.
+const UNSATISFIABLE_KIND_NONE: i32 = 0;
+const UNSATISFIABLE_KIND_INPUTS_SPENT: i32 = 1;
+const UNSATISFIABLE_KIND_INPUTS_INVALIDATED: i32 = 2;
+const UNSATISFIABLE_KIND_ANCHOR_INVALIDATED: i32 = 3;
+/// Dead only through the dependency closure — this transaction's own inputs are intact.
+const UNSATISFIABLE_KIND_INHERITED: i32 = 4;
+/// A cause added to the upstream `#[non_exhaustive]` enum that this boundary does not name yet.
+const UNSATISFIABLE_KIND_OTHER: i32 = 5;
 
 /// Two-tip decision (spec §3): the underlying `advance_migration` call is driven by
 /// `DuenessTargets::new(scanned, estimated)`, which folds the ESTIMATED tip into its `effective`

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -5258,6 +5258,55 @@ mod next_due_transfer_tests {
         }
     }
 
+    /// A reported rejection the wallet cannot yet explain WITHHOLDS everything: the node saw chain
+    /// state below a tip this wallet has not scanned to, so the answer is "sync, then ask again"
+    /// rather than the broadcast that was otherwise due. Nothing is marked — the report is
+    /// testimony, and this step is what the engine offers while it stands.
+    #[test]
+    fn an_unadjudicable_broadcast_failure_report_withholds_every_step() {
+        let mut st = make_state(
+            MigrationStatus::InProgress,
+            vec![transfer(7, MigrationTxState::Proved, 1000, 0)],
+        );
+        assert_eq!(
+            step_at(&st, 995, 1001),
+            (STEP_BROADCAST, 7),
+            "precondition: without a report this transfer is due for broadcast"
+        );
+
+        // The node reported a tip well above what this wallet has scanned, so its rejection
+        // cannot be checked against anything yet.
+        st.report_broadcast_failure(
+            MigrationTransferId::new(7),
+            BlockHeight::from_u32(995 + 200),
+        );
+
+        assert_eq!(
+            step_at(&st, 995, 1001),
+            (STEP_REEVALUATE, -1),
+            "a standing report outranks the due broadcast: sync to the reported tip first"
+        );
+    }
+
+    /// Once the wallet HAS scanned past the reported tip, the same report is adjudicated rather
+    /// than obeyed. Against a chain showing nothing wrong it is cleared and the broadcast
+    /// re-offered in the same call — which is what makes a wrong or stale node verdict
+    /// self-healing, and why a consumer re-reports freely instead of debouncing.
+    #[test]
+    fn an_adjudicable_report_clears_and_the_broadcast_is_reoffered() {
+        let mut st = make_state(
+            MigrationStatus::InProgress,
+            vec![transfer(7, MigrationTxState::Proved, 1000, 0)],
+        );
+        st.report_broadcast_failure(MigrationTransferId::new(7), BlockHeight::from_u32(995 - 5));
+
+        assert_eq!(
+            step_at(&st, 995, 1001),
+            (STEP_BROADCAST, 7),
+            "the wallet has scanned past the reported tip and sees no obstruction"
+        );
+    }
+
     #[test]
     fn broadcast_due_at_estimated_but_not_scanned_returns_broadcast() {
         // proved transfer scheduled at 1000; scanned tip behind (target 995), estimated at/after 1000.

--- a/backend-lib/src/main/rust/migration.rs
+++ b/backend-lib/src/main/rust/migration.rs
@@ -282,6 +282,31 @@ fn target_height(wallet: &Wallet) -> anyhow::Result<BlockHeight> {
     Ok(tip + 1)
 }
 
+/// The advance policy every drive of `advance_migration` in this file runs under — one
+/// constructor, so the reorg-settlement depth ([`SETTLE_DEPTH`]) cannot diverge between the
+/// step-query and read-reconciliation paths.
+fn advance_config() -> AdvanceConfig {
+    AdvanceConfig::new(SETTLE_DEPTH)
+}
+
+/// The two heights `satisfiability::advance_migration` judges against, in the crate's `height + 1`
+/// TARGET convention: what this wallet's chain data SUPPORTS (its fully-scanned frontier), and
+/// where the tip has probably reached (its chain view).
+///
+/// Every determination that persists a verdict or destroys work is made at `scanned`; the estimate
+/// only re-orders or protectively withholds. `DuenessTargets::new` clamps `effective >= scanned`,
+/// so an estimate lagging the wallet's own observations can never withhold work the chain data
+/// already justifies — which is why this can be derived here rather than trusted from the caller.
+fn dueness_targets(wallet: &Wallet) -> anyhow::Result<DuenessTargets> {
+    let scanned = wallet
+        .block_fully_scanned()
+        .map_err(|e| anyhow!("fully-scanned height lookup failed: {}", e))?
+        .map(|meta| meta.block_height() + 1)
+        .unwrap_or(BlockHeight::from_u32(0));
+    let estimated = target_height(wallet)?;
+    Ok(DuenessTargets::new(scanned, estimated))
+}
+
 /// The wallet's real, currently-witnessable anchor height (the same one ordinary, non-migration
 /// sends use, via `get_target_and_anchor_heights`) — NOT just "chain tip minus one", which isn't
 /// necessarily checkpointed (confirmed live: `root_at_checkpoint_id` returned `None` for a raw
@@ -1463,12 +1488,21 @@ pub extern "C" fn Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend_
     unwrap_exc_or(&mut env, res, ())
 }
 
-/// Reconciles mined-ness against the wallet's own transaction history before returning migration
-/// state, so `InProgress`/`Complete` derivation reflects broadcast truth instead of staying stuck at
-/// whatever `mark_broadcast` last recorded. The engine's own contract intentionally leaves mining
-/// detection to the caller (`state.rs` module doc: "the state machine's only job is to ORDER the
-/// broadcasts") — this is that caller-side reconciliation, run at read time rather than a background
-/// job, matching the iOS SDK's own `derive_state` reconciliation approach.
+/// Reads migration state after letting the engine reconcile it against the chain.
+///
+/// This used to walk every `Broadcast` transaction, ask the wallet `get_tx_height`, and call
+/// `MigrationState::mark_mined` by hand, because the engine's contract then left mining detection
+/// to the caller. It no longer does: `PoolMigrationRead::mined_height` asks the same question
+/// through the store, and `advance_migration` asks it about every in-flight transaction it
+/// sweeps, so minedness is now chain-derived on the engine's side — as its doc puts it, "a driver
+/// that never calls [`MigrationState::mark_mined`] is the intended shape": the consumer records
+/// what only it can know (that it submitted), and the engine derives inclusion from the wallet's
+/// own scan.
+///
+/// Driving here rather than only at the step-query site keeps every read path (progress, proposals,
+/// attention state) seeing the same adjudicated state, and the drive is idempotent — it persists
+/// only what it determined. The returned step is deliberately discarded; callers that act on a step
+/// call `advance_migration` themselves.
 fn read_reconciled(
     wallet: &Wallet,
     backend: &mut Backend<Wallet>,
@@ -1480,24 +1514,9 @@ fn read_reconciled(
         Some(s) => s,
         None => return Ok(None),
     };
-    let mut newly_mined = Vec::new();
-    for tx in state.transactions() {
-        if let MigrationTxState::Broadcast { txid } = tx.state()
-            && let Some(height) = wallet
-                .get_tx_height(txid)
-                .map_err(|e| anyhow!("Error reading tx height for {:?}: {:?}", txid, e))?
-        {
-            newly_mined.push((tx.id(), height));
-        }
-    }
-    if !newly_mined.is_empty() {
-        for (id, height) in newly_mined {
-            state.mark_mined(id, height);
-        }
-        backend
-            .replace_migration(&state)
-            .map_err(|e| anyhow!("Error persisting reconciled migration state: {:?}", e))?;
-    }
+    let targets = dueness_targets(wallet)?;
+    advance_migration(backend, &mut state, targets, &advance_config(), &mut OsRng)
+        .map_err(|e| anyhow!("Error advancing migration: {:?}", e))?;
     Ok(Some(state))
 }
 
@@ -1521,11 +1540,14 @@ fn pczt_txid(bytes: &[u8]) -> Option<[u8; 32]> {
 /// `"invalid_transfer"`, reason-first ordering — the same mechanism `recordTransferResultNative`
 /// tag 2 uses). Returns `true` iff the plan is (or already was) invalidated.
 ///
-///   1. `read_reconciled` — existing pass: any `Broadcast` transfer the wallet now knows a height
-///      for is promoted to `Mined`.
+///   1. `read_reconciled` — drives `advance_migration`, whose in-flight sweep promotes any
+///      broadcast transaction the wallet's scan now covers to `Mined`.
 ///   2. Submit-crash probe: for each `Proved` transfer, extract its txid from its proven PCZT and
 ///      ask the wallet `get_tx_height`; if the wallet already knows a height, our broadcast landed
-///      (we just never recorded it, e.g. crashed after broadcast) — `mark_broadcast` + `mark_mined`.
+///      (we just never recorded it, e.g. crashed after broadcast) — `mark_broadcast`. Only the
+///      broadcast: the engine's sweep considers only rows it knows were broadcast, so this
+///      observation is the consumer's to make, but the `mark_mined` that used to follow it is not —
+///      the engine derives that from `mined_height` on the next drive.
 ///
 /// A third, foreign-spend-detecting pass used to run here (comparing each candidate transfer's
 /// funding nullifier against the wallet's unspent set). It was removed — see
@@ -1556,8 +1578,9 @@ fn reconcile_invalidated(
         return Ok(matches!(state.status(), engine::MigrationStatus::Failed));
     }
 
-    // --- Pass 2: submit-crash probe. Promote any Proved transfer whose txid is already on chain. ---
-    let mut promotions: Vec<(MigrationTransferId, BlockHeight)> = Vec::new();
+    // --- Pass 2: submit-crash probe. Record the BROADCAST of any Proved transfer whose txid is
+    // already on chain (we submitted it and crashed before recording that). ---
+    let mut promotions: Vec<MigrationTransferId> = Vec::new();
     for tx in state.transactions() {
         if !matches!(tx.state(), MigrationTxState::Proved) {
             continue;
@@ -1566,17 +1589,17 @@ fn reconcile_invalidated(
             continue;
         };
         let txid = zcash_protocol::TxId::from_bytes(txid_bytes);
-        if let Some(height) = wallet
+        if wallet
             .get_tx_height(txid)
             .map_err(|e| anyhow!("Error reading tx height for {:?}: {:?}", txid, e))?
+            .is_some()
         {
-            promotions.push((tx.id(), height));
+            promotions.push(tx.id());
         }
     }
     if !promotions.is_empty() {
-        for (id, height) in &promotions {
+        for id in &promotions {
             state.mark_broadcast(*id);
-            state.mark_mined(*id, *height);
         }
         let mut backend = Backend::new(&*wallet, account, store_conn, *wallet.params())?;
         backend
@@ -1587,9 +1610,10 @@ fn reconcile_invalidated(
     Ok(false)
 }
 
-/// Reconciles a committed migration against on-chain truth via two passes: own-broadcast/mined
-/// promotion (submit-crash recovery), matching what `advance_migration`'s own in-flight sweep also
-/// does on every `nextStep` call. Returns `JNI_TRUE` iff the plan is (or already was) `Failed`.
+/// Reconciles a committed migration against on-chain truth via two passes: an engine drive
+/// (`read_reconciled`, whose in-flight sweep promotes mined transactions) and the submit-crash
+/// probe (recording an own broadcast that landed unrecorded, so the next sweep can promote it).
+/// Returns `JNI_TRUE` iff the plan is (or already was) `Failed`.
 ///
 /// Foreign-spend detection (formerly a third pass here) was removed — see
 /// spec/2026-08-05-migration-engine-full-delegation-design.md §4: its terminal `Failed` action
@@ -5963,7 +5987,9 @@ mod reconcile_tests {
             .expect("get_tx_height")
             .expect("fixture txid is mined");
 
-        // Simulate pass 2's promotion of an own crashed broadcast.
+        // Simulate the recovery of an own crashed broadcast: pass 2 records the broadcast, and
+        // the engine's in-flight sweep would then derive the mined promotion (constructed
+        // directly here — this test exercises the outstanding-filter, not the sweep).
         state.mark_broadcast(some_tx_id);
         state.mark_mined(some_tx_id, mined_height);
 
@@ -7456,7 +7482,7 @@ fn advance_step(
     estimated_target: BlockHeight,
 ) -> anyhow::Result<(i64, i64, i64, i64)> {
     let targets = DuenessTargets::new(scanned_target, estimated_target);
-    let config = AdvanceConfig::new(SETTLE_DEPTH);
+    let config = advance_config();
     let mut rng = OsRng;
     let advance = advance_migration(backend, state, targets, &config, &mut rng)
         .map_err(|e| anyhow!("Error advancing migration: {:?}", e))?;

--- a/backend-lib/src/main/rust/migration_engine.rs
+++ b/backend-lib/src/main/rust/migration_engine.rs
@@ -29,6 +29,7 @@ use zcash_client_backend::fees::StandardFeeRule;
 use zcash_client_backend::proposal::Proposal;
 use zcash_client_sqlite::AccountUuid;
 use zcash_protocol::ShieldedPool;
+use zcash_protocol::TxId;
 use zcash_protocol::consensus::{BlockHeight, Network, Parameters};
 use zcash_protocol::value::Zatoshis;
 
@@ -41,7 +42,6 @@ use zcash_pool_migration::engine::{
 };
 use zcash_pool_migration::satisfiability::{ReorgSettleDepth, StepSatisfiability};
 use zcash_pool_migration::scheduling::SchedulingParams;
-use zcash_protocol::TxId;
 
 use crate::migration::Wallet;
 
@@ -271,10 +271,10 @@ where
             .map_err(|e| anyhow::anyhow!("reading persisted migration failed: {e:?}"))
     }
 
-    /// Delegated wholesale. The satisfiability oracle answers per cached spend nullifier from the
-    /// wallet's own Orchard note and note-spend tables, bounded by the fully-scanned height; the
-    /// inner store is the thing that owns those tables, and answering here from anything else would
-    /// break the one-view consistency `mined_height` is required to share with it.
+    /// Delegated wholesale to the `zcash_client_sqlite` store, which answers the oracle's
+    /// mechanical questions (per-nullifier spend observations, expiry, anchor survival) from the
+    /// wallet's own scan data. Nothing about the answer is this adapter's to decide: the engine
+    /// adjudicates, and a wallet-side verdict is exactly what the satisfiability design removes.
     fn check_step_satisfiability(
         &self,
         tx: &MigrationTransaction,
@@ -285,6 +285,10 @@ where
             .map_err(|e| anyhow::anyhow!("checking migration step satisfiability failed: {e:?}"))
     }
 
+    /// Likewise delegated: the store answers from scan data, withholding a height it has not
+    /// scanned to. This is the roll-forward half of chain-derived state, and answering it is what
+    /// lets `advance_migration` promote a broadcast transaction to `Mined` by itself — which is
+    /// why this file's JNI layer no longer observes minedness by hand.
     fn mined_height(&self, txid: TxId) -> Result<Option<BlockHeight>, Self::Error> {
         self.store.mined_height(txid).map_err(|e| {
             anyhow::anyhow!("reading migration transaction mined height failed: {e:?}")

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/MigrationSdk.kt
@@ -218,6 +218,13 @@ data class MigrationTransferState(
     val action: MigrationNextAction? = null,
     /** Why a waiting transaction is not yet actionable, or null when none/ready. */
     val blocker: MigrationBlocker? = null,
+    /**
+     * Why the engine marked this transaction as one that can never execute, or null when it holds
+     * no such mark. Independent of [blocker]: the mark carries the cause and the blocker carries
+     * no payload, so a marked transaction can report a higher-precedence blocker and still answer
+     * here.
+     */
+    val unsatisfiableKind: MigrationUnsatisfiableKind? = null,
     /** The engine-persisted crossing value in zatoshi; null for preparations. */
     val amountZatoshi: Long? = null,
     /** Preparation layer/index within the note-split tree; null for transfers. */
@@ -293,6 +300,28 @@ enum class MigrationBlocker {
      * migration-level replan — more syncing can never help.
      */
     UNSATISFIABLE,
+}
+
+/**
+ * Why the engine marked a migration transaction as one that can never execute. The mark is
+ * evidence-stamped against scanned chain data, so it is cleared exactly by a reorg that removes
+ * the evidence — and by the transaction mining, which outranks any prior judgment.
+ */
+enum class MigrationUnsatisfiableKind {
+    /** The wallet saw this transaction's inputs spent: their nullifiers appeared in mined blocks. */
+    INPUTS_SPENT,
+
+    /** Its inputs' creating transaction can never mine, so those inputs will never exist. */
+    INPUTS_INVALIDATED,
+
+    /** It is broadcast but unmined, and a settled reorg removed the anchor it was proven against. */
+    ANCHOR_INVALIDATED,
+
+    /** Dead only through the dependency closure — its own inputs are intact. */
+    INHERITED,
+
+    /** A cause added upstream that this SDK version does not name yet; treat as unsatisfiable. */
+    OTHER,
 }
 
 /**

--- a/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
+++ b/sdk-lib/src/main/java/cash/z/ecc/android/sdk/internal/OrchardMigrationSdkImpl.kt
@@ -28,6 +28,7 @@ import cash.z.ecc.android.sdk.MigrationSummary
 import cash.z.ecc.android.sdk.MigrationSyncWakeup
 import cash.z.ecc.android.sdk.MigrationTransferState
 import cash.z.ecc.android.sdk.MigrationTransferStates
+import cash.z.ecc.android.sdk.MigrationUnsatisfiableKind
 import cash.z.ecc.android.sdk.NetworkPrivacyOptions
 import cash.z.ecc.android.sdk.NoteSplitProposal
 import cash.z.ecc.android.sdk.OrchardMigrationSdk
@@ -1794,6 +1795,7 @@ private fun JniMigrationTransferState.toPublic(): MigrationTransferState =
                 9 -> MigrationBlocker.UNSATISFIABLE
                 else -> null
             },
+        unsatisfiableKind = unsatisfiableKind.toUnsatisfiableKind(),
         amountZatoshi = amountZatoshi.takeIf { it >= 0 },
         prepLayer = prepLayer.takeIf { it >= 0 },
         prepIndex = prepIndex.takeIf { it >= 0 },
@@ -1804,6 +1806,23 @@ private fun JniMigrationTransferState.toPublic(): MigrationTransferState =
         // natural anchor).
         anchorBoundaryHeight = anchorBoundaryHeight.takeIf { it >= 0L },
     )
+
+private const val JNI_UNSATISFIABLE_INPUTS_SPENT = 1
+private const val JNI_UNSATISFIABLE_INPUTS_INVALIDATED = 2
+private const val JNI_UNSATISFIABLE_ANCHOR_INVALIDATED = 3
+private const val JNI_UNSATISFIABLE_INHERITED = 4
+
+// Any further cause the engine adds still means "can never execute"; reading it as "not marked"
+// would be the one wrong answer.
+private fun Int.toUnsatisfiableKind(): MigrationUnsatisfiableKind? =
+    when (this) {
+        JNI_UNSATISFIABLE_INPUTS_SPENT -> MigrationUnsatisfiableKind.INPUTS_SPENT
+        JNI_UNSATISFIABLE_INPUTS_INVALIDATED -> MigrationUnsatisfiableKind.INPUTS_INVALIDATED
+        JNI_UNSATISFIABLE_ANCHOR_INVALIDATED -> MigrationUnsatisfiableKind.ANCHOR_INVALIDATED
+        JNI_UNSATISFIABLE_INHERITED -> MigrationUnsatisfiableKind.INHERITED
+        0 -> null
+        else -> MigrationUnsatisfiableKind.OTHER
+    }
 
 private fun JniMigrationTransferStates.toPublic(): MigrationTransferStates =
     MigrationTransferStates(


### PR DESCRIPTION
Closes #2212. Replaces #2120, which was closed after the wallet team's development branch grew its
own JNI/Kotlin surface for the `zcash_pool_migration` satisfiability drive API.

That branch subsumed most of #2120: the librustzcash pin, the step-selection delegation to
`satisfiability::advance_migration` with its peek-ahead, the store adapter's
`check_step_satisfiability`/`mined_height` methods, `MigrationAdvanceStep.{Reevaluate, Replan}` with
supersede-on-`Replan` handled inside `nextStep()`, the three new blockers, and broadcast-failure
reporting folded into `recordTransferResult` (tag 4) behind the SDK's own rejection classification —
a factoring that needs neither of the dedicated `reportBroadcastFailure`/`markSuperseded` verbs
#2120 introduced. The late-dependency guard veto it carried is gone too: rc.6's prove-time boundary
redraw healed that wedge upstream.

This branch is what the rebase onto `maint/v3.0.x` left standing — the two work items from #2119
that nothing upstream picked up, plus test coverage for the report's two outcomes.

## Commits

**`Derive migration minedness from the engine's in-flight sweep, not hand marks`**

`read_reconciled` walked every `Broadcast` row, asked the wallet `get_tx_height`, and called
`MigrationState::mark_mined` from that observation. It now drives `advance_migration` instead, so
promotion to `Mined` is made by the engine from the wallet's own scan data and cannot outlive a
rollback of the block justifying it. As the drive API's doc puts it, "a driver that never calls
`MigrationState::mark_mined` is the intended shape".

The submit-crash probe in `reconcile_invalidated` keeps its `mark_broadcast` — the engine sweeps
only rows it knows were broadcast, so that observation is still genuinely the consumer's — but drops
the `mark_mined` that followed it. The next sweep derives that.

Driving at the read path rather than only at the step-query site keeps progress, proposals, and
attention state all seeing the same adjudicated state; the drive is idempotent and persists only
what it determined, and its returned step is deliberately discarded (callers that act on a step call
`advance_migration` themselves).

Two supporting pieces: `dueness_targets` derives the drive's scanned/estimated targets from the
wallet itself — safe to derive here rather than trust from the caller, because `DuenessTargets::new`
clamps `effective >= scanned`, so a lagging estimate can never withhold work the chain data already
justifies — and `advance_config()` single-sources the settle-depth policy between the step-query and
read-reconciliation paths.

**`Surface unsatisfiableKind through JNI and Kotlin`**

The one capability the development branch did not surface: *why* a marked transaction can never
execute. `MigrationBlocker.UNSATISFIABLE` carries no payload, so today an app can see that a
transaction is dead but not what killed it.

`MigrationTransferState.unsatisfiableKind` (`MigrationUnsatisfiableKind`) now carries the engine's
recorded cause, threaded from `MigrationTransaction::unsatisfiable_kind()` through the JNI
transfer-states projection. It is its own field rather than a blocker payload because the mark is
orthogonal to the blocker in both directions: a marked transaction can report a higher-precedence
blocker and still answer why it is dead. An upstream cause this boundary does not name yet maps to
`OTHER`, never to "not marked" — the one wrong answer available.

**`Pin the broadcast-failure report's two outcomes through the drive path`**

The report's whole value is in withholding: it must outrank a broadcast that is otherwise due, and
must stop doing so the moment the wallet can check it. Both directions are now asserted end to end
through the same `advance_migration` decision `advance_step` maps to step codes.

The first test establishes the un-reported baseline before reporting, so the second cannot pass
vacuously: the same row and state that yields `Broadcast` yields `Reevaluate` once a report stands
above the scanned height, and yields `Broadcast` again when the report sits below it and the chain
shows nothing wrong. That second case is the self-healing property that makes re-reporting on every
rejection correct rather than wasteful.

## Reviewer attention

The JNI constructor signature for `JniMigrationTransferState` gains an `int`
(`(JZZZJJZIIJII[JJJ)V` → `(JZZZJJZIIIJII[JJJ)V`). Both sides move together here, but this is the
class of change that compiles on both sides and only fails at runtime if one half lands alone.

## Verification

- `cargo test --all-targets` in `backend-lib`: exit 0, 62 passed, 0 failed, no warnings.
- `:sdk-lib:compileDebugUnitTestKotlin`: exit 0, BUILD SUCCESSFUL — the JNI arity change is
  consistent across both sides of the boundary.

---
*Opened with Claude Code assistance.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

